### PR TITLE
feat: add custom HTTP authentication schemes and partial API support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "anyhow",
  "aperture-cli",
  "assert_cmd",
+ "base64",
  "bincode",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tabled = "0.15.0"
 thiserror = "2.0.12"
 tokio = { version = "1.45.1", features = ["rt-multi-thread", "macros", "sync", "time", "fs"] }
 dirs = "6.0.0"
+base64 = "0.22.1"
 governor = "0.6.3"
 indexmap = "2.2.1"
 sha2 = "0.10.8"

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following authentication types require complex flows and are not supported:
 
 #### Partial API Support
 
-Starting from v0.1.5, Aperture handles APIs with unsupported features gracefully:
+Starting from v0.1.4, Aperture handles APIs with unsupported features gracefully:
 
 - **Non-Strict Mode (Default)**: APIs containing unsupported authentication schemes or content types are accepted
   - Only endpoints that require unsupported features are skipped

--- a/README.md
+++ b/README.md
@@ -33,18 +33,85 @@ Aperture follows a two-phase approach:
 
 ### Security Model
 
-Authentication is handled through custom `x-aperture-secret` extensions in OpenAPI specs that map security schemes to environment variables:
+Authentication is handled through custom `x-aperture-secret` extensions in OpenAPI specs that map security schemes to environment variables.
 
+#### Supported Authentication Schemes
+
+1. **API Key** (header, query, or cookie)
 ```yaml
 components:
   securitySchemes:
-    apiToken:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      x-aperture-secret:
+        source: env
+        name: API_KEY
+```
+
+2. **HTTP Bearer Token**
+```yaml
+components:
+  securitySchemes:
+    bearerAuth:
       type: http
       scheme: bearer
       x-aperture-secret:
         source: env
         name: API_TOKEN
 ```
+
+3. **HTTP Basic Authentication**
+```yaml
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+      x-aperture-secret:
+        source: env
+        name: BASIC_CREDENTIALS  # Format: base64(username:password)
+```
+
+4. **Custom HTTP Schemes** (Token, DSN, ApiKey, proprietary schemes)
+```yaml
+components:
+  securitySchemes:
+    # Common alternative to Bearer
+    tokenAuth:
+      type: http
+      scheme: Token
+      x-aperture-secret:
+        source: env
+        name: API_TOKEN
+    
+    # Sentry-style DSN authentication
+    dsnAuth:
+      type: http
+      scheme: DSN
+      x-aperture-secret:
+        source: env
+        name: SENTRY_DSN
+    
+    # Any custom scheme name
+    customAuth:
+      type: http
+      scheme: X-CompanyAuth-V2
+      x-aperture-secret:
+        source: env
+        name: COMPANY_TOKEN
+```
+
+All custom HTTP schemes are treated as bearer-like tokens and formatted as: `Authorization: <scheme> <token>`
+
+#### Unsupported Authentication
+
+The following authentication types require complex flows and are not supported:
+- OAuth2 (all flows)
+- OpenID Connect
+- HTTP Negotiate (Kerberos/NTLM)
+- HTTP OAuth scheme
 
 ### Parameter References
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ components:
       scheme: basic
       x-aperture-secret:
         source: env
-        name: BASIC_CREDENTIALS  # Format: base64(username:password)
+        name: BASIC_CREDENTIALS  # Format: username:password (will be base64 encoded automatically)
 ```
 
 4. **Custom HTTP Schemes** (Token, DSN, ApiKey, proprietary schemes)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ The following authentication types require complex flows and are not supported:
 - HTTP Negotiate (Kerberos/NTLM)
 - HTTP OAuth scheme
 
+#### Partial API Support
+
+Starting from v0.1.5, Aperture handles APIs with unsupported features gracefully:
+
+- **Non-Strict Mode (Default)**: APIs containing unsupported authentication schemes or content types are accepted
+  - Only endpoints that require unsupported features are skipped
+  - Endpoints with multiple authentication options (where at least one is supported) remain available
+  - Clear warnings show which endpoints are skipped and why
+  
+- **Strict Mode**: Use the `--strict` flag with `aperture config add` to reject specs with any unsupported features
+
+This allows you to use most endpoints of an API even if some require unsupported authentication methods or content types:
+
+```bash
+# Default behavior - accepts spec, skips unsupported endpoints with warnings
+aperture config add my-api ./openapi.yml
+
+# Strict mode - rejects spec if any unsupported features found
+aperture config add --strict my-api ./openapi.yml
+```
+
 ### Parameter References
 
 Aperture fully supports OpenAPI parameter references, allowing you to define reusable parameters:
@@ -184,6 +205,9 @@ aperture api my-api get-data --jq '.items | map(select(.active)) | .[0:5]'
 ```bash
 # Register an API specification
 aperture config add my-api ./openapi.yml
+
+# Register with strict validation (rejects specs with any unsupported features)
+aperture config add --strict my-api ./openapi.yml
 
 # List available APIs
 aperture config list

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,7 +102,7 @@ For APIs using these authentication methods, consider using alternative authenti
 
 ### Partial API Support
 
-Starting from v0.1.5, Aperture uses a non-strict validation mode by default:
+Starting from v0.1.4, Aperture uses a non-strict validation mode by default:
 - APIs containing unsupported authentication schemes are accepted
 - Only endpoints that require unsupported authentication are skipped
 - Endpoints with multiple authentication options (where at least one is supported) remain available

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -97,6 +97,16 @@ The following authentication types are explicitly not supported due to their com
 
 For APIs using these authentication methods, consider using alternative authentication schemes if available (e.g., API tokens or personal access tokens).
 
+### Partial API Support
+
+Starting from v0.1.5, Aperture uses a non-strict validation mode by default:
+- APIs containing unsupported authentication schemes are accepted
+- Only endpoints that require unsupported authentication are skipped
+- Endpoints with multiple authentication options (where at least one is supported) remain available
+- Use the `--strict` flag with `aperture config add` to reject specs with any unsupported features
+
+This allows you to use most endpoints of an API even if some require unsupported authentication methods.
+
 ## Updates
 
 This security policy may be updated as new features are added. Check the latest version in the repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,37 @@ components:
 
 #### Supported Authentication Methods
 
-- **Bearer Token Authentication**: Uses `Authorization: Bearer <token>` header
-- **API Key Authentication**: Supports header-based API keys
-- **Basic Authentication**: Supports HTTP Basic auth (base64 encoded)
+1. **API Key Authentication**: Supports header, query, or cookie-based API keys
+   ```yaml
+   apiKey:
+     type: apiKey
+     in: header  # or 'query' or 'cookie'
+     name: X-API-Key
+   ```
+
+2. **HTTP Bearer Token**: Uses `Authorization: Bearer <token>` header
+   ```yaml
+   bearerAuth:
+     type: http
+     scheme: bearer
+   ```
+
+3. **HTTP Basic Authentication**: Uses `Authorization: Basic <base64>` header
+   ```yaml
+   basicAuth:
+     type: http
+     scheme: basic
+   ```
+
+4. **Custom HTTP Schemes**: Any HTTP scheme not explicitly rejected
+   ```yaml
+   # Examples: Token, DSN, ApiKey, X-Custom-Auth, etc.
+   tokenAuth:
+     type: http
+     scheme: Token  # Results in: Authorization: Token <token>
+   ```
+
+All custom HTTP schemes are treated as bearer-like tokens with the format: `Authorization: <scheme> <token>`
 
 #### Security Features
 
@@ -60,9 +88,14 @@ Aperture properly implements OpenAPI 3.0 global security inheritance, applying s
 
 ## Limitations
 
-- OAuth2 and OpenID Connect are not currently supported
-- Only header-based API key authentication is supported (query parameters are not supported)
-- Basic authentication credentials must be provided as separate username/password environment variables
+The following authentication types are explicitly not supported due to their complexity:
+
+- **OAuth2** (all flows) - Requires token management, refresh flows, and state persistence
+- **OpenID Connect** - Even more complex than OAuth2 with discovery endpoints
+- **HTTP Negotiate** (Kerberos/NTLM) - Requires complex authentication handshakes
+- **HTTP OAuth scheme** - Indicates OAuth 1.0 which requires request signing
+
+For APIs using these authentication methods, consider using alternative authentication schemes if available (e.g., API tokens or personal access tokens).
 
 ## Updates
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,6 +47,9 @@ components:
    basicAuth:
      type: http
      scheme: basic
+     x-aperture-secret:
+       source: env
+       name: BASIC_CREDS  # Format: username:password (base64 encoding handled automatically)
    ```
 
 4. **Custom HTTP Schemes**: Any HTTP scheme not explicitly rejected

--- a/docs/adr/005-security-authentication-and-custom-headers.md
+++ b/docs/adr/005-security-authentication-and-custom-headers.md
@@ -11,7 +11,7 @@ When implementing Phase 6 of Aperture (Security and Custom Headers), we needed t
 3. **Agent Discovery Gap**: The `--describe-json` capability manifest didn't expose security requirements to autonomous agents
 4. **Security Separation**: Need to maintain strict separation between OpenAPI specs (configuration) and credentials (secrets)
 
-The solution needed to support common authentication schemes (Bearer tokens, API keys) while maintaining backward compatibility and enabling agent automation.
+The solution needed to support common authentication schemes (Bearer tokens, API keys, Basic auth, and custom HTTP schemes) while maintaining backward compatibility and enabling agent automation.
 
 **Update**: Implementation completed successfully with full x-aperture-secret extension parsing, comprehensive test coverage, and end-to-end functionality verification.
 
@@ -26,7 +26,7 @@ Extended the cached spec representation to include security information:
 pub struct CachedSecurityScheme {
     pub name: String,
     pub scheme_type: String,          // "http", "apiKey", etc.
-    pub scheme: Option<String>,       // "bearer", "basic", etc.  
+    pub scheme: Option<String>,       // "bearer", "basic", "token", "dsn", etc.  
     pub location: Option<String>,     // "header", "query", "cookie"
     pub parameter_name: Option<String>, // Header/parameter name
     pub aperture_secret: Option<CachedApertureSecret>,
@@ -99,5 +99,6 @@ Updated the agent manifest to expose security information:
 1. OAuth2 flow support with refresh tokens
 2. External secret manager integration (Vault, AWS Secrets Manager)
 3. Certificate-based authentication
-4. Basic authentication support (currently only Bearer tokens supported)
+4. ~~Basic authentication support~~ (COMPLETED - Basic auth is now supported)
+5. ~~Custom HTTP scheme support~~ (COMPLETED - Any HTTP scheme except OAuth2/OIDC/Negotiate is now supported)
 5. Advanced security scheme validation against OpenAPI specs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,7 @@ Aperture's v1.0 implementation will support a well-defined subset of the OpenAPI
 | `parameters` (`style`)       | **Unsupported**         | Default styles are assumed. Complex serialization is not supported.                                                       |
 | `requestBody`                | **Partially Supported** | Only `content` type `application/json` is supported. Other content types (e.g., `multipart/form-data`, `application/xml`) are skipped with warnings in non-strict mode. |
 | `responses`                  | **Supported**           | Used to validate successful response bodies.                                                                              |
-| `securitySchemes`            | **Partially Supported** | See §6 for the detailed security model. `apiKey` and `http` (bearer, basic, and custom schemes) are supported. `oauth2` and `openIdConnect` are not. |
+| `securitySchemes`            | **Partially Supported** | See §6 for the detailed security model. `apiKey` and `http` (bearer, basic, and custom schemes) are supported. `oauth2` and `openIdConnect` are skipped with warnings in non-strict mode. |
 
 Any unsupported keyword or feature encountered during `config add` will result in a clear validation error, preventing the spec from being registered.
 
@@ -130,7 +130,8 @@ Starting from v0.1.2, Aperture supports two validation modes during `config add`
 
 1. **Non-Strict Mode (Default):** Accepts specifications with unsupported features but intelligently handles endpoints:
    - Endpoints that support `application/json` alongside unsupported content types remain available
-   - Only endpoints with NO supported content types are skipped with warnings
+   - Endpoints with at least one supported authentication scheme remain available
+   - Only endpoints with NO supported content types or ONLY unsupported auth schemes are skipped with warnings
    - This maximizes API usability while clearly communicating limitations
    
 2. **Strict Mode (`--strict` flag):** Rejects specifications that contain any unsupported features. This ensures complete compatibility but may prevent usage of APIs that have mixed endpoint support.
@@ -147,11 +148,14 @@ aperture config add --strict my-api ./spec.yaml
 **Warning Display:**
 When endpoints are skipped in non-strict mode, Aperture displays detailed warnings:
 ```
-Warning: Skipping 2 endpoints with unsupported content types (3 of 5 endpoints will be available):
+Warning: Skipping 2 endpoints with unsupported content types (8 of 10 endpoints will be available):
   - POST /upload (multipart/form-data (file uploads are not supported)) - endpoint has no supported content types
   - PUT /binary (application/octet-stream (binary data uploads are not supported)) - endpoint has no supported content types
 
-Use --strict to reject specs with unsupported content types.
+Warning: Skipping 1 endpoints with unsupported authentication (7 of 8 endpoints will be available):
+  - GET /admin - endpoint requires unsupported authentication schemes: oauth2
+
+Use --strict to reject specs with unsupported features.
 ```
 
 ### 5.1. Command Generation Strategy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,7 @@ Aperture's v1.0 implementation will support a well-defined subset of the OpenAPI
 | `parameters` (`style`)       | **Unsupported**         | Default styles are assumed. Complex serialization is not supported.                                                       |
 | `requestBody`                | **Partially Supported** | Only `content` type `application/json` is supported. Other content types (e.g., `multipart/form-data`, `application/xml`) are skipped with warnings in non-strict mode. |
 | `responses`                  | **Supported**           | Used to validate successful response bodies.                                                                              |
-| `securitySchemes`            | **Partially Supported** | See §6 for the detailed security model. `apiKey` and `http` (bearer) are supported. `oauth2` and `openIdConnect` are not. |
+| `securitySchemes`            | **Partially Supported** | See §6 for the detailed security model. `apiKey` and `http` (bearer, basic, and custom schemes) are supported. `oauth2` and `openIdConnect` are not. |
 
 Any unsupported keyword or feature encountered during `config add` will result in a clear validation error, preventing the spec from being registered.
 
@@ -187,6 +187,21 @@ components:
 
 This configuration instructs Aperture to use the value of the `SENTRY_AUTH_TOKEN` environment variable for any operation secured by `sentryAuthToken`. If the extension is missing or the environment variable is unset, Aperture will fail with a `Config.SecretNotFound` error.
 
+**Supported Authentication Types:**
+
+1. **API Key** (`type: apiKey`): Supports header, query, or cookie placement
+2. **HTTP Bearer** (`type: http`, `scheme: bearer`): Standard Bearer token authentication
+3. **HTTP Basic** (`type: http`, `scheme: basic`): Basic authentication with base64 encoding
+4. **Custom HTTP Schemes** (`type: http`, `scheme: <custom>`): Any scheme not explicitly rejected (e.g., Token, DSN, ApiKey)
+
+Custom HTTP schemes are treated as bearer-like tokens, resulting in `Authorization: <scheme> <token>` headers.
+
+**Explicitly Unsupported:**
+- OAuth2 (all flows)
+- OpenID Connect
+- HTTP Negotiate (Kerberos/NTLM)
+- HTTP OAuth
+
 ## 7. Agent-Facing Contracts
 
 ### 7.1. Global Agent Flags
@@ -224,7 +239,7 @@ Aperture is **strict by default**. If an API returns a successful (2xx) status c
 
 This SDD describes Product v1.0. Future development will focus on:
 
-- **v1.1:** Introduce a generic pagination helper (`--auto-paginate`). Add support for non-interactive OAuth2 grants (`client_credentials`).
+- **v1.1:** Introduce a generic pagination helper (`--auto-paginate`). Add support for non-interactive OAuth2 grants (`client_credentials`). ~~Custom HTTP scheme support~~ (COMPLETED in v0.1.4).
 - **v1.2:** Add a `aperture config set <key> <value>` command for managing `config.toml`. Expand command validation and error reporting capabilities.
 - **v2.0:** Introduce keychain integration as an additional `SecretSource`. Expand OpenAPI support to include more complex features.
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -226,7 +226,7 @@ Beyond the original plan, the following major features have been successfully im
 
 ### **Phase 8: Comprehensive Security Implementation**
 - `[x]` **x-aperture-secret Extension**: Full OpenAPI extension parsing and integration
-- `[x]` **Authentication Support**: Bearer tokens, API keys, Basic auth via environment variables
+- `[x]` **Authentication Support**: Bearer tokens, API keys, Basic auth, and custom HTTP schemes via environment variables
 - `[x]` **Custom Headers**: `--header` flag with environment variable expansion
 - `[x]` **Security Discovery**: Agent capability manifest includes security requirements
 - `[x]` **Global Security Inheritance**: Proper OpenAPI 3.0 spec-level security handling

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -319,11 +319,14 @@ impl<F: FileSystem> ConfigManager<F> {
         // Transform into internal cached representation using SpecTransformer
         let transformer = SpecTransformer::new();
 
-        // Convert warnings to skip_endpoints format - only skip endpoints with NO JSON support
+        // Convert warnings to skip_endpoints format - skip endpoints with unsupported content types or auth
         let skip_endpoints: Vec<(String, String)> = validation_result
             .warnings
             .iter()
-            .filter(|w| w.reason.contains("no supported content types"))
+            .filter(|w| {
+                w.reason.contains("no supported content types")
+                    || w.reason.contains("unsupported authentication")
+            })
             .map(|w| (w.endpoint.path.clone(), w.endpoint.method.clone()))
             .collect();
 
@@ -421,11 +424,14 @@ impl<F: FileSystem> ConfigManager<F> {
         // Transform into internal cached representation using SpecTransformer
         let transformer = SpecTransformer::new();
 
-        // Convert warnings to skip_endpoints format - only skip endpoints with NO JSON support
+        // Convert warnings to skip_endpoints format - skip endpoints with unsupported content types or auth
         let skip_endpoints: Vec<(String, String)> = validation_result
             .warnings
             .iter()
-            .filter(|w| w.reason.contains("no supported content types"))
+            .filter(|w| {
+                w.reason.contains("no supported content types")
+                    || w.reason.contains("unsupported authentication")
+            })
             .map(|w| (w.endpoint.path.clone(), w.endpoint.method.clone()))
             .collect();
 
@@ -815,11 +821,14 @@ impl<F: FileSystem> ConfigManager<F> {
         // Transform into internal cached representation using SpecTransformer
         let transformer = SpecTransformer::new();
 
-        // Convert warnings to skip_endpoints format - only skip endpoints with NO JSON support
+        // Convert warnings to skip_endpoints format - skip endpoints with unsupported content types or auth
         let skip_endpoints: Vec<(String, String)> = validation_result
             .warnings
             .iter()
-            .filter(|w| w.reason.contains("no supported content types"))
+            .filter(|w| {
+                w.reason.contains("no supported content types")
+                    || w.reason.contains("unsupported authentication")
+            })
             .map(|w| (w.endpoint.path.clone(), w.endpoint.method.clone()))
             .collect();
 

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -323,11 +323,7 @@ impl<F: FileSystem> ConfigManager<F> {
         let skip_endpoints: Vec<(String, String)> = validation_result
             .warnings
             .iter()
-            .filter(|w| {
-                w.reason.contains("no supported content types")
-                    || w.reason.contains("unsupported authentication")
-            })
-            .map(|w| (w.endpoint.path.clone(), w.endpoint.method.clone()))
+            .filter_map(super::super::spec::validator::ValidationWarning::to_skip_endpoint)
             .collect();
 
         let cached_spec = transformer.transform_with_warnings(
@@ -428,11 +424,7 @@ impl<F: FileSystem> ConfigManager<F> {
         let skip_endpoints: Vec<(String, String)> = validation_result
             .warnings
             .iter()
-            .filter(|w| {
-                w.reason.contains("no supported content types")
-                    || w.reason.contains("unsupported authentication")
-            })
-            .map(|w| (w.endpoint.path.clone(), w.endpoint.method.clone()))
+            .filter_map(super::super::spec::validator::ValidationWarning::to_skip_endpoint)
             .collect();
 
         let cached_spec = transformer.transform_with_warnings(
@@ -825,11 +817,7 @@ impl<F: FileSystem> ConfigManager<F> {
         let skip_endpoints: Vec<(String, String)> = validation_result
             .warnings
             .iter()
-            .filter(|w| {
-                w.reason.contains("no supported content types")
-                    || w.reason.contains("unsupported authentication")
-            })
-            .map(|w| (w.endpoint.path.clone(), w.endpoint.method.clone()))
+            .filter_map(super::super::spec::validator::ValidationWarning::to_skip_endpoint)
             .collect();
 
         let cached_spec = transformer.transform_with_warnings(

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -511,7 +511,11 @@ fn add_authentication_header(
                         }
                         "basic" => {
                             // Basic auth expects "username:password" format in the secret
-                            let auth_value = format!("Basic {secret_value}");
+                            // The secret should contain the raw "username:password" string
+                            // We'll base64 encode it before adding to the header
+                            use base64::{engine::general_purpose, Engine as _};
+                            let encoded = general_purpose::STANDARD.encode(&secret_value);
+                            let auth_value = format!("Basic {encoded}");
                             let header_value = HeaderValue::from_str(&auth_value).map_err(|e| {
                                 Error::InvalidHeaderValue {
                                     name: "Authorization".to_string(),

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -477,6 +477,13 @@ fn add_authentication_header(
     headers: &mut HeaderMap,
     security_scheme: &CachedSecurityScheme,
 ) -> Result<(), Error> {
+    // Debug logging when RUST_LOG is set
+    if std::env::var("RUST_LOG").is_ok() {
+        eprintln!(
+            "[DEBUG] Adding authentication header for scheme: {} (type: {})",
+            security_scheme.name, security_scheme.scheme_type
+        );
+    }
     // Only process schemes that have aperture_secret mappings
     if let Some(aperture_secret) = &security_scheme.aperture_secret {
         // Read the secret from the environment variable
@@ -525,6 +532,11 @@ fn add_authentication_header(
                                 }
                             })?;
                             headers.insert("Authorization", header_value);
+
+                            // Debug logging
+                            if std::env::var("RUST_LOG").is_ok() {
+                                eprintln!("[DEBUG] Added Bearer authentication header");
+                            }
                         }
                         "basic" => {
                             // Basic auth expects "username:password" format in the secret
@@ -540,6 +552,13 @@ fn add_authentication_header(
                                 }
                             })?;
                             headers.insert("Authorization", header_value);
+
+                            // Debug logging
+                            if std::env::var("RUST_LOG").is_ok() {
+                                eprintln!(
+                                    "[DEBUG] Added Basic authentication header (base64 encoded)"
+                                );
+                            }
                         }
                         _ => {
                             // Treat any other HTTP scheme as a bearer-like token
@@ -553,6 +572,13 @@ fn add_authentication_header(
                                 }
                             })?;
                             headers.insert("Authorization", header_value);
+
+                            // Debug logging
+                            if std::env::var("RUST_LOG").is_ok() {
+                                eprintln!(
+                                    "[DEBUG] Added custom HTTP auth header with scheme: {scheme}"
+                                );
+                            }
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,11 +327,8 @@ fn display_skipped_endpoints_info(cached_spec: &aperture_cli::cache::models::Cac
         &cached_spec.skipped_endpoints,
     );
 
-    // Count total operations including skipped ones
-    let skipped_count = warnings
-        .iter()
-        .filter(|w| w.reason.contains("no supported content types"))
-        .count();
+    // Count total operations including all skipped ones
+    let skipped_count = warnings.len();
     let total_operations = cached_spec.commands.len() + skipped_count;
 
     // Format and display warnings

--- a/src/spec/validator.rs
+++ b/src/spec/validator.rs
@@ -56,6 +56,25 @@ pub struct ValidationWarning {
     pub reason: String,
 }
 
+impl ValidationWarning {
+    /// Determines if this warning should result in a skipped endpoint
+    #[must_use]
+    pub fn should_skip_endpoint(&self) -> bool {
+        self.reason.contains("no supported content types")
+            || self.reason.contains("unsupported authentication")
+    }
+
+    /// Converts to a skipped endpoint tuple if applicable
+    #[must_use]
+    pub fn to_skip_endpoint(&self) -> Option<(String, String)> {
+        if self.should_skip_endpoint() {
+            Some((self.endpoint.path.clone(), self.endpoint.method.clone()))
+        } else {
+            None
+        }
+    }
+}
+
 /// Details about an unsupported endpoint
 #[derive(Debug, Clone)]
 pub struct UnsupportedEndpoint {

--- a/tests/config_manager_tests.rs
+++ b/tests/config_manager_tests.rs
@@ -522,8 +522,14 @@ paths:
     let result = manager.add_spec(spec_name, &temp_spec_path, false, true);
     assert!(result.is_err());
     if let Err(Error::Validation(msg)) = result {
-        assert!(msg.contains("OAuth2 security scheme"));
-        assert!(msg.contains("not supported"));
+        // The error message has changed due to our refactoring
+        assert!(
+            msg.contains("oauth2")
+                || msg.contains("OAuth2")
+                || msg.contains("unsupported authentication"),
+            "Got validation message: {}",
+            msg
+        );
     } else {
         panic!("Unexpected error type: {:?}", result);
     }
@@ -557,8 +563,14 @@ paths:
     let result = manager.add_spec(spec_name, &temp_spec_path, false, true);
     assert!(result.is_err());
     if let Err(Error::Validation(msg)) = result {
-        assert!(msg.contains("OpenID Connect security scheme"));
-        assert!(msg.contains("not supported"));
+        // The error message has changed due to our refactoring
+        assert!(
+            msg.contains("OpenID Connect")
+                || msg.contains("openidconnect")
+                || msg.contains("unsupported authentication"),
+            "Got validation message: {}",
+            msg
+        );
     } else {
         panic!("Unexpected error type: {:?}", result);
     }

--- a/tests/config_manager_tests.rs
+++ b/tests/config_manager_tests.rs
@@ -567,17 +567,17 @@ paths:
 #[test]
 fn test_add_spec_rejects_unsupported_http_scheme() {
     let (manager, fs) = setup_manager();
-    let spec_name = "digest-auth-api";
+    let spec_name = "negotiate-auth-api";
     let spec_content = r#"
 openapi: 3.0.0
 info:
-  title: Digest Auth API
+  title: Negotiate Auth API
   version: 1.0.0
 components:
   securitySchemes:
-    digestAuth:
+    negotiateAuth:
       type: http
-      scheme: digest
+      scheme: negotiate
 paths:
   /users:
     get:
@@ -586,14 +586,14 @@ paths:
         '200':
           description: Success
 "#;
-    let temp_spec_path = PathBuf::from("/tmp/digest_auth_api.yaml");
+    let temp_spec_path = PathBuf::from("/tmp/negotiate_auth_api.yaml");
     fs.add_file(&temp_spec_path, spec_content);
 
     let result = manager.add_spec(spec_name, &temp_spec_path, false, true);
     assert!(result.is_err());
     if let Err(Error::Validation(msg)) = result {
-        assert!(msg.contains("Unsupported HTTP scheme 'digest'"));
-        assert!(msg.contains("Only 'bearer' and 'basic' are supported"));
+        assert!(msg.contains("HTTP scheme 'negotiate'"));
+        assert!(msg.contains("requires complex authentication flows"));
     } else {
         panic!("Unexpected error type: {:?}", result);
     }

--- a/tests/custom_auth_integration_tests.rs
+++ b/tests/custom_auth_integration_tests.rs
@@ -1,0 +1,294 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn setup_test_env() -> (TempDir, String) {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+    fs::create_dir_all(&config_dir).unwrap();
+    (temp_dir, config_dir.to_string_lossy().to_string())
+}
+
+#[tokio::test]
+async fn test_custom_http_scheme_token_execution() {
+    let (temp_dir, config_dir) = setup_test_env();
+    let mock_server = MockServer::start().await;
+
+    // Create OpenAPI spec with Token auth scheme
+    let spec_content = format!(
+        r#"
+openapi: 3.0.0
+info:
+  title: Token Auth Test API
+  version: 1.0.0
+servers:
+  - url: {}
+components:
+  securitySchemes:
+    tokenAuth:
+      type: http
+      scheme: Token
+      x-aperture-secret:
+        source: env
+        name: TEST_TOKEN
+paths:
+  /protected:
+    get:
+      operationId: getProtected
+      security:
+        - tokenAuth: []
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+"#,
+        mock_server.uri()
+    );
+
+    let spec_file = temp_dir.path().join("token-api.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .args(&["config", "add", "token-api", spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Set up mock to verify the correct Authorization header
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/protected"))
+        .and(wiremock::matchers::header(
+            "Authorization",
+            "Token test-token-123",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"status": "success"}"#))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Execute the command with Token auth
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .env("TEST_TOKEN", "test-token-123")
+        .args(&["api", "token-api", "default", "get-protected"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\": \"success\""));
+}
+
+#[tokio::test]
+async fn test_custom_http_scheme_dsn_execution() {
+    let (temp_dir, config_dir) = setup_test_env();
+    let mock_server = MockServer::start().await;
+
+    // Create OpenAPI spec with DSN auth scheme
+    let spec_content = format!(
+        r#"
+openapi: 3.0.0
+info:
+  title: DSN Auth Test API
+  version: 1.0.0
+servers:
+  - url: {}
+components:
+  securitySchemes:
+    dsnAuth:
+      type: http
+      scheme: DSN
+      x-aperture-secret:
+        source: env
+        name: SENTRY_DSN
+paths:
+  /api/events:
+    post:
+      operationId: sendEvent
+      security:
+        - dsnAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Event accepted
+"#,
+        mock_server.uri()
+    );
+
+    let spec_file = temp_dir.path().join("dsn-api.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .args(&["config", "add", "dsn-api", spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Set up mock to verify the correct DSN Authorization header
+    Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/api/events"))
+        .and(wiremock::matchers::header(
+            "Authorization",
+            "DSN https://key@sentry.io/123",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"id": "event123"}"#))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Execute the command with DSN auth
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .env("SENTRY_DSN", "https://key@sentry.io/123")
+        .args(&[
+            "api",
+            "dsn-api",
+            "default",
+            "send-event",
+            "--body",
+            r#"{"type": "error"}"#,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"id\": \"event123\""));
+}
+
+#[tokio::test]
+async fn test_custom_http_scheme_proprietary() {
+    let (temp_dir, config_dir) = setup_test_env();
+    let mock_server = MockServer::start().await;
+
+    // Create OpenAPI spec with completely custom auth scheme
+    let spec_content = format!(
+        r#"
+openapi: 3.0.0
+info:
+  title: Custom Auth Test API
+  version: 1.0.0
+servers:
+  - url: {}
+components:
+  securitySchemes:
+    customAuth:
+      type: http
+      scheme: X-Custom-Auth
+      x-aperture-secret:
+        source: env
+        name: CUSTOM_AUTH_KEY
+paths:
+  /api/data:
+    get:
+      operationId: getData
+      security:
+        - customAuth: []
+      responses:
+        '200':
+          description: Success
+"#,
+        mock_server.uri()
+    );
+
+    let spec_file = temp_dir.path().join("custom-api.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .args(&["config", "add", "custom-api", spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Set up mock to verify the correct custom Authorization header
+    Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/api/data"))
+        .and(wiremock::matchers::header(
+            "Authorization",
+            "X-Custom-Auth secret-key-789",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"data": "test"}"#))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Execute the command with custom auth
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .env("CUSTOM_AUTH_KEY", "secret-key-789")
+        .args(&["api", "custom-api", "default", "get-data"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"data\": \"test\""));
+}
+
+#[tokio::test]
+async fn test_dry_run_shows_custom_auth_header() {
+    let (temp_dir, config_dir) = setup_test_env();
+
+    // Create OpenAPI spec with Token auth
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Token Auth Dry Run Test
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    tokenAuth:
+      type: http
+      scheme: Token
+      x-aperture-secret:
+        source: env
+        name: API_TOKEN
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      security:
+        - tokenAuth: []
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_file = temp_dir.path().join("dry-run-api.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .args(&["config", "add", "dry-run-api", spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Run with --dry-run to see the request details
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .env("API_TOKEN", "my-token-value")
+        .args(&["api", "--dry-run", "dry-run-api", "default", "get-users"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "\"authorization\": \"Token my-token-value\"",
+        ))
+        .stdout(predicate::str::contains(
+            "\"url\": \"https://api.example.com/users\"",
+        ));
+}

--- a/tests/custom_http_schemes_tests.rs
+++ b/tests/custom_http_schemes_tests.rs
@@ -1,0 +1,374 @@
+use aperture_cli::config::manager::ConfigManager;
+use aperture_cli::error::Error;
+use aperture_cli::fs::FileSystem;
+use std::collections::HashMap;
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+// Mock FileSystem implementation for testing
+#[derive(Clone)]
+pub struct MockFileSystem {
+    files: Arc<Mutex<HashMap<PathBuf, Vec<u8>>>>,
+    dirs: Arc<Mutex<HashMap<PathBuf, bool>>>,
+}
+
+impl MockFileSystem {
+    pub fn new() -> Self {
+        Self {
+            files: Arc::new(Mutex::new(HashMap::new())),
+            dirs: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn add_file(&self, path: &Path, content: &str) {
+        self.files
+            .lock()
+            .unwrap()
+            .insert(path.to_path_buf(), content.as_bytes().to_vec());
+        self.dirs
+            .lock()
+            .unwrap()
+            .insert(path.parent().unwrap().to_path_buf(), true);
+    }
+
+    pub fn add_dir(&self, path: &Path) {
+        self.dirs.lock().unwrap().insert(path.to_path_buf(), true);
+    }
+}
+
+impl FileSystem for MockFileSystem {
+    fn read_to_string(&self, path: &Path) -> io::Result<String> {
+        let files = self.files.lock().unwrap();
+        if let Some(content) = files.get(path) {
+            String::from_utf8(content.clone())
+                .map_err(|_| io::Error::new(ErrorKind::InvalidData, "Invalid UTF-8 in file"))
+        } else {
+            Err(io::Error::new(ErrorKind::NotFound, "File not found"))
+        }
+    }
+
+    fn write_all(&self, path: &Path, contents: &[u8]) -> io::Result<()> {
+        self.files
+            .lock()
+            .unwrap()
+            .insert(path.to_path_buf(), contents.to_vec());
+        Ok(())
+    }
+
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.dirs.lock().unwrap().insert(path.to_path_buf(), true);
+        Ok(())
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        let files = self.files.lock().unwrap();
+        let dirs = self.dirs.lock().unwrap();
+        files.contains_key(path) || dirs.contains_key(path)
+    }
+
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        let mut files = self.files.lock().unwrap();
+        if files.remove(path).is_some() {
+            Ok(())
+        } else {
+            Err(io::Error::new(ErrorKind::NotFound, "File not found"))
+        }
+    }
+
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
+        let files = self.files.lock().unwrap();
+        let entries: Vec<PathBuf> = files
+            .keys()
+            .filter(|p| p.parent() == Some(path))
+            .cloned()
+            .collect();
+        Ok(entries)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.files.lock().unwrap().contains_key(path)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.dirs.lock().unwrap().remove(path);
+        Ok(())
+    }
+
+    fn is_dir(&self, path: &Path) -> bool {
+        self.dirs.lock().unwrap().contains_key(path)
+    }
+
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        Ok(path.to_path_buf())
+    }
+}
+
+fn setup_manager() -> (ConfigManager<MockFileSystem>, MockFileSystem) {
+    let fs = MockFileSystem::new();
+    let config_dir = PathBuf::from("/test/config");
+    fs.add_dir(&config_dir);
+    let manager = ConfigManager::with_fs(fs.clone(), config_dir);
+    (manager, fs)
+}
+
+fn setup_dir(fs: &MockFileSystem) -> PathBuf {
+    let dir = PathBuf::from("/test/specs");
+    fs.add_dir(&dir);
+    dir
+}
+
+#[test]
+fn test_add_spec_with_custom_http_scheme_token() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with Token HTTP scheme (common alternative to Bearer)
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Token Auth API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    tokenAuth:
+      type: http
+      scheme: Token
+      x-aperture-secret:
+        source: env
+        name: API_TOKEN
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      security:
+        - tokenAuth: []
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = setup_dir(&fs).join("token-api.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should succeed - Token scheme is now supported
+    let result = manager.add_spec("token-api", &spec_path, false, false);
+    assert!(result.is_ok(), "Token HTTP scheme should be supported");
+
+    // Verify the spec was added
+    let specs = manager.list_specs().expect("Failed to list specs");
+    assert!(specs.contains(&"token-api".to_string()));
+}
+
+#[test]
+fn test_add_spec_with_custom_http_scheme_apikey() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with ApiKey HTTP scheme (note: different from apiKey type)
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: ApiKey Scheme API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    customAuth:
+      type: http
+      scheme: ApiKey
+      x-aperture-secret:
+        source: env
+        name: CUSTOM_API_KEY
+paths:
+  /data:
+    get:
+      operationId: getData
+      security:
+        - customAuth: []
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = setup_dir(&fs).join("apikey-scheme.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should succeed - ApiKey HTTP scheme is now supported
+    let result = manager.add_spec("apikey-scheme", &spec_path, false, false);
+    assert!(result.is_ok(), "ApiKey HTTP scheme should be supported");
+}
+
+#[test]
+fn test_add_spec_with_dsn_scheme() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with DSN HTTP scheme (Sentry-style)
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Sentry-style API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    dsnAuth:
+      type: http
+      scheme: DSN
+      x-aperture-secret:
+        source: env
+        name: SENTRY_DSN
+paths:
+  /events:
+    post:
+      operationId: sendEvent
+      security:
+        - dsnAuth: []
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = setup_dir(&fs).join("dsn-api.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should succeed - DSN scheme is now supported
+    let result = manager.add_spec("dsn-api", &spec_path, false, false);
+    assert!(result.is_ok(), "DSN HTTP scheme should be supported");
+}
+
+#[test]
+fn test_add_spec_with_proprietary_http_scheme() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with a completely custom/proprietary HTTP scheme
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Proprietary Auth API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    customScheme:
+      type: http
+      scheme: X-CompanyAuth-V2
+      x-aperture-secret:
+        source: env
+        name: COMPANY_AUTH_TOKEN
+paths:
+  /protected:
+    get:
+      operationId: getProtected
+      security:
+        - customScheme: []
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = setup_dir(&fs).join("proprietary-api.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should succeed - any custom scheme name is now supported
+    let result = manager.add_spec("proprietary-api", &spec_path, false, false);
+    assert!(
+        result.is_ok(),
+        "Custom proprietary HTTP schemes should be supported"
+    );
+}
+
+#[test]
+fn test_reject_oauth_http_scheme() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with 'oauth' as HTTP scheme (should be rejected)
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: OAuth HTTP Scheme API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    oauthScheme:
+      type: http
+      scheme: oauth
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = setup_dir(&fs).join("oauth-http.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should fail - 'oauth' as HTTP scheme suggests complex flows
+    let result = manager.add_spec("oauth-http", &spec_path, false, false);
+    assert!(result.is_err());
+    if let Err(Error::Validation(msg)) = result {
+        assert!(
+            msg.contains("requires complex authentication flows"),
+            "Expected complex auth flow error, got: {}",
+            msg
+        );
+    } else {
+        panic!("Expected Validation error for oauth HTTP scheme");
+    }
+}
+
+#[test]
+fn test_reject_negotiate_http_scheme() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with 'negotiate' HTTP scheme (Kerberos/NTLM)
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Negotiate Auth API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    negotiateAuth:
+      type: http
+      scheme: Negotiate
+paths:
+  /secure:
+    get:
+      operationId: getSecure
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = setup_dir(&fs).join("negotiate-api.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should fail - Negotiate requires complex Kerberos/NTLM flows
+    let result = manager.add_spec("negotiate-api", &spec_path, false, false);
+    assert!(result.is_err());
+    if let Err(Error::Validation(msg)) = result {
+        assert!(
+            msg.contains("requires complex authentication flows"),
+            "Expected complex auth flow error, got: {}",
+            msg
+        );
+    } else {
+        panic!("Expected Validation error for Negotiate scheme");
+    }
+}

--- a/tests/custom_http_schemes_tests.rs
+++ b/tests/custom_http_schemes_tests.rs
@@ -316,7 +316,7 @@ paths:
         .expect("Failed to write spec");
 
     // Should fail - 'oauth' as HTTP scheme suggests complex flows
-    let result = manager.add_spec("oauth-http", &spec_path, false, false);
+    let result = manager.add_spec("oauth-http", &spec_path, false, true); // Use strict mode
     assert!(result.is_err());
     if let Err(Error::Validation(msg)) = result {
         assert!(
@@ -360,7 +360,7 @@ paths:
         .expect("Failed to write spec");
 
     // Should fail - Negotiate requires complex Kerberos/NTLM flows
-    let result = manager.add_spec("negotiate-api", &spec_path, false, false);
+    let result = manager.add_spec("negotiate-api", &spec_path, false, true); // Use strict mode
     assert!(result.is_err());
     if let Err(Error::Validation(msg)) = result {
         assert!(

--- a/tests/mixed_auth_scenarios_tests.rs
+++ b/tests/mixed_auth_scenarios_tests.rs
@@ -1,0 +1,569 @@
+use aperture_cli::config::manager::ConfigManager;
+use aperture_cli::error::Error;
+use aperture_cli::fs::FileSystem;
+use std::collections::HashMap;
+use std::io::{self, ErrorKind};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+// Mock FileSystem implementation for testing
+#[derive(Clone)]
+pub struct MockFileSystem {
+    files: Arc<Mutex<HashMap<PathBuf, Vec<u8>>>>,
+    dirs: Arc<Mutex<HashMap<PathBuf, bool>>>,
+}
+
+impl MockFileSystem {
+    pub fn new() -> Self {
+        Self {
+            files: Arc::new(Mutex::new(HashMap::new())),
+            dirs: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl FileSystem for MockFileSystem {
+    fn read_to_string(&self, path: &Path) -> io::Result<String> {
+        let files = self.files.lock().unwrap();
+        if let Some(content) = files.get(path) {
+            String::from_utf8(content.clone())
+                .map_err(|_| io::Error::new(ErrorKind::InvalidData, "Invalid UTF-8 in file"))
+        } else {
+            Err(io::Error::new(ErrorKind::NotFound, "File not found"))
+        }
+    }
+
+    fn write_all(&self, path: &Path, contents: &[u8]) -> io::Result<()> {
+        let mut files = self.files.lock().unwrap();
+        files.insert(path.to_path_buf(), contents.to_vec());
+        Ok(())
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        self.files.lock().unwrap().contains_key(path)
+            || self.dirs.lock().unwrap().contains_key(path)
+    }
+
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        let mut dirs = self.dirs.lock().unwrap();
+        dirs.insert(path.to_path_buf(), true);
+        // Also create parent directories
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                dirs.insert(parent.to_path_buf(), true);
+            }
+        }
+        Ok(())
+    }
+
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        let mut files = self.files.lock().unwrap();
+        if files.remove(path).is_some() {
+            Ok(())
+        } else {
+            Err(io::Error::new(ErrorKind::NotFound, "File not found"))
+        }
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        let mut dirs = self.dirs.lock().unwrap();
+        let mut files = self.files.lock().unwrap();
+
+        // Remove the directory
+        dirs.remove(path);
+
+        // Remove all files in the directory
+        let path_str = path.to_string_lossy();
+        files.retain(|k, _| !k.to_string_lossy().starts_with(&*path_str));
+
+        Ok(())
+    }
+
+    fn is_dir(&self, path: &Path) -> bool {
+        self.dirs.lock().unwrap().contains_key(path)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.files.lock().unwrap().contains_key(path)
+    }
+
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        Ok(path.to_path_buf())
+    }
+
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<PathBuf>> {
+        let files = self.files.lock().unwrap();
+        let path_str = path.to_string_lossy();
+        let entries: Vec<PathBuf> = files
+            .keys()
+            .filter_map(|k| {
+                let k_str = k.to_string_lossy();
+                if k_str.starts_with(&*path_str) && k_str.len() > path_str.len() {
+                    let relative = &k_str[path_str.len()..];
+                    let relative = relative.trim_start_matches('/');
+                    if !relative.is_empty() && !relative.contains('/') {
+                        return Some(PathBuf::from(relative));
+                    }
+                }
+                None
+            })
+            .collect();
+        Ok(entries)
+    }
+}
+
+impl MockFileSystem {
+    fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+        let files = self.files.lock().unwrap();
+        files
+            .get(path)
+            .cloned()
+            .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "File not found"))
+    }
+}
+
+fn setup_manager() -> (ConfigManager<MockFileSystem>, MockFileSystem) {
+    let fs = MockFileSystem::new();
+    let config_dir = PathBuf::from("/tmp/aperture_test");
+
+    // Create necessary directories
+    fs.create_dir_all(&config_dir.join("specs"))
+        .expect("Failed to create specs dir");
+    fs.create_dir_all(&config_dir.join(".cache"))
+        .expect("Failed to create cache dir");
+
+    let manager = ConfigManager::with_fs(fs.clone(), config_dir);
+    (manager, fs)
+}
+
+#[test]
+fn test_spec_with_mixed_auth_non_strict() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with both supported and unsupported auth schemes
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Mixed Auth API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      x-aperture-secret:
+        source: env
+        name: API_TOKEN
+    oauth2Auth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            read: Read access
+    apiKey:
+      type: apiKey
+      name: X-API-Key
+      in: header
+      x-aperture-secret:
+        source: env
+        name: API_KEY
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+  /admin:
+    get:
+      operationId: getAdmin
+      security:
+        - oauth2Auth: [read]
+      responses:
+        '200':
+          description: Success
+  /public:
+    get:
+      operationId: getPublic
+      responses:
+        '200':
+          description: Success
+  /mixed:
+    get:
+      operationId: getMixed
+      security:
+        - bearerAuth: []
+        - oauth2Auth: [read]
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = PathBuf::from("/tmp/mixed-auth.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should succeed in non-strict mode with warnings
+    let result = manager.add_spec("mixed-auth", &spec_path, false, false);
+    assert!(
+        result.is_ok(),
+        "Expected success in non-strict mode, got: {:?}",
+        result
+    );
+
+    // Check that the spec was cached
+    let cache_path = PathBuf::from("/tmp/aperture_test/.cache/mixed-auth.bin");
+    assert!(fs.exists(&cache_path), "Cache file should exist");
+
+    // Load the cached spec to verify operations
+    let cached_content = fs.read(&cache_path).expect("Failed to read cache");
+    let cached_spec: aperture_cli::cache::models::CachedSpec =
+        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+
+    // Should have 3 operations (getUsers, getPublic, getMixed) - getAdmin should be skipped
+    assert_eq!(
+        cached_spec.commands.len(),
+        3,
+        "Should have 3 available operations"
+    );
+
+    let op_names: Vec<&str> = cached_spec
+        .commands
+        .iter()
+        .map(|c| c.operation_id.as_str())
+        .collect();
+    assert!(op_names.contains(&"getUsers"), "Should include getUsers");
+    assert!(op_names.contains(&"getPublic"), "Should include getPublic");
+    assert!(
+        op_names.contains(&"getMixed"),
+        "Should include getMixed (has alternative auth)"
+    );
+    assert!(
+        !op_names.contains(&"getAdmin"),
+        "Should not include getAdmin (only OAuth2)"
+    );
+
+    // Check skipped endpoints
+    assert_eq!(
+        cached_spec.skipped_endpoints.len(),
+        1,
+        "Should have 1 skipped endpoint"
+    );
+    let skipped = &cached_spec.skipped_endpoints[0];
+    assert_eq!(skipped.path, "/admin");
+    assert_eq!(skipped.method, "GET");
+    assert!(skipped.reason.contains("unsupported authentication"));
+}
+
+#[test]
+fn test_spec_with_mixed_auth_strict() {
+    let (manager, fs) = setup_manager();
+
+    // Same spec as above
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Mixed Auth API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+    oauth2Auth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            read: Read access
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = PathBuf::from("/tmp/mixed-auth-strict.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should fail in strict mode
+    let result = manager.add_spec("mixed-auth-strict", &spec_path, false, true);
+    assert!(result.is_err(), "Expected failure in strict mode");
+
+    if let Err(Error::Validation(msg)) = result {
+        assert!(
+            msg.contains("OAuth2") || msg.contains("unsupported authentication"),
+            "Expected OAuth2 error, got: {}",
+            msg
+        );
+    } else {
+        panic!("Expected Validation error, got: {:?}", result);
+    }
+}
+
+#[test]
+fn test_global_security_with_unsupported_auth() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with global security using unsupported auth
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Global Auth API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+security:
+  - oauth2Auth: [read]
+components:
+  securitySchemes:
+    oauth2Auth:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://example.com/token
+          scopes:
+            read: Read access
+    bearerAuth:
+      type: http
+      scheme: bearer
+      x-aperture-secret:
+        source: env
+        name: API_TOKEN
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      responses:
+        '200':
+          description: Success
+  /public:
+    get:
+      operationId: getPublic
+      security: []  # No security requirement
+      responses:
+        '200':
+          description: Success
+  /admin:
+    get:
+      operationId: getAdmin
+      security:
+        - bearerAuth: []  # Override global with supported auth
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = PathBuf::from("/tmp/global-auth.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should succeed in non-strict mode
+    let result = manager.add_spec("global-auth", &spec_path, false, false);
+    assert!(
+        result.is_ok(),
+        "Expected success in non-strict mode, got: {:?}",
+        result
+    );
+
+    // Load the cached spec
+    let cache_path = PathBuf::from("/tmp/aperture_test/.cache/global-auth.bin");
+    let cached_content = fs.read(&cache_path).expect("Failed to read cache");
+    let cached_spec: aperture_cli::cache::models::CachedSpec =
+        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+
+    // Should have 2 operations (getPublic with no auth, getAdmin with bearer override)
+    assert_eq!(
+        cached_spec.commands.len(),
+        2,
+        "Should have 2 available operations"
+    );
+
+    let op_names: Vec<&str> = cached_spec
+        .commands
+        .iter()
+        .map(|c| c.operation_id.as_str())
+        .collect();
+    assert!(
+        op_names.contains(&"getPublic"),
+        "Should include getPublic (no auth)"
+    );
+    assert!(
+        op_names.contains(&"getAdmin"),
+        "Should include getAdmin (bearer override)"
+    );
+    assert!(
+        !op_names.contains(&"getUsers"),
+        "Should not include getUsers (inherits global OAuth2)"
+    );
+
+    // Check skipped endpoints
+    assert_eq!(
+        cached_spec.skipped_endpoints.len(),
+        1,
+        "Should have 1 skipped endpoint"
+    );
+    let skipped = &cached_spec.skipped_endpoints[0];
+    assert_eq!(skipped.path, "/users");
+    assert!(skipped.reason.contains("unsupported authentication"));
+}
+
+#[test]
+fn test_negotiate_scheme_in_http() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with negotiate HTTP scheme alongside bearer
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Negotiate Auth API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    negotiateAuth:
+      type: http
+      scheme: negotiate
+    bearerAuth:
+      type: http
+      scheme: bearer
+      x-aperture-secret:
+        source: env
+        name: API_TOKEN
+paths:
+  /krb:
+    get:
+      operationId: getKrb
+      security:
+        - negotiateAuth: []
+      responses:
+        '200':
+          description: Success
+  /dual:
+    get:
+      operationId: getDual
+      security:
+        - negotiateAuth: []
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = PathBuf::from("/tmp/negotiate-auth.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should succeed in non-strict mode
+    let result = manager.add_spec("negotiate-auth", &spec_path, false, false);
+    assert!(
+        result.is_ok(),
+        "Expected success in non-strict mode, got: {:?}",
+        result
+    );
+
+    // Load the cached spec
+    let cache_path = PathBuf::from("/tmp/aperture_test/.cache/negotiate-auth.bin");
+    let cached_content = fs.read(&cache_path).expect("Failed to read cache");
+    let cached_spec: aperture_cli::cache::models::CachedSpec =
+        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+
+    // Should have 1 operation (getDual has bearer alternative)
+    assert_eq!(
+        cached_spec.commands.len(),
+        1,
+        "Should have 1 available operation"
+    );
+    assert_eq!(cached_spec.commands[0].operation_id, "getDual");
+
+    // Check skipped endpoints
+    assert_eq!(
+        cached_spec.skipped_endpoints.len(),
+        1,
+        "Should have 1 skipped endpoint"
+    );
+    let skipped = &cached_spec.skipped_endpoints[0];
+    assert_eq!(skipped.path, "/krb");
+    assert!(skipped.reason.contains("unsupported authentication"));
+    assert!(skipped.reason.contains("negotiate"));
+}
+
+#[test]
+fn test_openid_connect_scheme() {
+    let (manager, fs) = setup_manager();
+
+    // Create a spec with OpenID Connect
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: OIDC API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+components:
+  securitySchemes:
+    oidc:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+paths:
+  /profile:
+    get:
+      operationId: getProfile
+      security:
+        - oidc: [profile, email]
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_path = PathBuf::from("/tmp/oidc-auth.yaml");
+    fs.write_all(&spec_path, spec_content.as_bytes())
+        .expect("Failed to write spec");
+
+    // Should succeed in non-strict mode but skip all endpoints
+    let result = manager.add_spec("oidc-auth", &spec_path, false, false);
+    assert!(
+        result.is_ok(),
+        "Expected success in non-strict mode, got: {:?}",
+        result
+    );
+
+    // Load the cached spec
+    let cache_path = PathBuf::from("/tmp/aperture_test/.cache/oidc-auth.bin");
+    let cached_content = fs.read(&cache_path).expect("Failed to read cache");
+    let cached_spec: aperture_cli::cache::models::CachedSpec =
+        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+
+    // Should have no operations
+    assert_eq!(
+        cached_spec.commands.len(),
+        0,
+        "Should have no available operations"
+    );
+
+    // All endpoints should be skipped
+    assert_eq!(
+        cached_spec.skipped_endpoints.len(),
+        1,
+        "Should have 1 skipped endpoint"
+    );
+    let skipped = &cached_spec.skipped_endpoints[0];
+    assert!(skipped.reason.contains("unsupported authentication"));
+    assert!(skipped.reason.contains("oidc"));
+}


### PR DESCRIPTION
## Summary

This PR implements two complementary features that significantly improve Aperture's authentication handling:

1. **Custom HTTP Authentication Schemes**: Support for any custom HTTP scheme beyond the standard Bearer and Basic auth
2. **Partial API Support**: Allow using APIs even when some endpoints require unsupported authentication methods

## Related Issues

- Resolves #15 - Add support for DSN authentication scheme
- Partially addresses #16 - Add OAuth2 authentication support (by allowing APIs with OAuth2 to be used partially)
- Related to #11 - Support partial OpenAPI spec acceptance (extends the pattern to authentication)

## What has been done

### Custom HTTP Authentication Schemes
- Extended the validator to accept any HTTP authentication scheme that is not explicitly unsupported (OAuth2, OpenID Connect, Negotiate, OAuth)
- Modified the executor to treat custom schemes as bearer-like tokens, formatting them as `Authorization: <scheme> <token>`
- Added comprehensive test coverage for various custom schemes including Token, DSN, ApiKey, and proprietary formats

### Partial API Support for Unsupported Authentication
- Changed the default validation behavior to accept OpenAPI specs containing unsupported authentication schemes
- Implemented intelligent endpoint filtering that only skips operations requiring unsupported auth
- Operations with multiple authentication options (OR relationship) remain available if at least one option is supported
- Added clear warnings during `aperture config add` that show which endpoints are skipped and why
- Maintained backward compatibility with a `--strict` flag for users who need the previous rejection behavior

### Technical Implementation
- Modified `src/spec/validator.rs` to track unsupported schemes as warnings instead of errors in non-strict mode
- Updated `src/config/manager.rs` to properly filter and display auth-related warnings
- Fixed a critical bug where operations with unsupported auth were being included in commands despite warnings
- Added extensive test suites: `custom_http_schemes_tests.rs` and `mixed_auth_scenarios_tests.rs`
- Updated all relevant documentation including README.md, SECURITY.md, and architecture docs

## What has been obtained

### User Benefits
- **Broader API Compatibility**: Users can now work with APIs that use custom authentication schemes like Sentry's DSN
- **Partial API Usage**: APIs with mixed authentication support (e.g., some OAuth2 endpoints, some Bearer endpoints) can now be used instead of being completely rejected
- **Better Error Communication**: Clear warnings explain exactly which endpoints are unavailable and why
- **Flexibility**: Users can choose between permissive (default) and strict validation modes

### Example Scenarios Now Supported
```yaml
# Custom scheme - now supported
securitySchemes:
  dsnAuth:
    type: http
    scheme: DSN
    x-aperture-secret:
      source: env
      name: SENTRY_DSN

# Mixed auth API - partially supported
paths:
  /public:
    get: ...  # Available (no auth)
  /users:
    get:
      security:
        - bearerAuth: []  # Available
  /admin:
    get:
      security:
        - oauth2: []  # Skipped with warning
  /data:
    get:
      security:
        - oauth2: []
        - bearerAuth: []  # Available (has bearer option)
```

## Test Plan

- [x] All existing tests pass
- [x] New test suite for custom HTTP schemes (374 lines)
- [x] New test suite for mixed authentication scenarios (569 lines)
- [x] Integration tests for custom authentication (294 lines)
- [x] Manual testing with real-world OpenAPI specs
- [x] Documentation updated and reviewed