### PR TITLE
fix: handle server URL templates without panicking

### DIFF
--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -332,30 +332,34 @@ fn find_operation<'a>(
 fn contains_template_variables(url: &str) -> bool {
     let mut chars = url.chars();
     while let Some(ch) = chars.next() {
-        if ch == '{' {
-            // Found opening brace, check if it forms a valid template variable
-            let mut var_name = String::new();
-            let mut found_closing = false;
+        if ch != '{' {
+            continue;
+        }
 
-            for next_ch in chars.by_ref() {
-                if next_ch == '}' {
-                    found_closing = true;
-                    break;
-                } else if next_ch.is_alphanumeric() || next_ch == '_' || next_ch == '-' {
-                    var_name.push(next_ch);
-                } else {
-                    // Invalid character in template variable name
-                    break;
-                }
+        // Found opening brace, check if it forms a valid template variable
+        let mut var_name = String::new();
+        let mut found_closing = false;
+
+        for next_ch in chars.by_ref() {
+            if next_ch == '}' {
+                found_closing = true;
+                break;
             }
 
-            // Valid template variable must have:
-            // 1. A closing brace
-            // 2. A non-empty variable name
-            // 3. Only alphanumeric, underscore, or hyphen characters
-            if found_closing && !var_name.is_empty() {
-                return true;
+            if next_ch.is_alphanumeric() || next_ch == '_' || next_ch == '-' {
+                var_name.push(next_ch);
+            } else {
+                // Invalid character in template variable name
+                break;
             }
+        }
+
+        // Valid template variable must have:
+        // 1. A closing brace
+        // 2. A non-empty variable name
+        // 3. Only alphanumeric, underscore, or hyphen characters
+        if found_closing && !var_name.is_empty() {
+            return true;
         }
     }
     false

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -92,7 +92,7 @@ pub async fn execute_request(
     let base_url = resolver.resolve(base_url);
 
     // Build the full URL with path parameters
-    let url = build_url(&base_url, &operation.path, operation, matches)?;
+    let url = build_url(&base_url, &operation.path, operation, matches, &spec.name)?;
 
     // Create HTTP client with timeout
     let client = reqwest::Client::builder()
@@ -334,7 +334,18 @@ fn build_url(
     path_template: &str,
     operation: &CachedCommand,
     matches: &ArgMatches,
+    api_name: &str,
 ) -> Result<String, Error> {
+    // Check if base_url contains template variables
+    if base_url.contains('{') && base_url.contains('}') {
+        return Err(Error::InvalidConfig {
+            reason: format!(
+                "Server URL contains template variable(s): {base_url}. \
+                Please use 'aperture config set-url {api_name} <concrete-url>' to set a specific base URL."
+            ),
+        });
+    }
+
     let mut url = format!("{}{}", base_url.trim_end_matches('/'), path_template);
 
     // Get to the deepest subcommand matches

--- a/tests/server_template_integration_tests.rs
+++ b/tests/server_template_integration_tests.rs
@@ -1,0 +1,233 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// Helper to create test directory with config
+fn setup_test_env() -> (TempDir, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = TempDir::new().unwrap();
+    let config_dir = home_dir.path().join(".config").join("aperture");
+    let specs_dir = config_dir.join("specs");
+    let cache_dir = config_dir.join(".cache");
+
+    fs::create_dir_all(&specs_dir).unwrap();
+    fs::create_dir_all(&cache_dir).unwrap();
+
+    // Create empty config.toml
+    let config_content = r#"
+[general]
+default_output_format = "json"
+
+[api_configs]
+"#;
+    fs::write(config_dir.join("config.toml"), config_content).unwrap();
+
+    (temp_dir, home_dir)
+}
+
+#[test]
+fn test_server_url_template_error_message() {
+    let (_temp_dir, home_dir) = setup_test_env();
+
+    // Create a Sentry-like OpenAPI spec with server URL template
+    let sentry_spec = r#"
+openapi: 3.0.0
+info:
+  title: Sentry API
+  version: 1.0.0
+servers:
+  - url: https://{region}.sentry.io
+    variables:
+      region:
+        default: us
+        enum: [us, eu]
+        description: The regional instance of Sentry
+paths:
+  /api/0/projects/{organization}/{project}/events/:
+    get:
+      operationId: listEvents
+      tags: [events]
+      summary: List project events
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: project
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+"#;
+
+    let spec_file = home_dir.path().join("sentry.yaml");
+    fs::write(&spec_file, sentry_spec).unwrap();
+
+    // Add the spec
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("HOME", home_dir.path())
+        .args(&["config", "add", "sentry", spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Try to execute a command - should fail with template error
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("HOME", home_dir.path())
+        .args(&[
+            "api",
+            "sentry",
+            "events",
+            "list-events",
+            "--organization",
+            "my-org",
+            "--project",
+            "my-project",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Server URL contains template variable(s): https://{region}.sentry.io",
+        ))
+        .stderr(predicate::str::contains("aperture config set-url sentry"));
+}
+
+#[test]
+fn test_server_url_template_with_override() {
+    let (_temp_dir, home_dir) = setup_test_env();
+
+    // Create a spec with server URL template
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Regional API
+  version: 1.0.0
+servers:
+  - url: https://{env}.api.example.com
+    variables:
+      env:
+        default: prod
+        enum: [dev, staging, prod]
+paths:
+  /status:
+    get:
+      operationId: getStatus
+      tags: [health]
+      summary: Get API status
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_file = home_dir.path().join("regional.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("HOME", home_dir.path())
+        .args(&["config", "add", "regional", spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // First attempt should fail
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("HOME", home_dir.path())
+        .args(&["api", "regional", "health", "get-status"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Server URL contains template variable(s)",
+        ));
+
+    // Set a base URL override
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("HOME", home_dir.path())
+        .args(&[
+            "config",
+            "set-url",
+            "regional",
+            "https://prod.api.example.com",
+        ])
+        .assert()
+        .success();
+
+    // Now it should work (would fail at network level, but not template error)
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("HOME", home_dir.path())
+        .args(&["--dry-run", "api", "regional", "health", "get-status"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "https://prod.api.example.com/status",
+        ));
+}
+
+#[test]
+fn test_multiple_server_url_templates() {
+    let (_temp_dir, home_dir) = setup_test_env();
+
+    // Create a spec with multiple template variables
+    let spec_content = r#"
+openapi: 3.0.0
+info:
+  title: Multi-Region API
+  version: 1.0.0
+servers:
+  - url: https://{region}-{env}.api.example.com
+    variables:
+      region:
+        default: us
+        enum: [us, eu, ap]
+      env:
+        default: prod
+        enum: [dev, prod]
+paths:
+  /ping:
+    get:
+      operationId: ping
+      tags: [health]
+      summary: Ping endpoint
+      responses:
+        '200':
+          description: Success
+"#;
+
+    let spec_file = home_dir.path().join("multi.yaml");
+    fs::write(&spec_file, spec_content).unwrap();
+
+    // Add the spec
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("HOME", home_dir.path())
+        .args(&["config", "add", "multi", spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Should fail with error mentioning the templated URL
+    Command::cargo_bin("aperture")
+        .unwrap()
+        .env("HOME", home_dir.path())
+        .args(&["api", "multi", "health", "ping"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "https://{region}-{env}.api.example.com",
+        ))
+        .stderr(predicate::str::contains("aperture config set-url multi"));
+}


### PR DESCRIPTION
## Summary
Prevents panic when using APIs with server URL templates by detecting template variables and providing a helpful error message.

## Problem
OpenAPI specs with server URL templates would cause a panic:
```yaml
servers:
  - url: https://{region}.sentry.io
```
The error occurred because aperture tried to substitute `{region}` as a path parameter.

## Solution
Added detection for template variables in the base URL. When found, returns a clear error message guiding users to use `aperture config set-url`.

## Result
Instead of panic:
```
Error: Invalid configuration
Server URL contains template variable(s): https://{region}.sentry.io. 
Please use 'aperture config set-url sentry-main <concrete-url>' to set a specific base URL.
```

## Testing
- Tested with Sentry API (contains {region} variable)
- Verified error message appears correctly
- Confirmed APIs without server variables work normally
- All existing tests pass

## Future Enhancement
This fix prevents the panic but still requires manual URL configuration. A future enhancement could add full server variable support with CLI flags like `--server-var region=us`.