### PR TITLE
fix: move unix-gated dependencies to cross-platform section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,6 @@ dirs = "6.0.0"
 base64 = "0.22.1"
 fastrand = "2.3.0"
 fs2 = "0.4.3"
-
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
 fuzzy-matcher = "0.3.7"
 governor = "0.6.3"
 httpdate = "1.0"
@@ -71,6 +68,9 @@ toml_edit = "0.22"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt", "json"] }
 urlencoding = "2.1.3"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [features]
 default = []


### PR DESCRIPTION
## Problem

The Windows integration test has been failing on `main` and on all 12 open dependabot PRs (#79–#90). The failure is a **compilation error** — 48 unresolved import errors at the clippy step — not a test failure.

### Root cause

`Cargo.toml` placed 11 crates under `[target.'cfg(unix)'.dependencies]`:

```
fuzzy-matcher, governor, httpdate, indexmap, sha2, toml, toml_edit,
tracing, tracing-subscriber, urlencoding, libc
```

However, the source code uses all of these **unconditionally** — there are zero `#[cfg(unix)]` guards anywhere in `src/` except for `libc` in `src/atomic.rs`. This means the project cannot compile on Windows at all.

## Fix

Move the 10 unconditionally-used crates to `[dependencies]`. Keep only `libc` under `[target.'cfg(unix)'.dependencies]` since it is the sole dependency with proper platform guards.

This is a Cargo.toml-only change (no source modifications).

## Validation

- `cargo check` — clean
- `cargo clippy --all-targets --features integration -- -D warnings` — clean
- `cargo test --lib --no-default-features` — 187 passed
- `cargo fmt --check` — clean

## Impact

Unblocks all 12 open dependabot PRs (#79–#90) which all fail on the same Windows compilation error.