### PR TITLE
chore: replace bincode with postcard for cache serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,6 @@ dependencies = [
  "aperture-cli",
  "assert_cmd",
  "base64",
- "bincode",
  "chrono",
  "clap",
  "ctor",
@@ -123,6 +122,7 @@ dependencies = [
  "oas3",
  "once_cell",
  "openapiv3",
+ "postcard",
  "predicates",
  "regex",
  "reqwest",
@@ -208,15 +208,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -352,6 +343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -560,6 +560,18 @@ name = "dyn-clone"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "equivalent"
@@ -1486,6 +1498,18 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ path = "src/main.rs"
 [dependencies]
 ahash = { version = "0.8.12", optional = true }
 anyhow = "1.0.100"
-bincode = "1.3.3"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5.54", features = ["derive"] }
 jaq-core = { version = "2.2.1", optional = true }
@@ -68,6 +67,7 @@ toml_edit = "0.24"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt", "json"] }
 urlencoding = "2.1.3"
+postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/deny.toml
+++ b/deny.toml
@@ -3,8 +3,8 @@
 
 [advisories]
 ignore = [
-    "RUSTSEC-2025-0141", # bincode unmaintained — no safe upgrade, transitive dep
-    "RUSTSEC-2024-0370", # proc-macro-error unmaintained — transitive via tabled_derive
+
+
 ]
 
 [licenses]

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -1160,7 +1160,7 @@ impl<F: FileSystem> ConfigManager<F> {
         self.fs.atomic_write(spec_path, content.as_bytes())?;
 
         // Serialize and write cached representation atomically
-        let cached_data = bincode::serialize(cached_spec)
+        let cached_data = postcard::to_allocvec(cached_spec)
             .map_err(|e| Error::serialization_error(e.to_string()))?;
         self.fs.atomic_write(cache_path, &cached_data)?;
 

--- a/src/engine/loader.rs
+++ b/src/engine/loader.rs
@@ -134,7 +134,7 @@ fn load_cached_spec_without_version_check<P: AsRef<Path>>(
 
     let cache_data = fs::read(&cache_path)
         .map_err(|e| Error::io_error(format!("Failed to read cache file: {e}")))?;
-    bincode::deserialize(&cache_data)
+    postcard::from_bytes(&cache_data)
         .map_err(|e| Error::cached_spec_corrupted(spec_name, e.to_string()))
 }
 
@@ -153,7 +153,7 @@ fn load_cached_spec_with_version_check<P: AsRef<Path>>(
 
     let cache_data = fs::read(&cache_path)
         .map_err(|e| Error::io_error(format!("Failed to read cache file: {e}")))?;
-    let cached_spec: CachedSpec = bincode::deserialize(&cache_data)
+    let cached_spec: CachedSpec = postcard::from_bytes(&cache_data)
         .map_err(|e| Error::cached_spec_corrupted(spec_name, e.to_string()))?;
 
     // Check cache format version

--- a/tests/config_manager_tests.rs
+++ b/tests/config_manager_tests.rs
@@ -812,9 +812,9 @@ paths:
     let cache_data = cache_content.unwrap();
     assert!(!cache_data.is_empty());
 
-    // Verify it's valid bincode by attempting to deserialize
+    // Verify it's valid postcard by attempting to deserialize
     let cached_spec: Result<aperture_cli::cache::models::CachedSpec, _> =
-        bincode::deserialize(&cache_data);
+        postcard::from_bytes(&cache_data);
     assert!(cached_spec.is_ok());
 
     let spec = cached_spec.unwrap();
@@ -867,7 +867,7 @@ paths:
 
     let cache_data = fs.files.lock().unwrap().get(&cache_path).cloned().unwrap();
     let cached_spec: aperture_cli::cache::models::CachedSpec =
-        bincode::deserialize(&cache_data).unwrap();
+        postcard::from_bytes(&cache_data).unwrap();
 
     assert_eq!(cached_spec.commands.len(), 1);
     assert_eq!(cached_spec.commands[0].name, "default"); // No tags, so default

--- a/tests/engine_loader_tests.rs
+++ b/tests/engine_loader_tests.rs
@@ -59,7 +59,7 @@ fn test_load_cached_spec_success() {
 
     // Create a test cached spec
     let test_spec = create_test_cached_spec();
-    let cache_data = bincode::serialize(&test_spec).unwrap();
+    let cache_data = postcard::to_allocvec(&test_spec).unwrap();
 
     let cache_file = cache_dir.join("test-api.bin");
     fs::write(&cache_file, cache_data).unwrap();
@@ -139,7 +139,7 @@ fn test_load_cached_spec_version_mismatch() {
     let mut test_spec = create_test_cached_spec();
     test_spec.cache_format_version = 1; // Old version (current is 2)
 
-    let cache_data = bincode::serialize(&test_spec).unwrap();
+    let cache_data = postcard::to_allocvec(&test_spec).unwrap();
     let cache_file = cache_dir.join("old-version-api.bin");
     fs::write(&cache_file, cache_data).unwrap();
 

--- a/tests/mixed_auth_scenarios_tests.rs
+++ b/tests/mixed_auth_scenarios_tests.rs
@@ -250,7 +250,7 @@ paths:
     // Load the cached spec to verify operations
     let cached_content = fs.read(&cache_path).expect("Failed to read cache");
     let cached_spec: aperture_cli::cache::models::CachedSpec =
-        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+        postcard::from_bytes(&cached_content).expect("Failed to deserialize");
 
     // Should have 3 operations (getUsers, getPublic, getMixed) - getAdmin should be skipped
     assert_eq!(
@@ -404,7 +404,7 @@ paths:
 
     let cached_content = fs.read(&cache_path).expect("Failed to read cache");
     let cached_spec: aperture_cli::cache::models::CachedSpec =
-        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+        postcard::from_bytes(&cached_content).expect("Failed to deserialize");
 
     // Should have only getPublic operation (getPrivate uses global OAuth2)
     assert_eq!(
@@ -557,7 +557,7 @@ paths:
     let cache_path = PathBuf::from("/tmp/aperture_test/.cache/global-auth.bin");
     let cached_content = fs.read(&cache_path).expect("Failed to read cache");
     let cached_spec: aperture_cli::cache::models::CachedSpec =
-        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+        postcard::from_bytes(&cached_content).expect("Failed to deserialize");
 
     // Should have 2 operations (getPublic with no auth, getAdmin with bearer override)
     assert_eq!(
@@ -653,7 +653,7 @@ paths:
     let cache_path = PathBuf::from("/tmp/aperture_test/.cache/negotiate-auth.bin");
     let cached_content = fs.read(&cache_path).expect("Failed to read cache");
     let cached_spec: aperture_cli::cache::models::CachedSpec =
-        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+        postcard::from_bytes(&cached_content).expect("Failed to deserialize");
 
     // Should have 1 operation (getDual has bearer alternative)
     assert_eq!(
@@ -718,7 +718,7 @@ paths:
     let cache_path = PathBuf::from("/tmp/aperture_test/.cache/oidc-auth.bin");
     let cached_content = fs.read(&cache_path).expect("Failed to read cache");
     let cached_spec: aperture_cli::cache::models::CachedSpec =
-        bincode::deserialize(&cached_content).expect("Failed to deserialize");
+        postcard::from_bytes(&cached_content).expect("Failed to deserialize");
 
     // Should have no operations
     assert_eq!(

--- a/tests/parameter_reference_integration_tests.rs
+++ b/tests/parameter_reference_integration_tests.rs
@@ -182,7 +182,7 @@ paths:
     // Load and verify the cached spec
     let cached_content = std::fs::read(&cache_file).unwrap();
     let cached_spec: aperture_cli::cache::models::CachedSpec =
-        bincode::deserialize(&cached_content).unwrap();
+        postcard::from_bytes(&cached_content).unwrap();
 
     // Verify commands were created with resolved parameters
     assert_eq!(cached_spec.commands.len(), 2);
@@ -303,7 +303,7 @@ paths:
     // Load and verify the cached spec
     let cached_content = std::fs::read(&cache_file).unwrap();
     let cached_spec: aperture_cli::cache::models::CachedSpec =
-        bincode::deserialize(&cached_content).unwrap();
+        postcard::from_bytes(&cached_content).unwrap();
 
     // Verify command was created with all special parameters
     assert_eq!(cached_spec.commands.len(), 1);


### PR DESCRIPTION
## Problem

`bincode` is unmaintained ([RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141)) and v3.0.0 is a non-functional protest publish (`compile_error!("https://xkcd.com/2347/")`).

## Fix

Replace with [postcard](https://crates.io/crates/postcard), an actively maintained serde-compatible binary serializer:

- `bincode::serialize()` → `postcard::to_allocvec()`
- `bincode::deserialize()` → `postcard::from_bytes()`

Only the `alloc` feature is enabled (no `heapless`, avoids the unmaintained `atomic-polyfill` transitive dep).

Also removes two stale `cargo-deny` advisory ignores:
- `RUSTSEC-2025-0141` (bincode — no longer in tree)
- `RUSTSEC-2024-0370` (proc-macro-error — dropped by tabled 0.20)

## Validation

- `cargo test --lib --no-default-features` — 187 passed
- `cargo test --features integration` — all passed
- `cargo clippy --all-targets --features integration -- -D warnings` — clean
- `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- `cargo fmt --check` — clean

## Note

Existing caches will need to be rebuilt (`aperture config refresh`) since the binary format changes. This is already handled by the cache version check in the loader.