### PR TITLE
fix: convert parameter flags to kebab-case for CLI consistency

### DIFF
--- a/src/engine/generator.rs
+++ b/src/engine/generator.rs
@@ -157,7 +157,7 @@ fn create_arg_from_parameter(param: &CachedParameter, use_positional_args: bool)
                     .action(ArgAction::Set);
             } else {
                 // Default mode: path parameters become flags too
-                let long_name = to_static_str(param.name.clone());
+                let long_name = to_static_str(to_kebab_case(&param.name));
                 let value_name = to_static_str(param.name.to_uppercase());
                 arg = arg
                     .long(long_name)
@@ -169,7 +169,7 @@ fn create_arg_from_parameter(param: &CachedParameter, use_positional_args: bool)
         }
         "query" | "header" => {
             // Query and header parameters are flags
-            let long_name = to_static_str(param.name.clone());
+            let long_name = to_static_str(to_kebab_case(&param.name));
             let value_name = to_static_str(param.name.to_uppercase());
             arg = arg
                 .long(long_name)
@@ -184,7 +184,7 @@ fn create_arg_from_parameter(param: &CachedParameter, use_positional_args: bool)
         }
         _ => {
             // Unknown location, treat as flag
-            let long_name = to_static_str(param.name.clone());
+            let long_name = to_static_str(to_kebab_case(&param.name));
             let value_name = to_static_str(param.name.to_uppercase());
             arg = arg
                 .long(long_name)

--- a/tests/command_syntax_integration_tests.rs
+++ b/tests/command_syntax_integration_tests.rs
@@ -148,7 +148,7 @@ async fn test_flag_based_syntax_with_caching() {
             "get-user-by-id",
             "--id",
             "123",
-            "--include_profile",
+            "--include-profile",
             "true",
             "--x-request-id",
             "req-123",
@@ -230,7 +230,7 @@ async fn test_legacy_positional_syntax_with_caching() {
             "users",
             "get-user-by-id",
             "456",
-            "--include_profile",
+            "--include-profile",
             "false",
         ])
         .unwrap();
@@ -313,7 +313,7 @@ async fn test_different_parameter_combinations_cache_separately() {
             "get-user-by-id",
             "--id",
             "123",
-            "--include_profile",
+            "--include-profile",
             "true",
         ])
         .unwrap();
@@ -342,7 +342,7 @@ async fn test_different_parameter_combinations_cache_separately() {
             "get-user-by-id",
             "--id",
             "123",
-            "--include_profile",
+            "--include-profile",
             "false",
         ])
         .unwrap();
@@ -463,7 +463,7 @@ async fn test_dry_run_with_flag_based_syntax() {
             "get-user-by-id",
             "--id",
             "123",
-            "--include_profile",
+            "--include-profile",
             "true",
         ])
         .unwrap();

--- a/tests/experimental_flags_tests.rs
+++ b/tests/experimental_flags_tests.rs
@@ -91,7 +91,7 @@ fn test_default_flag_based_command_generation() {
         .expect("include_profile argument should exist");
     assert_eq!(
         include_profile_arg.get_long(),
-        Some("include_profile"),
+        Some("include-profile"),
         "Query parameter should have long flag"
     );
 }
@@ -131,7 +131,7 @@ fn test_legacy_positional_command_generation() {
         .expect("include_profile argument should exist");
     assert_eq!(
         include_profile_arg.get_long(),
-        Some("include_profile"),
+        Some("include-profile"),
         "Query parameter should still have long flag"
     );
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -432,7 +432,7 @@ paths:
             "test",
             "--limit",
             "10",
-            "--X-API-Key",
+            "--x-api-key",
             "secret123",
         ])
         .assert()

--- a/tests/kebab_case_parameter_tests.rs
+++ b/tests/kebab_case_parameter_tests.rs
@@ -1,0 +1,268 @@
+use aperture_cli::cache::models::{CachedCommand, CachedParameter, CachedSpec};
+use aperture_cli::cli::OutputFormat;
+use aperture_cli::engine::executor::execute_request;
+use aperture_cli::engine::generator::generate_command_tree;
+use std::collections::HashMap;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Create a test spec with various snake_case and mixed-case parameters
+fn create_snake_case_spec() -> CachedSpec {
+    CachedSpec {
+        cache_format_version: aperture_cli::cache::models::CACHE_FORMAT_VERSION,
+        name: "snake-case-api".to_string(),
+        version: "1.0.0".to_string(),
+        commands: vec![CachedCommand {
+            name: "organizations".to_string(),
+            description: Some("Organization operations".to_string()),
+            summary: None,
+            operation_id: "getOrganizationDetails".to_string(),
+            method: "GET".to_string(),
+            path: "/orgs/{organization_id_or_slug}/details".to_string(),
+            parameters: vec![
+                CachedParameter {
+                    name: "organization_id_or_slug".to_string(),
+                    location: "path".to_string(),
+                    required: true,
+                    description: Some("Organization ID or slug".to_string()),
+                    schema: Some(r#"{"type": "string"}"#.to_string()),
+                    schema_type: Some("string".to_string()),
+                    format: None,
+                    default_value: None,
+                    enum_values: vec![],
+                    example: None,
+                },
+                CachedParameter {
+                    name: "include_members".to_string(),
+                    location: "query".to_string(),
+                    required: false,
+                    description: Some("Include member information".to_string()),
+                    schema: Some(r#"{"type": "boolean"}"#.to_string()),
+                    schema_type: Some("boolean".to_string()),
+                    format: None,
+                    default_value: Some("false".to_string()),
+                    enum_values: vec![],
+                    example: None,
+                },
+                CachedParameter {
+                    name: "X_Custom_Header".to_string(),
+                    location: "header".to_string(),
+                    required: false,
+                    description: Some("Custom header value".to_string()),
+                    schema: Some(r#"{"type": "string"}"#.to_string()),
+                    schema_type: Some("string".to_string()),
+                    format: None,
+                    default_value: None,
+                    enum_values: vec![],
+                    example: None,
+                },
+            ],
+            responses: vec![],
+            request_body: None,
+            security_requirements: vec![],
+            tags: vec!["organizations".to_string()],
+            deprecated: false,
+            external_docs_url: None,
+        }],
+        base_url: None,
+        servers: vec!["https://api.example.com".to_string()],
+        security_schemes: HashMap::new(),
+        skipped_endpoints: vec![],
+        server_variables: HashMap::new(),
+    }
+}
+
+#[test]
+fn test_snake_case_parameters_converted_to_kebab_case() {
+    let spec = create_snake_case_spec();
+    let command = generate_command_tree(&spec);
+
+    // Navigate to the operation
+    let orgs_group = command
+        .find_subcommand("organizations")
+        .expect("organizations group should exist");
+    let operation = orgs_group
+        .find_subcommand("get-organization-details")
+        .expect("get-organization-details operation should exist");
+
+    // Verify path parameter has kebab-case flag
+    let org_id_arg = operation
+        .get_arguments()
+        .find(|arg| arg.get_id() == "organization_id_or_slug")
+        .expect("organization_id_or_slug argument should exist");
+    assert_eq!(
+        org_id_arg.get_long(),
+        Some("organization-id-or-slug"),
+        "Path parameter flag should be converted to kebab-case"
+    );
+
+    // Verify query parameter has kebab-case flag
+    let include_members_arg = operation
+        .get_arguments()
+        .find(|arg| arg.get_id() == "include_members")
+        .expect("include_members argument should exist");
+    assert_eq!(
+        include_members_arg.get_long(),
+        Some("include-members"),
+        "Query parameter flag should be converted to kebab-case"
+    );
+
+    // Verify header parameter has kebab-case flag (and lowercase)
+    let custom_header_arg = operation
+        .get_arguments()
+        .find(|arg| arg.get_id() == "X_Custom_Header")
+        .expect("X_Custom_Header argument should exist");
+    assert_eq!(
+        custom_header_arg.get_long(),
+        Some("x-custom-header"),
+        "Header parameter flag should be converted to kebab-case and lowercase"
+    );
+}
+
+#[tokio::test]
+async fn test_kebab_case_parameters_work_end_to_end() {
+    let spec = create_snake_case_spec();
+    let mock_server = MockServer::start().await;
+
+    // Set up mock response
+    Mock::given(method("GET"))
+        .and(path("/orgs/my-org/details"))
+        .and(query_param("include_members", "true"))
+        .and(wiremock::matchers::header("X_Custom_Header", "test-value"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "org-123",
+            "name": "My Organization",
+            "members_included": true
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Build command with kebab-case flags
+    let command = generate_command_tree(&spec);
+
+    // Simulate command line arguments with kebab-case flags
+    let matches = command
+        .try_get_matches_from(vec![
+            "api",
+            "organizations",
+            "get-organization-details",
+            "--organization-id-or-slug",
+            "my-org",
+            "--include-members",
+            "true",
+            "--x-custom-header",
+            "test-value",
+        ])
+        .expect("Should parse kebab-case arguments");
+
+    // Execute the request
+    let result = execute_request(
+        &spec,
+        &matches,
+        Some(&mock_server.uri()),
+        false, // dry_run
+        None,  // idempotency_key
+        None,  // global_config
+        &OutputFormat::Json,
+        None,  // jq_filter
+        None,  // cache_config
+        false, // capture_output
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Request should succeed with kebab-case parameters"
+    );
+
+    // Verify the response
+    if let Ok(Some(output)) = result {
+        let json: serde_json::Value =
+            serde_json::from_str(&output).expect("Output should be valid JSON");
+        assert_eq!(json["id"], "org-123");
+        assert_eq!(json["members_included"], true);
+    }
+}
+
+#[test]
+fn test_mixed_case_parameters_normalization() {
+    let spec = CachedSpec {
+        cache_format_version: aperture_cli::cache::models::CACHE_FORMAT_VERSION,
+        name: "mixed-case-api".to_string(),
+        version: "1.0.0".to_string(),
+        commands: vec![CachedCommand {
+            name: "data".to_string(),
+            description: Some("Data operations".to_string()),
+            summary: None,
+            operation_id: "getData".to_string(),
+            method: "GET".to_string(),
+            path: "/data/{DataID}".to_string(),
+            parameters: vec![
+                CachedParameter {
+                    name: "DataID".to_string(),
+                    location: "path".to_string(),
+                    required: true,
+                    description: Some("Data identifier".to_string()),
+                    schema: Some(r#"{"type": "string"}"#.to_string()),
+                    schema_type: Some("string".to_string()),
+                    format: None,
+                    default_value: None,
+                    enum_values: vec![],
+                    example: None,
+                },
+                CachedParameter {
+                    name: "IncludeMetaData".to_string(),
+                    location: "query".to_string(),
+                    required: false,
+                    description: Some("Include metadata".to_string()),
+                    schema: Some(r#"{"type": "boolean"}"#.to_string()),
+                    schema_type: Some("boolean".to_string()),
+                    format: None,
+                    default_value: None,
+                    enum_values: vec![],
+                    example: None,
+                },
+            ],
+            responses: vec![],
+            request_body: None,
+            security_requirements: vec![],
+            tags: vec!["data".to_string()],
+            deprecated: false,
+            external_docs_url: None,
+        }],
+        base_url: None,
+        servers: vec!["https://api.example.com".to_string()],
+        security_schemes: HashMap::new(),
+        skipped_endpoints: vec![],
+        server_variables: HashMap::new(),
+    };
+
+    let command = generate_command_tree(&spec);
+    let data_group = command
+        .find_subcommand("data")
+        .expect("data group should exist");
+    let operation = data_group
+        .find_subcommand("get-data")
+        .expect("get-data operation should exist");
+
+    // Verify mixed case parameters are converted properly
+    let data_id_arg = operation
+        .get_arguments()
+        .find(|arg| arg.get_id() == "DataID")
+        .expect("DataID argument should exist");
+    assert_eq!(
+        data_id_arg.get_long(),
+        Some("data-id"),
+        "Mixed case parameter should be converted to lowercase kebab-case"
+    );
+
+    let include_meta_arg = operation
+        .get_arguments()
+        .find(|arg| arg.get_id() == "IncludeMetaData")
+        .expect("IncludeMetaData argument should exist");
+    assert_eq!(
+        include_meta_arg.get_long(),
+        Some("include-meta-data"),
+        "CamelCase parameter should be converted to kebab-case"
+    );
+}

--- a/tests/parameter_reference_integration_tests.rs
+++ b/tests/parameter_reference_integration_tests.rs
@@ -423,8 +423,8 @@ paths:
 
     // Check that parameter was resolved correctly
     assert!(
-        stdout.contains("--petId") || stderr.contains("--petId"),
-        "Output should contain --petId parameter. stdout: {}, stderr: {}",
+        stdout.contains("--pet-id") || stderr.contains("--pet-id"),
+        "Output should contain --pet-id parameter. stdout: {}, stderr: {}",
         stdout,
         stderr
     );
@@ -550,7 +550,7 @@ paths:
     let combined = format!("{}{}", stdout, stderr);
 
     assert!(
-        combined.contains("--user-id") && combined.contains("--include.fields"),
+        combined.contains("--user-id") && combined.contains("--include-fields"),
         "Help should show both special character parameters"
     );
 
@@ -566,7 +566,7 @@ paths:
             "get-user",
             "--user-id",
             "123",
-            "--include.fields",
+            "--include-fields",
             "name,email",
         ])
         .output()


### PR DESCRIPTION
## Summary
- Converts all parameter flags to kebab-case format (e.g., `--organization-id-or-slug` instead of `--organization_id_or_slug`)
- Maintains backward compatibility with the executor through clap's Arg ID separation
- Aligns parameter naming with CLI conventions and existing operation naming

## Changes
1. **Core Implementation**: Modified `src/engine/generator.rs` to apply `to_kebab_case()` conversion to parameter flag names while keeping original names as Arg IDs
2. **Comprehensive Tests**: Added dedicated test suite (`kebab_case_parameter_tests.rs`) covering snake_case, CamelCase, and mixed-case parameter conversions
3. **Test Updates**: Updated all existing tests to expect the new kebab-case format

## Breaking Change
This is a breaking change for existing users. Parameter flags now use kebab-case instead of snake_case.
Users must update their scripts to use `--parameter-name` instead of `--parameter_name`.

## Testing
- All existing tests pass
- New integration tests verify correct conversion for various naming patterns
- End-to-end test confirms functionality with mock server

## Technical Details
The fix leverages clap's separation between:
- **Arg ID**: Used for value retrieval (keeps original parameter name)
- **Long flag**: Displayed to users (converted to kebab-case)

This ensures the executor can retrieve values using original OpenAPI parameter names while presenting consistent kebab-case flags to users.

Fixes #28