### PR TITLE
chore: bump oas3 from 0.17.0 to 0.20.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "oas3"
-version = "0.17.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ecc0ddb68858bb2babd656e59d8ad2c74c87bfff390dd6cb675d61655ac42d2"
+checksum = "16f67c885c7b19aaf652e84102035258ecb4e0425a4f71037e187798e367bd87"
 dependencies = [
  "derive_more",
  "http",
@@ -1735,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ clap = { version = "4.5.54", features = ["derive"] }
 jaq-core = { version = "2.2.1", optional = true }
 jaq-json = { version = "1.1.3", features = ["serde_json"], optional = true }
 jaq-std = { version = "2.1.2", optional = true }
-oas3 = { version = "0.17", features = ["yaml-spec"], optional = true }
+oas3 = { version = "0.20", features = ["yaml-spec"], optional = true }
 openapiv3 = "2.2.0"
 regex = "1"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }


### PR DESCRIPTION
Bump oas3 and fix clippy pedantic and ast-grep lints in the openapi31 feature-gated `restore_security_schemes` function.

Supersedes #82