### PR TITLE
fix(deps): bump aws-lc-sys to 0.39.0 and rustls-webpki to 0.103.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,9 +183,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -1828,9 +1828,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Resolves the Security Audit CI failure introduced after the merge of #125. Six new RUSTSEC advisories were published against two transitive dependencies.

## Advisories resolved

### `aws-lc-sys` (0.36.0 → 0.39.0, via aws-lc-rs 1.15.3 → 1.16.2)

| Advisory | Title |
|---|---|
| RUSTSEC-2026-0044 | X.509 Name Constraints Bypass via Wildcard/Unicode CN |
| RUSTSEC-2026-0045 | Timing Side-Channel in AES-CCM Tag Verification |
| RUSTSEC-2026-0046 | PKCS7_verify Certificate Chain Validation Bypass |
| RUSTSEC-2026-0047 | PKCS7_verify Signature Validation Bypass |
| RUSTSEC-2026-0048 | CRL Distribution Point Scope Check Logic Error |

### `rustls-webpki` (0.103.9 → 0.103.10)

| Advisory | Title |
|---|---|
| RUSTSEC-2026-0049 | CRLs not considered authoritative by Distribution Point (faulty matching logic) |

## Changes

Only `Cargo.lock` is modified — no `Cargo.toml` changes required, as both bumps fall within existing semver constraints.