### PR TITLE
refactor: simplify config and api dispatch

### DIFF
--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -64,8 +64,13 @@ fn resolve_output_format(
     }
 }
 
-#[allow(clippy::too_many_lines)]
-pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) -> Result<(), Error> {
+struct ApiCommandContext {
+    config_dir: PathBuf,
+    spec: CachedSpec,
+    global_config: Option<GlobalConfig>,
+}
+
+fn load_api_command_context(context: &str) -> Result<ApiCommandContext, Error> {
     let config_dir = if let Ok(dir) = std::env::var(constants::ENV_APERTURE_CONFIG_DIR) {
         PathBuf::from(dir)
     } else {
@@ -81,72 +86,91 @@ pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) ->
         _ => e,
     })?;
 
-    // Handle --describe-json flag
-    if cli.describe_json {
-        let specs_dir = config_dir.join(constants::DIR_SPECS);
-        let spec_path = specs_dir.join(format!("{context}.yaml"));
-        // ast-grep-ignore: no-nested-if
-        if !spec_path.exists() {
-            return Err(Error::spec_not_found(context));
-        }
-        let spec_content = std::fs::read_to_string(&spec_path)?;
-        let openapi_spec = crate::spec::parse_openapi(&spec_content)
-            .map_err(|e| Error::invalid_config(format!("Failed to parse OpenAPI spec: {e}")))?;
-        let manifest = crate::agent::generate_capability_manifest_from_openapi(
-            context,
-            &openapi_spec,
-            &spec,
-            global_config.as_ref(),
-        )?;
-        let output = match &cli.jq {
-            Some(jq_filter) => executor::apply_jq_filter(&manifest, jq_filter)?,
-            None => manifest,
-        };
-        // ast-grep-ignore: no-println
-        println!("{output}");
-        return Ok(());
+    Ok(ApiCommandContext {
+        config_dir,
+        spec,
+        global_config,
+    })
+}
+
+fn handle_describe_json_command(
+    context: &str,
+    command_context: &ApiCommandContext,
+    cli: &Cli,
+) -> Result<(), Error> {
+    let specs_dir = command_context.config_dir.join(constants::DIR_SPECS);
+    let spec_path = specs_dir.join(format!("{context}.yaml"));
+    // ast-grep-ignore: no-nested-if
+    if !spec_path.exists() {
+        return Err(Error::spec_not_found(context));
     }
+    let spec_content = std::fs::read_to_string(&spec_path)?;
+    let openapi_spec = crate::spec::parse_openapi(&spec_content)
+        .map_err(|e| Error::invalid_config(format!("Failed to parse OpenAPI spec: {e}")))?;
+    let manifest = crate::agent::generate_capability_manifest_from_openapi(
+        context,
+        &openapi_spec,
+        &command_context.spec,
+        command_context.global_config.as_ref(),
+    )?;
+    let output = match &cli.jq {
+        Some(jq_filter) => executor::apply_jq_filter(&manifest, jq_filter)?,
+        None => manifest,
+    };
+    // ast-grep-ignore: no-println
+    println!("{output}");
+    Ok(())
+}
 
-    // Handle --batch-file flag
-    if let Some(batch_file_path) = &cli.batch_file {
-        return execute_batch_operations(
-            context,
-            batch_file_path,
-            &spec,
-            global_config.as_ref(),
-            cli,
-        )
-        .await;
-    }
+async fn handle_batch_file_command(
+    context: &str,
+    batch_file_path: &str,
+    command_context: &ApiCommandContext,
+    cli: &Cli,
+) -> Result<(), Error> {
+    execute_batch_operations(
+        context,
+        batch_file_path,
+        &command_context.spec,
+        command_context.global_config.as_ref(),
+        cli,
+    )
+    .await
+}
 
-    // Generate the dynamic command tree and parse arguments
-    let command = generator::generate_command_tree_with_flags(&spec, cli.positional_args);
-    let matches = command
-        .try_get_matches_from(std::iter::once(constants::CLI_ROOT_COMMAND.to_string()).chain(args))
-        .map_err(|e| Error::invalid_command(context, e.to_string()))?;
+fn handle_show_examples_command(
+    context: &str,
+    matches: &clap::ArgMatches,
+    command_context: &ApiCommandContext,
+) -> Result<(), Error> {
+    let operation_id =
+        crate::cli::translate::matches_to_operation_id(&command_context.spec, matches)?;
+    let operation = command_context
+        .spec
+        .commands
+        .iter()
+        .find(|cmd| cmd.operation_id == operation_id)
+        .ok_or_else(|| Error::spec_not_found(context))?;
+    crate::cli::render::render_examples(operation);
+    Ok(())
+}
 
-    // Check --show-examples flag
-    if crate::cli::translate::has_show_examples_flag(&matches) {
-        let operation_id = crate::cli::translate::matches_to_operation_id(&spec, &matches)?;
-        let operation = spec
-            .commands
-            .iter()
-            .find(|cmd| cmd.operation_id == operation_id)
-            .ok_or_else(|| Error::spec_not_found(context))?;
-        crate::cli::render::render_examples(operation);
-        return Ok(());
-    }
-
+async fn execute_api_runtime(
+    spec: &CachedSpec,
+    matches: &clap::ArgMatches,
+    cli: &Cli,
+    global_config: Option<GlobalConfig>,
+) -> Result<(), Error> {
     let jq_filter = matches
         .get_one::<String>("jq")
         .map(String::as_str)
         .or(cli.jq.as_deref());
-    let output_format = resolve_output_format(&matches, &cli.format);
+    let output_format = resolve_output_format(matches, &cli.format);
 
     // Translate ArgMatches → domain types
-    let call = crate::cli::translate::matches_to_operation_call(&spec, &matches)?;
+    let call = crate::cli::translate::matches_to_operation_call(spec, matches)?;
     let mut ctx = crate::cli::translate::cli_to_execution_context(cli, global_config)?;
-    ctx.server_var_args = crate::cli::translate::extract_server_var_args(&matches);
+    ctx.server_var_args = crate::cli::translate::extract_server_var_args(matches);
 
     if ctx.auto_paginate && jq_filter.is_some() {
         tracing::warn!(
@@ -158,10 +182,9 @@ pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) ->
         tracing::warn!("--format is ignored with --auto-paginate; output is always NDJSON");
     }
 
-    // Route to pagination loop when --auto-paginate is set
     if ctx.auto_paginate {
         let mut stdout = std::io::stdout();
-        let result = crate::pagination::execute_paginated(&spec, call, ctx, &mut stdout).await;
+        let result = crate::pagination::execute_paginated(spec, call, ctx, &mut stdout).await;
         return match result {
             Ok(_) => Ok(()),
             Err(e) => {
@@ -175,13 +198,46 @@ pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) ->
         };
     }
 
-    // Single-page execute
-    let result = executor::execute(&spec, call, ctx)
+    let result = executor::execute(spec, call, ctx)
         .await
         .map_err(enrich_network_error)?;
 
     crate::cli::render::render_result(&result, &output_format, jq_filter)?;
     Ok(())
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) -> Result<(), Error> {
+    let command_context = load_api_command_context(context)?;
+
+    if cli.describe_json {
+        return handle_describe_json_command(context, &command_context, cli);
+    }
+
+    if let Some(batch_file_path) = &cli.batch_file {
+        return handle_batch_file_command(context, batch_file_path, &command_context, cli).await;
+    }
+
+    // Generate the dynamic command tree and parse arguments
+    let command =
+        generator::generate_command_tree_with_flags(&command_context.spec, cli.positional_args);
+    let matches = command
+        .try_get_matches_from(std::iter::once(constants::CLI_ROOT_COMMAND.to_string()).chain(args))
+        .map_err(|e| Error::invalid_command(context, e.to_string()))?;
+
+    // Check --show-examples flag
+    if crate::cli::translate::has_show_examples_flag(&matches) {
+        handle_show_examples_command(context, &matches, &command_context)?;
+        return Ok(());
+    }
+
+    execute_api_runtime(
+        &command_context.spec,
+        &matches,
+        cli,
+        command_context.global_config.clone(),
+    )
+    .await
 }
 
 /// Executes batch operations from a batch file

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -15,6 +15,353 @@ pub fn validate_api_name(name: &str) -> Result<ApiContextName, Error> {
     ApiContextName::new(name)
 }
 
+#[allow(clippy::needless_pass_by_value)]
+async fn handle_add_spec_command(
+    manager: &ConfigManager<OsFileSystem>,
+    name: String,
+    file_or_url: String,
+    force: bool,
+    strict: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    let name = validate_api_name(&name)?;
+    manager
+        .add_spec_auto(&name, &file_or_url, force, strict)
+        .await?;
+    output.success(format!("Spec '{name}' added successfully."));
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_remove_spec_command(
+    manager: &ConfigManager<OsFileSystem>,
+    name: String,
+    output: &Output,
+) -> Result<(), Error> {
+    let name = validate_api_name(&name)?;
+    manager.remove_spec(&name)?;
+    output.success(format!("Spec '{name}' removed successfully."));
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_edit_spec_command(
+    manager: &ConfigManager<OsFileSystem>,
+    name: String,
+    output: &Output,
+) -> Result<(), Error> {
+    let name = validate_api_name(&name)?;
+    manager.edit_spec(&name)?;
+    output.success(format!("Opened spec '{name}' in editor."));
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_get_url_command(
+    manager: &ConfigManager<OsFileSystem>,
+    name: String,
+    output: &Output,
+) -> Result<(), Error> {
+    let name = validate_api_name(&name)?;
+    let (base_override, env_urls, resolved) = manager.get_url(&name)?;
+    print_url_configuration(
+        &name,
+        base_override.as_deref(),
+        &env_urls,
+        &resolved,
+        output,
+    );
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_remove_secret_command(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: String,
+    scheme_name: String,
+    output: &Output,
+) -> Result<(), Error> {
+    let api_name = validate_api_name(&api_name)?;
+    manager.remove_secret(&api_name, &scheme_name)?;
+    output.success(format!(
+        "Removed secret configuration for scheme '{scheme_name}' from API '{api_name}'"
+    ));
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_set_setting_command(
+    manager: &ConfigManager<OsFileSystem>,
+    key: String,
+    value: String,
+    output: &Output,
+) -> Result<(), Error> {
+    use crate::config::settings::{SettingKey, SettingValue};
+
+    let setting_key: SettingKey = key.parse()?;
+    let setting_value = SettingValue::parse_for_key(setting_key, &value)?;
+    manager.set_setting(&setting_key, &setting_value)?;
+    output.success(format!("Set {key} = {value}"));
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+fn handle_set_mapping_command(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: String,
+    group: Option<Vec<String>>,
+    operation: Option<String>,
+    name: Option<String>,
+    op_group: Option<String>,
+    alias: Option<String>,
+    remove_alias: Option<String>,
+    hidden: bool,
+    visible: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    let api_name = validate_api_name(&api_name)?;
+    handle_set_mapping(
+        manager,
+        &api_name,
+        group.as_deref(),
+        operation.as_deref(),
+        name.as_deref(),
+        op_group.as_deref(),
+        alias.as_deref(),
+        remove_alias.as_deref(),
+        hidden,
+        visible,
+        output,
+    )
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_list_mappings_command(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: String,
+    output: &Output,
+) -> Result<(), Error> {
+    let api_name = validate_api_name(&api_name)?;
+    handle_list_mappings(manager, &api_name, output)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_remove_mapping_command(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: String,
+    group: Option<String>,
+    operation: Option<String>,
+    output: &Output,
+) -> Result<(), Error> {
+    let api_name = validate_api_name(&api_name)?;
+    handle_remove_mapping(manager, &api_name, group, operation, output)
+}
+
+fn handle_list_specs(
+    manager: &ConfigManager<OsFileSystem>,
+    verbose: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    let specs = manager.list_specs()?;
+    if specs.is_empty() {
+        output.info("No API specifications found.");
+    } else {
+        output.info("Registered API specifications:");
+        list_specs_with_details(manager, specs, verbose, output);
+    }
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_set_url(
+    manager: &ConfigManager<OsFileSystem>,
+    name: String,
+    url: String,
+    env: Option<String>,
+    output: &Output,
+) -> Result<(), Error> {
+    let name = validate_api_name(&name)?;
+    manager.set_url(&name, &url, env.as_deref())?;
+    if let Some(environment) = env {
+        output.success(format!(
+            "Set base URL for '{name}' in environment '{environment}': {url}"
+        ));
+    } else {
+        output.success(format!("Set base URL for '{name}': {url}"));
+    }
+    Ok(())
+}
+
+fn handle_list_urls(manager: &ConfigManager<OsFileSystem>, output: &Output) -> Result<(), Error> {
+    let all_urls = manager.list_urls()?;
+    if all_urls.is_empty() {
+        output.info("No base URLs configured.");
+        return Ok(());
+    }
+    output.info("Configured base URLs:");
+    for (api_name, (base_override, env_urls)) in all_urls {
+        print_api_url_entry(&api_name, base_override.as_deref(), &env_urls, output);
+    }
+    Ok(())
+}
+
+fn handle_reinit(
+    manager: &ConfigManager<OsFileSystem>,
+    context: Option<String>,
+    all: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    if all {
+        reinit_all_specs(manager, output)?;
+        return Ok(());
+    }
+    let Some(spec_name) = context else {
+        // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
+        // ast-grep-ignore: no-println
+        eprintln!("Error: Either specify a spec name or use --all flag");
+        std::process::exit(1);
+    };
+    let spec_name = validate_api_name(&spec_name)?;
+    reinit_spec(manager, &spec_name, output)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+async fn handle_clear_cache(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: Option<String>,
+    all: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    if let Some(ref name) = api_name {
+        validate_api_name(name)?;
+    }
+    clear_response_cache(manager, api_name.as_deref(), all, output).await
+}
+
+#[allow(clippy::needless_pass_by_value)]
+async fn handle_cache_stats(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: Option<String>,
+    output: &Output,
+) -> Result<(), Error> {
+    if let Some(ref name) = api_name {
+        validate_api_name(name)?;
+    }
+    show_cache_stats(manager, api_name.as_deref(), output).await
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_set_secret(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: String,
+    scheme_name: Option<String>,
+    env: Option<String>,
+    interactive: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    let api_name = validate_api_name(&api_name)?;
+    if interactive {
+        manager.set_secret_interactive(&api_name)?;
+        return Ok(());
+    }
+    let (Some(scheme), Some(env_var)) = (scheme_name, env) else {
+        return Err(Error::invalid_config(
+            "Either provide --scheme and --env, or use --interactive",
+        ));
+    };
+    manager.set_secret(&api_name, &scheme, &env_var)?;
+    output.success(format!(
+        "Set secret for scheme '{scheme}' in API '{api_name}' to use environment variable '{env_var}'"
+    ));
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_list_secrets(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: String,
+    output: &Output,
+) -> Result<(), Error> {
+    let api_name = validate_api_name(&api_name)?;
+    let secrets = manager.list_secrets(&api_name)?;
+    if secrets.is_empty() {
+        output.info(format!("No secrets configured for API '{api_name}'"));
+    } else {
+        print_secrets_list(&api_name, secrets, output);
+    }
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_clear_secrets(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: String,
+    force: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    let api_name = validate_api_name(&api_name)?;
+    let secrets = manager.list_secrets(&api_name)?;
+    if secrets.is_empty() {
+        output.info(format!("No secrets configured for API '{api_name}'"));
+        return Ok(());
+    }
+    if force {
+        manager.clear_secrets(&api_name)?;
+        output.success(format!(
+            "Cleared all secret configurations for API '{api_name}'"
+        ));
+        return Ok(());
+    }
+    output.info(format!(
+        "This will remove all {} secret configuration(s) for API '{api_name}':",
+        secrets.len()
+    ));
+    for scheme_name in secrets.keys() {
+        output.info(format!("  - {scheme_name}"));
+    }
+    if !crate::interactive::confirm("Are you sure you want to continue?")? {
+        output.info("Operation cancelled");
+        return Ok(());
+    }
+    manager.clear_secrets(&api_name)?;
+    output.success(format!(
+        "Cleared all secret configurations for API '{api_name}'"
+    ));
+    Ok(())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn handle_get_setting(
+    manager: &ConfigManager<OsFileSystem>,
+    key: String,
+    json: bool,
+) -> Result<(), Error> {
+    use crate::config::settings::SettingKey;
+
+    let setting_key: SettingKey = key.parse()?;
+    let value = manager.get_setting(&setting_key)?;
+    if json {
+        // ast-grep-ignore: no-println
+        println!(
+            "{}",
+            serde_json::json!({ "key": key, "value": value.to_string() })
+        );
+    } else {
+        // ast-grep-ignore: no-println
+        println!("{value}");
+    }
+    Ok(())
+}
+
+fn handle_settings(
+    manager: &ConfigManager<OsFileSystem>,
+    json: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    let settings = manager.list_settings()?;
+    print_settings_list(settings, json, output)
+}
+
 /// Execute `aperture config <subcommand>`.
 #[allow(clippy::too_many_lines)]
 pub async fn execute_config_command(
@@ -28,187 +375,51 @@ pub async fn execute_config_command(
             file_or_url,
             force,
             strict,
-        } => {
-            let name = validate_api_name(&name)?;
-            manager
-                .add_spec_auto(&name, &file_or_url, force, strict)
-                .await?;
-            output.success(format!("Spec '{name}' added successfully."));
-        }
-        crate::cli::ConfigCommands::List { verbose } => {
-            let specs = manager.list_specs()?;
-            if specs.is_empty() {
-                output.info("No API specifications found.");
-            } else {
-                output.info("Registered API specifications:");
-                list_specs_with_details(manager, specs, verbose, output);
-            }
-        }
+        } => handle_add_spec_command(manager, name, file_or_url, force, strict, output).await,
+        crate::cli::ConfigCommands::List { verbose } => handle_list_specs(manager, verbose, output),
         crate::cli::ConfigCommands::Remove { name } => {
-            let name = validate_api_name(&name)?;
-            manager.remove_spec(&name)?;
-            output.success(format!("Spec '{name}' removed successfully."));
+            handle_remove_spec_command(manager, name, output)
         }
         crate::cli::ConfigCommands::Edit { name } => {
-            let name = validate_api_name(&name)?;
-            manager.edit_spec(&name)?;
-            output.success(format!("Opened spec '{name}' in editor."));
+            handle_edit_spec_command(manager, name, output)
         }
         crate::cli::ConfigCommands::SetUrl { name, url, env } => {
-            let name = validate_api_name(&name)?;
-            manager.set_url(&name, &url, env.as_deref())?;
-            if let Some(environment) = env {
-                output.success(format!(
-                    "Set base URL for '{name}' in environment '{environment}': {url}"
-                ));
-            } else {
-                output.success(format!("Set base URL for '{name}': {url}"));
-            }
+            handle_set_url(manager, name, url, env, output)
         }
         crate::cli::ConfigCommands::GetUrl { name } => {
-            let name = validate_api_name(&name)?;
-            let (base_override, env_urls, resolved) = manager.get_url(&name)?;
-            print_url_configuration(
-                &name,
-                base_override.as_deref(),
-                &env_urls,
-                &resolved,
-                output,
-            );
+            handle_get_url_command(manager, name, output)
         }
-        crate::cli::ConfigCommands::ListUrls {} => {
-            let all_urls = manager.list_urls()?;
-            if all_urls.is_empty() {
-                output.info("No base URLs configured.");
-                return Ok(());
-            }
-            output.info("Configured base URLs:");
-            for (api_name, (base_override, env_urls)) in all_urls {
-                print_api_url_entry(&api_name, base_override.as_deref(), &env_urls, output);
-            }
-        }
+        crate::cli::ConfigCommands::ListUrls {} => handle_list_urls(manager, output),
         crate::cli::ConfigCommands::Reinit { context, all } => {
-            if all {
-                reinit_all_specs(manager, output)?;
-                return Ok(());
-            }
-            let Some(spec_name) = context else {
-                // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
-                // ast-grep-ignore: no-println
-                eprintln!("Error: Either specify a spec name or use --all flag");
-                std::process::exit(1);
-            };
-            let spec_name = validate_api_name(&spec_name)?;
-            reinit_spec(manager, &spec_name, output)?;
+            handle_reinit(manager, context, all, output)
         }
         crate::cli::ConfigCommands::ClearCache { api_name, all } => {
-            if let Some(ref name) = api_name {
-                validate_api_name(name)?;
-            }
-            clear_response_cache(manager, api_name.as_deref(), all, output).await?;
+            handle_clear_cache(manager, api_name, all, output).await
         }
         crate::cli::ConfigCommands::CacheStats { api_name } => {
-            if let Some(ref name) = api_name {
-                validate_api_name(name)?;
-            }
-            show_cache_stats(manager, api_name.as_deref(), output).await?;
+            handle_cache_stats(manager, api_name, output).await
         }
         crate::cli::ConfigCommands::SetSecret {
             api_name,
             scheme_name,
             env,
             interactive,
-        } => {
-            let api_name = validate_api_name(&api_name)?;
-            if interactive {
-                manager.set_secret_interactive(&api_name)?;
-                return Ok(());
-            }
-            let (Some(scheme), Some(env_var)) = (scheme_name, env) else {
-                return Err(Error::invalid_config(
-                    "Either provide --scheme and --env, or use --interactive",
-                ));
-            };
-            manager.set_secret(&api_name, &scheme, &env_var)?;
-            output.success(format!(
-                "Set secret for scheme '{scheme}' in API '{api_name}' to use environment variable '{env_var}'"
-            ));
-        }
+        } => handle_set_secret(manager, api_name, scheme_name, env, interactive, output),
         crate::cli::ConfigCommands::ListSecrets { api_name } => {
-            let api_name = validate_api_name(&api_name)?;
-            let secrets = manager.list_secrets(&api_name)?;
-            if secrets.is_empty() {
-                output.info(format!("No secrets configured for API '{api_name}'"));
-            } else {
-                print_secrets_list(&api_name, secrets, output);
-            }
+            handle_list_secrets(manager, api_name, output)
         }
         crate::cli::ConfigCommands::RemoveSecret {
             api_name,
             scheme_name,
-        } => {
-            let api_name = validate_api_name(&api_name)?;
-            manager.remove_secret(&api_name, &scheme_name)?;
-            output.success(format!(
-                "Removed secret configuration for scheme '{scheme_name}' from API '{api_name}'"
-            ));
-        }
+        } => handle_remove_secret_command(manager, api_name, scheme_name, output),
         crate::cli::ConfigCommands::ClearSecrets { api_name, force } => {
-            let api_name = validate_api_name(&api_name)?;
-            let secrets = manager.list_secrets(&api_name)?;
-            if secrets.is_empty() {
-                output.info(format!("No secrets configured for API '{api_name}'"));
-                return Ok(());
-            }
-            if force {
-                manager.clear_secrets(&api_name)?;
-                output.success(format!(
-                    "Cleared all secret configurations for API '{api_name}'"
-                ));
-                return Ok(());
-            }
-            output.info(format!(
-                "This will remove all {} secret configuration(s) for API '{api_name}':",
-                secrets.len()
-            ));
-            for scheme_name in secrets.keys() {
-                output.info(format!("  - {scheme_name}"));
-            }
-            if !crate::interactive::confirm("Are you sure you want to continue?")? {
-                output.info("Operation cancelled");
-                return Ok(());
-            }
-            manager.clear_secrets(&api_name)?;
-            output.success(format!(
-                "Cleared all secret configurations for API '{api_name}'"
-            ));
+            handle_clear_secrets(manager, api_name, force, output)
         }
         crate::cli::ConfigCommands::Set { key, value } => {
-            use crate::config::settings::{SettingKey, SettingValue};
-            let setting_key: SettingKey = key.parse()?;
-            let setting_value = SettingValue::parse_for_key(setting_key, &value)?;
-            manager.set_setting(&setting_key, &setting_value)?;
-            output.success(format!("Set {key} = {value}"));
+            handle_set_setting_command(manager, key, value, output)
         }
-        crate::cli::ConfigCommands::Get { key, json } => {
-            use crate::config::settings::SettingKey;
-            let setting_key: SettingKey = key.parse()?;
-            let value = manager.get_setting(&setting_key)?;
-            if json {
-                // ast-grep-ignore: no-println
-                println!(
-                    "{}",
-                    serde_json::json!({ "key": key, "value": value.to_string() })
-                );
-            } else {
-                // ast-grep-ignore: no-println
-                println!("{value}");
-            }
-        }
-        crate::cli::ConfigCommands::Settings { json } => {
-            let settings = manager.list_settings()?;
-            print_settings_list(settings, json, output)?;
-        }
+        crate::cli::ConfigCommands::Get { key, json } => handle_get_setting(manager, key, json),
+        crate::cli::ConfigCommands::Settings { json } => handle_settings(manager, json, output),
         crate::cli::ConfigCommands::SetMapping {
             api_name,
             group,
@@ -219,37 +430,28 @@ pub async fn execute_config_command(
             remove_alias,
             hidden,
             visible,
-        } => {
-            let api_name = validate_api_name(&api_name)?;
-            handle_set_mapping(
-                manager,
-                &api_name,
-                group.as_deref(),
-                operation.as_deref(),
-                name.as_deref(),
-                op_group.as_deref(),
-                alias.as_deref(),
-                remove_alias.as_deref(),
-                hidden,
-                visible,
-                output,
-            )?;
-        }
+        } => handle_set_mapping_command(
+            manager,
+            api_name,
+            group,
+            operation,
+            name,
+            op_group,
+            alias,
+            remove_alias,
+            hidden,
+            visible,
+            output,
+        ),
         crate::cli::ConfigCommands::ListMappings { api_name } => {
-            let api_name = validate_api_name(&api_name)?;
-            handle_list_mappings(manager, &api_name, output)?;
+            handle_list_mappings_command(manager, api_name, output)
         }
         crate::cli::ConfigCommands::RemoveMapping {
             api_name,
             group,
             operation,
-        } => {
-            let api_name = validate_api_name(&api_name)?;
-            handle_remove_mapping(manager, &api_name, group, operation, output)?;
-        }
+        } => handle_remove_mapping_command(manager, api_name, group, operation, output),
     }
-
-    Ok(())
 }
 
 /// Print the list of configured secrets for an API


### PR DESCRIPTION
## Summary
- Split `config` command handling into smaller helpers to reduce dispatcher complexity
- Split `api` command handling into context-loading, special-mode, and runtime helpers
- Kept behavior intact while reducing the largest compl hotspots

## Verification
- `cargo test --features integration --test cli_tests --test base_url_integration_tests --test config_secrets_integration_tests --test config_settings_integration_tests --test quiet_mode_tests`
- `cargo test --features integration --test integration_tests`
- `cargo test --features integration --test show_examples_execution_test`
- `compl scan . --json`
