### PR TITLE
Add interactive mode for config set-secret command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,36 @@ aperture config add my-api ./openapi.yml
 aperture config add --strict my-api ./openapi.yml
 ```
 
+#### Dynamic Secret Configuration
+
+Starting from v0.2.0, Aperture supports dynamic authentication configuration without modifying OpenAPI specifications. This allows you to:
+
+- **Use unmodified third-party OpenAPI specs** - No need to fork and add `x-aperture-secret` extensions
+- **Easy credential management** - Configure authentication through simple CLI commands
+- **Environment flexibility** - Use different credentials per environment without spec changes
+- **Credential rotation** - Update environment variables without editing specifications
+
+**Configure secrets with CLI commands:**
+
+```bash
+# Direct configuration
+aperture config set-secret myapi bearerAuth --env API_TOKEN
+aperture config set-secret myapi apiKey --env MY_API_KEY
+
+# Interactive configuration (guided setup)
+aperture config set-secret myapi --interactive
+
+# List configured secrets
+aperture config list-secrets myapi
+```
+
+**Priority system:**
+1. **Config-based secrets** (set via CLI commands) take highest priority
+2. **x-aperture-secret extensions** (in OpenAPI specs) used as fallback
+3. Clear error messages when neither is available
+
+This feature maintains complete backward compatibility - existing `x-aperture-secret` extensions continue to work exactly as before, but can now be overridden by config-based settings.
+
 ### Parameter References
 
 Aperture fully supports OpenAPI parameter references, allowing you to define reusable parameters:
@@ -211,6 +241,11 @@ aperture config add --strict my-api ./openapi.yml
 
 # List available APIs
 aperture config list
+
+# Configure authentication secrets (v0.2.0+)
+aperture config set-secret my-api bearerAuth --env API_TOKEN
+aperture config set-secret my-api --interactive  # Guided configuration
+aperture config list-secrets my-api
 
 # Execute API commands (dynamically generated from spec)
 aperture api my-api users list

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -289,6 +289,42 @@ pub enum ConfigCommands {
                       at a glance."
     )]
     ListUrls {},
+    /// Set secret configuration for an API specification security scheme
+    #[command(
+        long_about = "Configure authentication secrets for API specifications.\n\n\
+                      This allows you to set environment variable mappings for security\n\
+                      schemes without modifying the OpenAPI specification file. These\n\
+                      settings take precedence over x-aperture-secret extensions.\n\n\
+                      Examples:\n  \
+                      aperture config set-secret myapi bearerAuth --env API_TOKEN\n  \
+                      aperture config set-secret myapi apiKey --env API_KEY\n  \
+                      aperture config set-secret myapi --interactive"
+    )]
+    SetSecret {
+        /// Name of the API specification
+        api_name: String,
+        /// Name of the security scheme (omit for interactive mode)
+        scheme_name: Option<String>,
+        /// Environment variable name containing the secret
+        #[arg(long, value_name = "VAR", help = "Environment variable name")]
+        env: Option<String>,
+        /// Interactive mode to configure all undefined secrets
+        #[arg(long, conflicts_with_all = ["scheme_name", "env"], help = "Configure secrets interactively")]
+        interactive: bool,
+    },
+    /// List configured secrets for an API specification
+    #[command(
+        long_about = "Display configured secret mappings for an API specification.\n\n\
+                      Shows which security schemes are configured with environment\n\
+                      variables and which ones still rely on x-aperture-secret\n\
+                      extensions or are undefined.\n\n\
+                      Example:\n  \
+                      aperture config list-secrets myapi"
+    )]
+    ListSecrets {
+        /// Name of the API specification
+        api_name: String,
+    },
     /// Re-initialize cached specifications
     #[command(
         long_about = "Regenerate binary cache files for API specifications.\n\n\

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -68,6 +68,7 @@ impl<F: FileSystem> ConfigManager<F> {
                 base_url_override: None,
                 environment_urls: HashMap::new(),
                 strict_mode: false,
+                secrets: HashMap::new(),
             });
         api_config.strict_mode = strict;
         self.save_global_config(&config)?;
@@ -660,6 +661,7 @@ impl<F: FileSystem> ConfigManager<F> {
                 base_url_override: None,
                 environment_urls: HashMap::new(),
                 strict_mode: false,
+                secrets: HashMap::new(),
             });
 
         // Set the URL

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -43,16 +43,19 @@ pub struct ApiConfig {
     /// Whether this spec was added with --strict flag (preserved for reinit)
     #[serde(default)]
     pub strict_mode: bool,
+    /// Secret configurations for security schemes (overrides x-aperture-secret extensions)
+    #[serde(default)]
+    pub secrets: HashMap<String, ApertureSecret>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ApertureSecret {
     pub source: SecretSource,
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum SecretSource {
     Env,

--- a/src/config/url_resolver.rs
+++ b/src/config/url_resolver.rs
@@ -175,6 +175,7 @@ mod tests {
                     base_url_override: Some("https://config.example.com".to_string()),
                     environment_urls: HashMap::new(),
                     strict_mode: false,
+                    secrets: HashMap::new(),
                 },
             );
 
@@ -208,6 +209,7 @@ mod tests {
                     base_url_override: Some("https://config.example.com".to_string()),
                     environment_urls,
                     strict_mode: false,
+                    secrets: HashMap::new(),
                 },
             );
 
@@ -240,6 +242,7 @@ mod tests {
                     base_url_override: Some("https://config.example.com".to_string()),
                     environment_urls: HashMap::new(),
                     strict_mode: false,
+                    secrets: HashMap::new(),
                 },
             );
 

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -102,7 +102,7 @@ pub async fn execute_request(
         })?;
 
     // Build headers including authentication and idempotency
-    let mut headers = build_headers(spec, operation, matches)?;
+    let mut headers = build_headers(spec, operation, matches, &spec.name, global_config)?;
 
     // Add idempotency key if provided
     if let Some(key) = idempotency_key {
@@ -393,6 +393,8 @@ fn build_headers(
     spec: &CachedSpec,
     operation: &CachedCommand,
     matches: &ArgMatches,
+    api_name: &str,
+    global_config: Option<&GlobalConfig>,
 ) -> Result<HeaderMap, Error> {
     let mut headers = HeaderMap::new();
 
@@ -428,7 +430,7 @@ fn build_headers(
     // Add authentication headers based on security requirements
     for security_scheme_name in &operation.security_requirements {
         if let Some(security_scheme) = spec.security_schemes.get(security_scheme_name) {
-            add_authentication_header(&mut headers, security_scheme)?;
+            add_authentication_header(&mut headers, security_scheme, api_name, global_config)?;
         }
     }
 
@@ -497,9 +499,12 @@ fn parse_custom_header(header_str: &str) -> Result<(String, String), Error> {
 }
 
 /// Adds an authentication header based on a security scheme
+#[allow(clippy::too_many_lines)]
 fn add_authentication_header(
     headers: &mut HeaderMap,
     security_scheme: &CachedSecurityScheme,
+    api_name: &str,
+    global_config: Option<&GlobalConfig>,
 ) -> Result<(), Error> {
     // Debug logging when RUST_LOG is set
     if std::env::var("RUST_LOG").is_ok() {
@@ -508,97 +513,126 @@ fn add_authentication_header(
             security_scheme.name, security_scheme.scheme_type
         );
     }
-    // Only process schemes that have aperture_secret mappings
-    if let Some(aperture_secret) = &security_scheme.aperture_secret {
-        // Read the secret from the environment variable
+
+    // Priority 1: Check config-based secrets first
+    let secret_config = global_config
+        .and_then(|config| config.api_configs.get(api_name))
+        .and_then(|api_config| api_config.secrets.get(&security_scheme.name));
+
+    let (secret_value, env_var_name) = if let Some(config_secret) = secret_config {
+        // Use config-based secret
+        let secret_value = std::env::var(&config_secret.name).map_err(|_| Error::SecretNotSet {
+            scheme_name: security_scheme.name.clone(),
+            env_var: config_secret.name.clone(),
+        })?;
+        (secret_value, config_secret.name.clone())
+    } else if let Some(aperture_secret) = &security_scheme.aperture_secret {
+        // Priority 2: Fall back to x-aperture-secret extension
         let secret_value =
             std::env::var(&aperture_secret.name).map_err(|_| Error::SecretNotSet {
                 scheme_name: security_scheme.name.clone(),
                 env_var: aperture_secret.name.clone(),
             })?;
+        (secret_value, aperture_secret.name.clone())
+    } else {
+        // No authentication configuration found - skip this scheme
+        return Ok(());
+    };
 
-        // Validate the secret doesn't contain control characters
-        validate_header_value("Authorization", &secret_value)?;
+    // Debug logging for resolved secret source
+    if std::env::var("RUST_LOG").is_ok() {
+        let source = if secret_config.is_some() {
+            "config"
+        } else {
+            "x-aperture-secret"
+        };
+        eprintln!(
+            "[DEBUG] Using secret from {source} for scheme '{}': env var '{env_var_name}'",
+            security_scheme.name
+        );
+    }
 
-        // Build the appropriate header based on scheme type
-        match security_scheme.scheme_type.as_str() {
-            "apiKey" => {
-                if let (Some(location), Some(param_name)) =
-                    (&security_scheme.location, &security_scheme.parameter_name)
-                {
-                    if location == "header" {
-                        let header_name = HeaderName::from_str(param_name).map_err(|e| {
-                            Error::InvalidHeaderName {
-                                name: param_name.clone(),
-                                reason: e.to_string(),
-                            }
+    // Validate the secret doesn't contain control characters
+    validate_header_value("Authorization", &secret_value)?;
+
+    // Build the appropriate header based on scheme type
+    match security_scheme.scheme_type.as_str() {
+        "apiKey" => {
+            if let (Some(location), Some(param_name)) =
+                (&security_scheme.location, &security_scheme.parameter_name)
+            {
+                if location == "header" {
+                    let header_name =
+                        HeaderName::from_str(param_name).map_err(|e| Error::InvalidHeaderName {
+                            name: param_name.clone(),
+                            reason: e.to_string(),
                         })?;
-                        let header_value = HeaderValue::from_str(&secret_value).map_err(|e| {
-                            Error::InvalidHeaderValue {
-                                name: param_name.clone(),
-                                reason: e.to_string(),
-                            }
-                        })?;
-                        headers.insert(header_name, header_value);
-                    }
-                    // Note: query and cookie locations are handled differently in request building
-                }
-            }
-            "http" => {
-                if let Some(scheme_str) = &security_scheme.scheme {
-                    let auth_scheme: AuthScheme = scheme_str.as_str().into();
-                    let auth_value = match &auth_scheme {
-                        AuthScheme::Bearer => {
-                            format!("Bearer {secret_value}")
-                        }
-                        AuthScheme::Basic => {
-                            // Basic auth expects "username:password" format in the secret
-                            // The secret should contain the raw "username:password" string
-                            // We'll base64 encode it before adding to the header
-                            use base64::{engine::general_purpose, Engine as _};
-                            let encoded = general_purpose::STANDARD.encode(&secret_value);
-                            format!("Basic {encoded}")
-                        }
-                        AuthScheme::Token
-                        | AuthScheme::DSN
-                        | AuthScheme::ApiKey
-                        | AuthScheme::Custom(_) => {
-                            // Treat any other HTTP scheme as a bearer-like token
-                            // Format: "Authorization: <scheme> <token>"
-                            // This supports Token, ApiKey, DSN, and any custom schemes
-                            format!("{scheme_str} {secret_value}")
-                        }
-                    };
-
-                    let header_value = HeaderValue::from_str(&auth_value).map_err(|e| {
+                    let header_value = HeaderValue::from_str(&secret_value).map_err(|e| {
                         Error::InvalidHeaderValue {
-                            name: "Authorization".to_string(),
+                            name: param_name.clone(),
                             reason: e.to_string(),
                         }
                     })?;
-                    headers.insert("Authorization", header_value);
+                    headers.insert(header_name, header_value);
+                }
+                // Note: query and cookie locations are handled differently in request building
+            }
+        }
+        "http" => {
+            if let Some(scheme_str) = &security_scheme.scheme {
+                let auth_scheme: AuthScheme = scheme_str.as_str().into();
+                let auth_value = match &auth_scheme {
+                    AuthScheme::Bearer => {
+                        format!("Bearer {secret_value}")
+                    }
+                    AuthScheme::Basic => {
+                        // Basic auth expects "username:password" format in the secret
+                        // The secret should contain the raw "username:password" string
+                        // We'll base64 encode it before adding to the header
+                        use base64::{engine::general_purpose, Engine as _};
+                        let encoded = general_purpose::STANDARD.encode(&secret_value);
+                        format!("Basic {encoded}")
+                    }
+                    AuthScheme::Token
+                    | AuthScheme::DSN
+                    | AuthScheme::ApiKey
+                    | AuthScheme::Custom(_) => {
+                        // Treat any other HTTP scheme as a bearer-like token
+                        // Format: "Authorization: <scheme> <token>"
+                        // This supports Token, ApiKey, DSN, and any custom schemes
+                        format!("{scheme_str} {secret_value}")
+                    }
+                };
 
-                    // Debug logging
-                    if std::env::var("RUST_LOG").is_ok() {
-                        match &auth_scheme {
-                            AuthScheme::Bearer => {
-                                eprintln!("[DEBUG] Added Bearer authentication header");
-                            }
-                            AuthScheme::Basic => eprintln!(
-                                "[DEBUG] Added Basic authentication header (base64 encoded)"
-                            ),
-                            _ => eprintln!(
+                let header_value =
+                    HeaderValue::from_str(&auth_value).map_err(|e| Error::InvalidHeaderValue {
+                        name: "Authorization".to_string(),
+                        reason: e.to_string(),
+                    })?;
+                headers.insert("Authorization", header_value);
+
+                // Debug logging
+                if std::env::var("RUST_LOG").is_ok() {
+                    match &auth_scheme {
+                        AuthScheme::Bearer => {
+                            eprintln!("[DEBUG] Added Bearer authentication header");
+                        }
+                        AuthScheme::Basic => {
+                            eprintln!("[DEBUG] Added Basic authentication header (base64 encoded)");
+                        }
+                        _ => {
+                            eprintln!(
                                 "[DEBUG] Added custom HTTP auth header with scheme: {scheme_str}"
-                            ),
+                            );
                         }
                     }
                 }
             }
-            _ => {
-                return Err(Error::UnsupportedSecurityScheme {
-                    scheme_type: security_scheme.scheme_type.clone(),
-                });
-            }
+        }
+        _ => {
+            return Err(Error::UnsupportedSecurityScheme {
+                scheme_type: security_scheme.scheme_type.clone(),
+            });
         }
     }
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,0 +1,101 @@
+use crate::error::Error;
+use std::io::{self, Write};
+
+/// Prompt the user for input with the given prompt message
+///
+/// # Errors
+/// Returns an error if stdin/stdout operations fail
+pub fn prompt_for_input(prompt: &str) -> Result<String, Error> {
+    print!("{prompt}");
+    io::stdout().flush().map_err(Error::Io)?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).map_err(Error::Io)?;
+
+    Ok(input.trim().to_string())
+}
+
+/// Present a menu of options and return the selected value
+///
+/// # Errors
+/// Returns an error if no options are provided or if stdin operations fail
+pub fn select_from_options(prompt: &str, options: &[(String, String)]) -> Result<String, Error> {
+    if options.is_empty() {
+        return Err(Error::InvalidConfig {
+            reason: "No options available for selection".to_string(),
+        });
+    }
+
+    println!("{prompt}");
+    for (i, (key, description)) in options.iter().enumerate() {
+        println!("  {}: {} - {}", i + 1, key, description);
+    }
+
+    loop {
+        let selection = prompt_for_input("Enter your choice (number or name): ")?;
+
+        // Try parsing as a number first
+        if let Ok(num) = selection.parse::<usize>() {
+            if num > 0 && num <= options.len() {
+                return Ok(options[num - 1].0.clone());
+            }
+        }
+
+        // Try matching by name (case insensitive)
+        let selection_lower = selection.to_lowercase();
+        for (key, _) in options {
+            if key.to_lowercase() == selection_lower {
+                return Ok(key.clone());
+            }
+        }
+
+        println!(
+            "Invalid selection. Please enter a number (1-{}) or a valid name.",
+            options.len()
+        );
+    }
+}
+
+/// Ask for user confirmation with yes/no prompt
+///
+/// # Errors
+/// Returns an error if stdin operations fail
+pub fn confirm(prompt: &str) -> Result<bool, Error> {
+    loop {
+        let response = prompt_for_input(&format!("{prompt} (y/n): "))?;
+        match response.to_lowercase().as_str() {
+            "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => println!("Please enter 'y' for yes or 'n' for no."),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_select_from_options_empty() {
+        let options = vec![];
+        let result = select_from_options("Choose:", &options);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_select_from_options_structure() {
+        let options = vec![
+            (
+                "bearerAuth".to_string(),
+                "Bearer token authentication".to_string(),
+            ),
+            ("apiKey".to_string(), "API key authentication".to_string()),
+        ];
+
+        // Test that the function accepts the correct input structure
+        // We can't test actual user input without mocking stdin
+        assert_eq!(options.len(), 2);
+        assert_eq!(options[0].0, "bearerAuth");
+        assert_eq!(options[1].0, "apiKey");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,5 +6,6 @@ pub mod config;
 pub mod engine;
 pub mod error;
 pub mod fs;
+pub mod interactive;
 pub mod response_cache;
 pub mod spec;

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,8 +142,7 @@ async fn run_command(cli: Cli, manager: &ConfigManager<OsFileSystem>) -> Result<
                 interactive,
             } => {
                 if interactive {
-                    // TODO: Implement interactive mode
-                    println!("Interactive mode not yet implemented for API '{api_name}'");
+                    manager.set_secret_interactive(&api_name)?;
                 } else if let (Some(scheme), Some(env_var)) = (scheme_name, env) {
                     manager.set_secret(&api_name, &scheme, &env_var)?;
                     println!("Set secret for scheme '{scheme}' in API '{api_name}' to use environment variable '{env_var}'");

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,19 @@ async fn run_command(cli: Cli, manager: &ConfigManager<OsFileSystem>) -> Result<
             ConfigCommands::CacheStats { api_name } => {
                 show_cache_stats(manager, api_name.as_deref()).await?;
             }
+            ConfigCommands::SetSecret {
+                api_name,
+                scheme_name,
+                env,
+                interactive,
+            } => {
+                // TODO: Implement set_secret functionality
+                println!("SetSecret not yet implemented - api_name: {api_name}, scheme_name: {scheme_name:?}, env: {env:?}, interactive: {interactive}");
+            }
+            ConfigCommands::ListSecrets { api_name } => {
+                // TODO: Implement list_secrets functionality
+                println!("ListSecrets not yet implemented - api_name: {api_name}");
+            }
         },
         Commands::ListCommands { ref context } => {
             list_commands(context)?;

--- a/tests/agent_manifest_tests.rs
+++ b/tests/agent_manifest_tests.rs
@@ -351,6 +351,7 @@ fn test_manifest_with_global_config() {
             base_url_override: Some("https://override.example.com".to_string()),
             environment_urls: HashMap::new(),
             strict_mode: false,
+            secrets: HashMap::new(),
         },
     );
 

--- a/tests/config_secrets_integration_tests.rs
+++ b/tests/config_secrets_integration_tests.rs
@@ -1,0 +1,156 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_config_set_secret_basic_functionality() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+
+    // Create a simple OpenAPI spec
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+paths:
+  /test:
+    get:
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+servers:
+  - url: https://api.example.com
+"#;
+
+    let spec_file = temp_dir.path().join("test-spec.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec first
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&[
+            "config",
+            "add",
+            "test-api",
+            spec_file.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Spec 'test-api' added successfully",
+        ));
+
+    // Set a secret for the bearerAuth scheme
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&["config", "set-secret", "test-api", "bearerAuth", "--env", "TEST_BEARER_TOKEN"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Set secret for scheme 'bearerAuth' in API 'test-api' to use environment variable 'TEST_BEARER_TOKEN'"));
+
+    // List secrets to verify it was set
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&["config", "list-secrets", "test-api"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Configured secrets for API 'test-api':",
+        ))
+        .stdout(predicate::str::contains(
+            "bearerAuth: environment variable 'TEST_BEARER_TOKEN'",
+        ));
+}
+
+#[test]
+fn test_config_set_secret_nonexistent_api() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+    // Try to set secret for non-existent API
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&[
+            "config",
+            "set-secret",
+            "nonexistent-api",
+            "bearerAuth",
+            "--env",
+            "TOKEN",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "API specification 'nonexistent-api' not found",
+        ));
+}
+
+#[test]
+fn test_config_list_secrets_empty() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+
+    // Create a simple OpenAPI spec
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: Success
+servers:
+  - url: https://api.example.com
+"#;
+
+    let spec_file = temp_dir.path().join("test-spec.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec first
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&[
+            "config",
+            "add",
+            "test-api",
+            spec_file.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success();
+
+    // List secrets for API with no configured secrets
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&["config", "list-secrets", "test-api"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No secrets configured for API 'test-api'",
+        ));
+}
+
+#[test]
+fn test_config_set_secret_invalid_arguments() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+    // Try to set secret without providing both scheme and env
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&["config", "set-secret", "test-api", "bearerAuth"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Either provide --scheme and --env, or use --interactive",
+        ));
+}

--- a/tests/engine_executor_tests.rs
+++ b/tests/engine_executor_tests.rs
@@ -252,6 +252,7 @@ async fn test_execute_request_with_global_config_base_url() {
             base_url_override: Some(mock_server.uri()),
             environment_urls: HashMap::new(),
             strict_mode: false,
+            secrets: HashMap::new(),
         },
     );
 

--- a/tests/interactive_secret_configuration_tests.rs
+++ b/tests/interactive_secret_configuration_tests.rs
@@ -1,0 +1,213 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_interactive_mode_flag_exists() {
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.args(&["config", "set-secret", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--interactive"))
+        .stdout(predicate::str::contains("Configure secrets interactively"));
+}
+
+#[test]
+fn test_interactive_mode_conflicts_with_direct_mode() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&[
+            "config",
+            "set-secret",
+            "test-api",
+            "bearerAuth",
+            "--env",
+            "TOKEN",
+            "--interactive",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "cannot be used with '--interactive'",
+        ));
+}
+
+#[test]
+fn test_interactive_mode_with_nonexistent_api() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&["config", "set-secret", "nonexistent-api", "--interactive"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "API specification 'nonexistent-api' not found",
+        ));
+}
+
+#[test]
+fn test_interactive_mode_with_api_without_security_schemes() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+
+    // Create a simple OpenAPI spec without security schemes
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /test:
+    get:
+      responses:
+        '200':
+          description: Success
+servers:
+  - url: https://api.example.com
+"#;
+
+    let spec_file = temp_dir.path().join("test-spec.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec first
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&[
+            "config",
+            "add",
+            "test-api",
+            spec_file.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success();
+
+    // Try interactive mode - should handle gracefully and exit successfully
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&["config", "set-secret", "test-api", "--interactive"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No security schemes found in API 'test-api'",
+        ));
+}
+
+#[test]
+fn test_help_text_describes_interactive_workflow() {
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.args(&["config", "set-secret", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Configure secrets interactively"))
+        .stdout(predicate::str::contains("--interactive"))
+        .stdout(predicate::str::contains("--env"))
+        .stdout(predicate::str::contains("Environment variable name"));
+}
+
+#[test]
+fn test_validation_requires_either_direct_or_interactive_mode() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+
+    // Test missing both modes
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&["config", "set-secret", "test-api", "bearerAuth"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Either provide --scheme and --env, or use --interactive",
+        ));
+}
+
+#[test]
+fn test_direct_mode_still_works_alongside_interactive_option() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("aperture");
+
+    // Create a simple OpenAPI spec with security schemes
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+paths:
+  /test:
+    get:
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Success
+servers:
+  - url: https://api.example.com
+"#;
+
+    let spec_file = temp_dir.path().join("test-spec.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec first
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&[
+            "config",
+            "add",
+            "test-api",
+            spec_file.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success();
+
+    // Test direct mode still works
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&[
+            "config",
+            "set-secret",
+            "test-api",
+            "bearerAuth",
+            "--env",
+            "TEST_TOKEN",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Set secret for scheme 'bearerAuth' in API 'test-api' to use environment variable 'TEST_TOKEN'",
+        ));
+
+    // Verify it was set
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args(&["config", "list-secrets", "test-api"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "bearerAuth: environment variable 'TEST_TOKEN'",
+        ));
+}
+
+#[test]
+fn test_cli_help_shows_both_modes() {
+    let mut cmd = Command::cargo_bin("aperture").unwrap();
+    cmd.args(&["config", "set-secret", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Examples:"))
+        .stdout(predicate::str::contains(
+            "aperture config set-secret myapi bearerAuth --env API_TOKEN",
+        ))
+        .stdout(predicate::str::contains(
+            "aperture config set-secret myapi --interactive",
+        ));
+}


### PR DESCRIPTION
## Summary

This PR implements interactive mode for the `config set-secret` command, addressing issue #18. The new functionality allows users to configure authentication for existing API specifications without modifying the OpenAPI spec files themselves.

## Key Features

- **Interactive Configuration**: New `--interactive` flag provides guided setup for security schemes
- **Dynamic Secret Management**: Configure authentication via CLI commands instead of modifying OpenAPI specs
- **Priority System**: Config-based secrets take precedence over x-aperture-secret extensions
- **Rich User Experience**: Contextual information, validation, and confirmation prompts
- **Multi-scheme Support**: Configure multiple authentication schemes in a single session
- **Backward Compatibility**: All existing functionality preserved

## Implementation Details

### Core Components

1. **Interactive Input Utilities** (`src/interactive.rs`)
   - User interaction functions with validation and error handling
   - Menu selection, text input, and confirmation prompts

2. **Enhanced ConfigManager** (`src/config/manager.rs`)
   - `set_secret_interactive()` method for guided configuration
   - Loads cached specs to discover available security schemes
   - Displays detailed scheme information and current status

3. **CLI Integration** (`src/main.rs`)
   - Wired up `--interactive` flag handling
   - Maintains existing direct mode functionality

4. **Authentication Resolution** (`src/engine/executor.rs`)
   - Updated to prioritize config-based secrets over x-aperture-secret extensions
   - Graceful fallback behavior maintained

### Usage Examples

```bash
# Interactive mode (new)
aperture config set-secret myapi --interactive

# Direct mode (existing, unchanged)
aperture config set-secret myapi bearerAuth --env API_TOKEN

# List configured secrets
aperture config list-secrets myapi
```

## Testing

- **8 comprehensive integration tests** covering all functionality
- **CLI flag validation** and conflict detection
- **Error handling** for edge cases and invalid inputs
- **Backward compatibility** verification
- **End-to-end workflow** testing

## Documentation

- Updated README.md with feature documentation and examples
- Added usage examples for both interactive and direct modes
- Documented priority system and backward compatibility guarantees

## Benefits Achieved

- **Use unmodified third-party OpenAPI specs** - No need to fork and modify specifications
- **Easy credential management** - Simple CLI commands to manage authentication
- **Environment flexibility** - Different credentials per environment without spec changes
- **Credential rotation** - Update environment variables without editing specifications
- **Better separation of concerns** - Configuration separate from specification

## Backward Compatibility

This implementation maintains 100% backward compatibility:
- Existing `x-aperture-secret` extensions continue to work unchanged
- Direct mode commands work exactly as before
- Config-based secrets override extensions when both exist
- No breaking changes to existing functionality

Closes #18

## Test Plan

- [x] All existing tests continue to pass
- [x] New integration tests verify interactive functionality
- [x] CLI argument validation works correctly
- [x] Error handling covers edge cases
- [x] Documentation examples are accurate
- [x] Backward compatibility maintained