### PR TITLE
Address build failures - #42

### DIFF
--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -1209,7 +1209,7 @@ pub fn apply_jq_filter(response_text: &str, filter: &str) -> Result<String, Erro
                 }
             }
             Err(e) => Err(Error::jq_filter_error(
-                filter,
+                format!("{:?}", filter),
                 format!("Filter execution error: {e}"),
             )),
         }

--- a/src/spec/parser.rs
+++ b/src/spec/parser.rs
@@ -225,7 +225,7 @@ fn parse_with_oas3_direct_with_original(
                 Error::serialization_error(format!(
                     "Failed to parse OpenAPI 3.1 spec as YAML or JSON: {e}"
                 ))
-            })?;
+            })?
         }
     };
 


### PR DESCRIPTION
Fix #42:

1. Format `Error::jq_filter_error` such as to make Into<String> fit the constraint.
2. Return the `Spec` struct value from the match arms instead of consuming with `;`

Testing:
  CI built in Arch chroot successfully