### PR TITLE
refactor: reduce complexity violations

### DIFF
--- a/src/batch/graph.rs
+++ b/src/batch/graph.rs
@@ -205,20 +205,43 @@ fn topological_sort(
     adj: &[Vec<usize>],
 ) -> Result<ExecutionOrder, Error> {
     let n = operations.len();
-    let mut in_degree = vec![0usize; n];
+    let mut in_degree = compute_in_degree(adj, n);
+    let mut queue = seed_zero_in_degree_queue(&in_degree);
+    let order = kahn_topological_order(adj, &mut in_degree, &mut queue, n);
+
+    if order.len() == n {
+        return Ok(order);
+    }
+
+    let cycle_ids = unresolved_cycle_ids(operations, adj, &in_degree);
+    Err(Error::batch_cycle_detected(&cycle_ids))
+}
+
+fn compute_in_degree(adj: &[Vec<usize>], node_count: usize) -> Vec<usize> {
+    let mut in_degree = vec![0usize; node_count];
     for successors in adj {
         for &succ in successors {
             in_degree[succ] += 1;
         }
     }
+    in_degree
+}
 
-    // Seed queue with zero-in-degree nodes in original order
-    let mut queue: VecDeque<usize> = (0..n).filter(|&i| in_degree[i] == 0).collect();
+fn seed_zero_in_degree_queue(in_degree: &[usize]) -> VecDeque<usize> {
+    (0..in_degree.len())
+        .filter(|&i| in_degree[i] == 0)
+        .collect()
+}
 
-    let mut order = Vec::with_capacity(n);
+fn kahn_topological_order(
+    adj: &[Vec<usize>],
+    in_degree: &mut [usize],
+    queue: &mut VecDeque<usize>,
+    node_count: usize,
+) -> ExecutionOrder {
+    let mut order = Vec::with_capacity(node_count);
     while let Some(node) = queue.pop_front() {
         order.push(node);
-        // Sort successors to preserve original order among siblings
         let mut successors = adj[node].clone();
         successors.sort_unstable();
         for succ in successors {
@@ -228,30 +251,28 @@ fn topological_sort(
             }
         }
     }
+    order
+}
 
-    if order.len() != n {
-        // Build the unresolved subgraph (nodes with in-degree > 0 after Kahn).
-        // This includes cycle members and possibly downstream nodes blocked by
-        // those cycles; we then extract one concrete cycle path from that subgraph.
-        let unresolved: Vec<bool> = in_degree.iter().map(|&d| d > 0).collect();
+fn unresolved_cycle_ids(
+    operations: &[BatchOperation],
+    adj: &[Vec<usize>],
+    in_degree: &[usize],
+) -> Vec<String> {
+    let unresolved: Vec<bool> = in_degree.iter().map(|&d| d > 0).collect();
 
-        let cycle_indices = find_cycle_path(adj, &unresolved)
-            .unwrap_or_else(|| (0..n).filter(|&i| unresolved[i]).collect());
+    let cycle_indices = find_cycle_path(adj, &unresolved)
+        .unwrap_or_else(|| (0..operations.len()).filter(|&i| unresolved[i]).collect());
 
-        let cycle_ids: Vec<String> = cycle_indices
-            .into_iter()
-            .map(|i| {
-                operations[i]
-                    .id
-                    .clone()
-                    .unwrap_or_else(|| format!("index {i}"))
-            })
-            .collect();
-
-        return Err(Error::batch_cycle_detected(&cycle_ids));
-    }
-
-    Ok(order)
+    cycle_indices
+        .into_iter()
+        .map(|i| {
+            operations[i]
+                .id
+                .clone()
+                .unwrap_or_else(|| format!("index {i}"))
+        })
+        .collect()
 }
 
 /// Finds one concrete directed cycle in the unresolved subgraph.

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -502,17 +502,75 @@ impl BatchProcessor {
     ) -> Result<BatchResult, Error> {
         let start_time = std::time::Instant::now();
         let total_operations = batch_file.operations.len();
+        Self::log_batch_start(self.config.show_progress, total_operations);
 
-        if self.config.show_progress {
+        let handles = self.spawn_batch_operation_handles(
+            spec,
+            batch_file.operations,
+            global_config,
+            base_url,
+            dry_run,
+            output_format,
+            jq_filter,
+        );
+        let results = Self::collect_batch_operation_results(handles).await?;
+
+        let total_duration = start_time.elapsed();
+        let success_count = results.iter().filter(|r| r.success).count();
+        let failure_count = results.len() - success_count;
+
+        Self::log_batch_completion(
+            self.config.show_progress,
+            success_count,
+            total_operations,
+            total_duration,
+        );
+
+        Ok(BatchResult {
+            results,
+            total_duration,
+            success_count,
+            failure_count,
+        })
+    }
+
+    fn log_batch_start(show_progress: bool, total_operations: usize) {
+        if show_progress {
             // ast-grep-ignore: no-println
             println!("Starting batch execution: {total_operations} operations");
         }
+    }
 
-        let mut results = Vec::with_capacity(total_operations);
+    fn log_batch_completion(
+        show_progress: bool,
+        success_count: usize,
+        total_operations: usize,
+        total_duration: std::time::Duration,
+    ) {
+        if show_progress {
+            // ast-grep-ignore: no-println
+            println!(
+                "Batch execution completed: {}/{} operations successful in {:.2}s",
+                success_count,
+                total_operations,
+                total_duration.as_secs_f64()
+            );
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_batch_operation_handles(
+        &self,
+        spec: &CachedSpec,
+        operations: Vec<BatchOperation>,
+        global_config: Option<&GlobalConfig>,
+        base_url: Option<&str>,
+        dry_run: bool,
+        output_format: &crate::cli::OutputFormat,
+        jq_filter: Option<&str>,
+    ) -> Vec<tokio::task::JoinHandle<BatchOperationResult>> {
         let mut handles = Vec::new();
-
-        // Create tasks for each operation
-        for (index, operation) in batch_file.operations.into_iter().enumerate() {
+        for (index, operation) in operations.into_iter().enumerate() {
             let spec = spec.clone();
             let global_config = global_config.cloned();
             let base_url = base_url.map(String::from);
@@ -523,92 +581,102 @@ impl BatchProcessor {
             let show_progress = self.config.show_progress;
             let suppress_output = self.config.suppress_output;
 
-            let handle = tokio::spawn(async move {
-                // Acquire semaphore permit for concurrency control
-                let _permit = semaphore
-                    .acquire()
-                    .await
-                    .expect("semaphore should not be closed");
-
-                // Apply rate limiting if configured
-                if let Some(limiter) = rate_limiter {
-                    limiter.until_ready().await;
-                }
-
-                let operation_start = std::time::Instant::now();
-
-                // Execute the operation
-                let result = Self::execute_single_operation(
-                    &spec,
-                    &operation,
-                    global_config.as_ref(),
-                    base_url.as_deref(),
-                    dry_run,
-                    &output_format,
-                    jq_filter.as_deref(),
-                    suppress_output,
-                )
-                .await;
-
-                let duration = operation_start.elapsed();
-
-                let (success, error, response) = match result {
-                    Ok(resp) => {
-                        if show_progress {
-                            // ast-grep-ignore: no-println
-                            println!("Operation {} completed", index + 1);
-                        }
-                        (true, None, Some(resp))
-                    }
-                    Err(e) => {
-                        if show_progress {
-                            // ast-grep-ignore: no-println
-                            println!("Operation {} failed: {}", index + 1, e);
-                        }
-                        (false, Some(e.to_string()), None)
-                    }
-                };
-
-                BatchOperationResult {
+            handles.push(tokio::spawn(async move {
+                Self::execute_batch_operation_task(
+                    spec,
                     operation,
-                    success,
-                    error,
-                    response,
-                    duration,
-                }
-            });
+                    global_config,
+                    base_url,
+                    dry_run,
+                    output_format,
+                    jq_filter,
+                    semaphore,
+                    rate_limiter,
+                    show_progress,
+                    suppress_output,
+                    index,
+                )
+                .await
+            }));
+        }
+        handles
+    }
 
-            handles.push(handle);
+    #[allow(clippy::too_many_arguments)]
+    async fn execute_batch_operation_task(
+        spec: CachedSpec,
+        operation: BatchOperation,
+        global_config: Option<GlobalConfig>,
+        base_url: Option<String>,
+        dry_run: bool,
+        output_format: crate::cli::OutputFormat,
+        jq_filter: Option<String>,
+        semaphore: Arc<Semaphore>,
+        rate_limiter: Option<Arc<DefaultDirectRateLimiter>>,
+        show_progress: bool,
+        suppress_output: bool,
+        index: usize,
+    ) -> BatchOperationResult {
+        let _permit = semaphore
+            .acquire()
+            .await
+            .expect("semaphore should not be closed");
+
+        if let Some(limiter) = rate_limiter {
+            limiter.until_ready().await;
         }
 
-        // Collect all results
+        let operation_start = std::time::Instant::now();
+        let result = Self::execute_single_operation(
+            &spec,
+            &operation,
+            global_config.as_ref(),
+            base_url.as_deref(),
+            dry_run,
+            &output_format,
+            jq_filter.as_deref(),
+            suppress_output,
+        )
+        .await;
+        let duration = operation_start.elapsed();
+
+        let (success, error, response) = match result {
+            Ok(resp) => {
+                if show_progress {
+                    // ast-grep-ignore: no-println
+                    println!("Operation {} completed", index + 1);
+                }
+                (true, None, Some(resp))
+            }
+            Err(e) => {
+                if show_progress {
+                    // ast-grep-ignore: no-println
+                    println!("Operation {} failed: {}", index + 1, e);
+                }
+                (false, Some(e.to_string()), None)
+            }
+        };
+
+        BatchOperationResult {
+            operation,
+            success,
+            error,
+            response,
+            duration,
+        }
+    }
+
+    async fn collect_batch_operation_results(
+        handles: Vec<tokio::task::JoinHandle<BatchOperationResult>>,
+    ) -> Result<Vec<BatchOperationResult>, Error> {
+        let mut results = Vec::with_capacity(handles.len());
         for handle in handles {
             let result = handle
                 .await
                 .map_err(|e| Error::invalid_config(format!("Task failed: {e}")))?;
             results.push(result);
         }
-
-        let total_duration = start_time.elapsed();
-        let success_count = results.iter().filter(|r| r.success).count();
-        let failure_count = results.len() - success_count;
-
-        if self.config.show_progress {
-            // ast-grep-ignore: no-println
-            println!(
-                "Batch execution completed: {}/{} operations successful in {:.2}s",
-                success_count,
-                total_operations,
-                total_duration.as_secs_f64()
-            );
-        }
-
-        Ok(BatchResult {
-            results,
-            total_duration,
-            success_count,
-            failure_count,
-        })
+        Ok(results)
     }
 
     fn validate_batch_body_file_args(operation: &BatchOperation) -> Result<(), Error> {

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -166,38 +166,57 @@ async fn execute_api_runtime(
         .map(String::as_str)
         .or(cli.jq.as_deref());
     let output_format = resolve_output_format(matches, &cli.format);
-
-    // Translate ArgMatches → domain types
     let call = crate::cli::translate::matches_to_operation_call(spec, matches)?;
     let mut ctx = crate::cli::translate::cli_to_execution_context(cli, global_config)?;
     ctx.server_var_args = crate::cli::translate::extract_server_var_args(matches);
 
-    if ctx.auto_paginate && jq_filter.is_some() {
+    if ctx.auto_paginate {
+        return execute_paginated_api_runtime(spec, call, ctx, cli, jq_filter, output_format).await;
+    }
+
+    execute_standard_api_runtime(spec, call, ctx, output_format, jq_filter).await
+}
+
+async fn execute_paginated_api_runtime(
+    spec: &CachedSpec,
+    call: crate::invocation::OperationCall,
+    ctx: crate::invocation::ExecutionContext,
+    cli: &Cli,
+    jq_filter: Option<&str>,
+    output_format: crate::cli::OutputFormat,
+) -> Result<(), Error> {
+    if jq_filter.is_some() {
         tracing::warn!(
             "--jq is ignored with --auto-paginate; \
              pipe NDJSON output through an external jq process instead"
         );
     }
-    if ctx.auto_paginate && !matches!(output_format, crate::cli::OutputFormat::Json) {
+    if !matches!(output_format, crate::cli::OutputFormat::Json) {
         tracing::warn!("--format is ignored with --auto-paginate; output is always NDJSON");
     }
 
-    if ctx.auto_paginate {
-        let mut stdout = std::io::stdout();
-        let result = crate::pagination::execute_paginated(spec, call, ctx, &mut stdout).await;
-        return match result {
-            Ok(_) => Ok(()),
-            Err(e) => {
-                let e = enrich_network_error(e);
-                // When --json-errors is active, emit the error as the final NDJSON
-                // line on stdout so pipeline consumers can detect mid-stream failure
-                // without inspecting stderr.
-                emit_pagination_error_ndjson(cli, &mut stdout, &e);
-                Err(e)
-            }
-        };
+    let mut stdout = std::io::stdout();
+    let result = crate::pagination::execute_paginated(spec, call, ctx, &mut stdout).await;
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let e = enrich_network_error(e);
+            // When --json-errors is active, emit the error as the final NDJSON
+            // line on stdout so pipeline consumers can detect mid-stream failure
+            // without inspecting stderr.
+            emit_pagination_error_ndjson(cli, &mut stdout, &e);
+            Err(e)
+        }
     }
+}
 
+async fn execute_standard_api_runtime(
+    spec: &CachedSpec,
+    call: crate::invocation::OperationCall,
+    ctx: crate::invocation::ExecutionContext,
+    output_format: crate::cli::OutputFormat,
+    jq_filter: Option<&str>,
+) -> Result<(), Error> {
     let result = executor::execute(spec, call, ctx)
         .await
         .map_err(enrich_network_error)?;
@@ -272,41 +291,49 @@ pub async fn execute_batch_operations(
         .await?;
 
     let output = Output::new(cli.quiet, cli.json_errors);
-
     if cli.json_errors {
-        let summary = serde_json::json!({
-            "batch_execution_summary": {
-                "total_operations": result.results.len(),
-                "successful_operations": result.success_count,
-                "failed_operations": result.failure_count,
-                "total_duration_seconds": result.total_duration.as_secs_f64(),
-                "operations": result.results.iter().map(|r| serde_json::json!({
-                    "operation_id": r.operation.id,
-                    "args": r.operation.args,
-                    "success": r.success,
-                    "duration_seconds": r.duration.as_secs_f64(),
-                    "error": r.error
-                })).collect::<Vec<_>>()
-            }
-        });
-        let json_output = match &cli.jq {
-            Some(jq_filter) => {
-                let summary_json = serde_json::to_string(&summary)
-                    .expect("JSON serialization of valid structure cannot fail");
-                executor::apply_jq_filter(&summary_json, jq_filter)?
-            }
-            None => serde_json::to_string_pretty(&summary)
-                .expect("JSON serialization of valid structure cannot fail"),
-        };
-        // ast-grep-ignore: no-println
-        println!("{json_output}");
-        // ast-grep-ignore: no-nested-if
-        if result.failure_count > 0 {
-            std::process::exit(1);
-        }
+        render_batch_json_summary(&result, cli)?;
         return Ok(());
     }
 
+    render_batch_text_summary(&result, &output);
+    Ok(())
+}
+
+fn render_batch_json_summary(result: &crate::batch::BatchResult, cli: &Cli) -> Result<(), Error> {
+    let summary = serde_json::json!({
+        "batch_execution_summary": {
+            "total_operations": result.results.len(),
+            "successful_operations": result.success_count,
+            "failed_operations": result.failure_count,
+            "total_duration_seconds": result.total_duration.as_secs_f64(),
+            "operations": result.results.iter().map(|r| serde_json::json!({
+                "operation_id": r.operation.id,
+                "args": r.operation.args,
+                "success": r.success,
+                "duration_seconds": r.duration.as_secs_f64(),
+                "error": r.error
+            })).collect::<Vec<_>>()
+        }
+    });
+    let json_output = match &cli.jq {
+        Some(jq_filter) => {
+            let summary_json = serde_json::to_string(&summary)
+                .expect("JSON serialization of valid structure cannot fail");
+            executor::apply_jq_filter(&summary_json, jq_filter)?
+        }
+        None => serde_json::to_string_pretty(&summary)
+            .expect("JSON serialization of valid structure cannot fail"),
+    };
+    // ast-grep-ignore: no-println
+    println!("{json_output}");
+    if result.failure_count > 0 {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn render_batch_text_summary(result: &crate::batch::BatchResult, output: &Output) {
     output.info("\n=== Batch Execution Summary ===");
     // ast-grep-ignore: no-println
     println!("Total operations: {}", result.results.len());
@@ -318,7 +345,7 @@ pub async fn execute_batch_operations(
     println!("Total time: {:.2}s", result.total_duration.as_secs_f64());
 
     if result.failure_count == 0 {
-        return Ok(());
+        return;
     }
 
     output.info("\nFailed operations:");
@@ -335,10 +362,7 @@ pub async fn execute_batch_operations(
         );
     }
 
-    if result.failure_count > 0 {
-        std::process::exit(1);
-    }
-    Ok(())
+    std::process::exit(1);
 }
 
 /// Execute a command using shortcut resolution
@@ -350,20 +374,7 @@ pub async fn execute_shortcut_command(
     let output = Output::new(cli.quiet, cli.json_errors);
 
     if args.is_empty() {
-        // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
-        // ast-grep-ignore: no-println
-        eprintln!("Error: No command specified");
-        // ast-grep-ignore: no-println
-        eprintln!("Usage: aperture exec <shortcut> [args...]");
-        // ast-grep-ignore: no-println
-        eprintln!("Examples:");
-        // ast-grep-ignore: no-println
-        eprintln!("  aperture exec getUserById --id 123");
-        // ast-grep-ignore: no-println
-        eprintln!("  aperture exec GET /users/123");
-        // ast-grep-ignore: no-println
-        eprintln!("  aperture exec users list");
-        std::process::exit(1);
+        print_shortcut_usage();
     }
 
     let specs = manager.list_specs()?;
@@ -372,16 +383,7 @@ pub async fn execute_shortcut_command(
         return Ok(());
     }
 
-    let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
-    let mut all_specs = std::collections::BTreeMap::new();
-    for spec_name in &specs {
-        match loader::load_cached_spec(&cache_dir, spec_name) {
-            Ok(spec) => {
-                all_specs.insert(spec_name.clone(), spec);
-            }
-            Err(e) => tracing::warn!(spec = spec_name, error = %e, "could not load spec"),
-        }
-    }
+    let all_specs = load_shortcut_specs(manager, &specs);
     if all_specs.is_empty() {
         output.info("No valid API specifications found.");
         return Ok(());
@@ -389,7 +391,32 @@ pub async fn execute_shortcut_command(
 
     let mut resolver = ShortcutResolver::new();
     resolver.index_specs(&all_specs);
+    handle_shortcut_resolution(&resolver, args, cli, &output).await
+}
 
+fn load_shortcut_specs(
+    manager: &ConfigManager<OsFileSystem>,
+    specs: &[String],
+) -> std::collections::BTreeMap<String, crate::cache::models::CachedSpec> {
+    let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
+    let mut all_specs = std::collections::BTreeMap::new();
+    for spec_name in specs {
+        match loader::load_cached_spec(&cache_dir, spec_name) {
+            Ok(spec) => {
+                all_specs.insert(spec_name.clone(), spec);
+            }
+            Err(e) => tracing::warn!(spec = spec_name, error = %e, "could not load spec"),
+        }
+    }
+    all_specs
+}
+
+async fn handle_shortcut_resolution(
+    resolver: &ShortcutResolver,
+    args: Vec<String>,
+    cli: &Cli,
+    output: &Output,
+) -> Result<(), Error> {
     match resolver.resolve_shortcut(&args) {
         ResolutionResult::Resolved(shortcut) => {
             output.info(format!(
@@ -434,6 +461,23 @@ pub async fn execute_shortcut_command(
             std::process::exit(1);
         }
     }
+}
+
+fn print_shortcut_usage() -> ! {
+    // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
+    // ast-grep-ignore: no-println
+    eprintln!("Error: No command specified");
+    // ast-grep-ignore: no-println
+    eprintln!("Usage: aperture exec <shortcut> [args...]");
+    // ast-grep-ignore: no-println
+    eprintln!("Examples:");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture exec getUserById --id 123");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture exec GET /users/123");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture exec users list");
+    std::process::exit(1);
 }
 
 fn count_shortcut_args(args: &[String]) -> usize {

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -44,54 +44,77 @@ pub fn execute_help_command(
     output: &Output,
 ) -> Result<(), Error> {
     match (api_name, tag, operation) {
-        (None, None, None) => {
-            let specs = load_all_specs(manager)?;
-            let doc_gen = DocumentationGenerator::new(specs);
-            // ast-grep-ignore: no-println
-            println!("{}", doc_gen.generate_interactive_menu());
+        (None, None, None) => render_interactive_menu(manager),
+        (Some(api), None, None) => render_api_overview(manager, api),
+        (Some(api), Some(tag), Some(op)) => {
+            render_command_help(manager, api, tag, op, enhanced, output)
         }
-        (Some(api), tag_opt, operation_opt) => {
-            let specs = load_all_specs(manager)?;
-            let doc_gen = DocumentationGenerator::new(specs);
-            match (tag_opt, operation_opt) {
-                (None, None) => {
-                    let overview = doc_gen.generate_api_overview(api)?;
-                    // ast-grep-ignore: no-println
-                    println!("{overview}");
-                }
-                (Some(tag), Some(op)) => {
-                    let help = doc_gen.generate_command_help(api, tag, op)?;
-                    if enhanced {
-                        // ast-grep-ignore: no-println
-                        println!("{help}");
-                    } else {
-                        // ast-grep-ignore: no-println
-                        println!("{}", help.lines().take(20).collect::<Vec<_>>().join("\n"));
-                        output.tip("Use --enhanced for full documentation with examples");
-                    }
-                }
-                _ => {
-                    // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
-                    // ast-grep-ignore: no-println
-                    eprintln!("Invalid docs command. Usage:");
-                    // ast-grep-ignore: no-println
-                    eprintln!("  aperture docs                        # Interactive menu");
-                    // ast-grep-ignore: no-println
-                    eprintln!("  aperture docs <api>                  # API overview");
-                    // ast-grep-ignore: no-println
-                    eprintln!("  aperture docs <api> <tag> <operation> # Command help");
-                    std::process::exit(1);
-                }
-            }
+        (Some(_), _, _) => {
+            print_invalid_docs_usage();
         }
         _ => {
-            // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
-            // ast-grep-ignore: no-println
-            eprintln!("Invalid help command arguments");
-            std::process::exit(1);
+            print_invalid_help_arguments();
         }
     }
+}
+
+fn render_interactive_menu(manager: &ConfigManager<OsFileSystem>) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let doc_gen = DocumentationGenerator::new(specs);
+    // ast-grep-ignore: no-println
+    println!("{}", doc_gen.generate_interactive_menu());
     Ok(())
+}
+
+fn render_api_overview(manager: &ConfigManager<OsFileSystem>, api: &str) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let doc_gen = DocumentationGenerator::new(specs);
+    let overview = doc_gen.generate_api_overview(api)?;
+    // ast-grep-ignore: no-println
+    println!("{overview}");
+    Ok(())
+}
+
+fn render_command_help(
+    manager: &ConfigManager<OsFileSystem>,
+    api: &str,
+    tag: &str,
+    operation: &str,
+    enhanced: bool,
+    output: &Output,
+) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let doc_gen = DocumentationGenerator::new(specs);
+    let help = doc_gen.generate_command_help(api, tag, operation)?;
+    if enhanced {
+        // ast-grep-ignore: no-println
+        println!("{help}");
+    } else {
+        // ast-grep-ignore: no-println
+        println!("{}", help.lines().take(20).collect::<Vec<_>>().join("\n"));
+        output.tip("Use --enhanced for full documentation with examples");
+    }
+    Ok(())
+}
+
+fn print_invalid_docs_usage() -> ! {
+    // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
+    // ast-grep-ignore: no-println
+    eprintln!("Invalid docs command. Usage:");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture docs                        # Interactive menu");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture docs <api>                  # API overview");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture docs <api> <tag> <operation> # Command help");
+    std::process::exit(1);
+}
+
+fn print_invalid_help_arguments() -> ! {
+    // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
+    // ast-grep-ignore: no-println
+    eprintln!("Invalid help command arguments");
+    std::process::exit(1);
 }
 
 /// Execute overview command
@@ -104,25 +127,30 @@ pub fn execute_overview_command(
 ) -> Result<(), Error> {
     if !all {
         let Some(api) = api_name else {
-            // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
-            // ast-grep-ignore: no-println
-            eprintln!("Error: Must specify API name or use --all flag");
-            // ast-grep-ignore: no-println
-            eprintln!("Usage:");
-            // ast-grep-ignore: no-println
-            eprintln!("  aperture overview <api>");
-            // ast-grep-ignore: no-println
-            eprintln!("  aperture overview --all");
-            std::process::exit(1);
+            print_overview_usage();
         };
-        let specs = load_all_specs(manager)?;
-        let doc_gen = DocumentationGenerator::new(specs);
-        let overview = doc_gen.generate_api_overview(api)?;
-        // ast-grep-ignore: no-println
-        println!("{overview}");
-        return Ok(());
+        return render_single_api_overview(manager, api);
     }
 
+    render_all_api_overviews(manager, output)
+}
+
+fn render_single_api_overview(
+    manager: &ConfigManager<OsFileSystem>,
+    api: &str,
+) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let doc_gen = DocumentationGenerator::new(specs);
+    let overview = doc_gen.generate_api_overview(api)?;
+    // ast-grep-ignore: no-println
+    println!("{overview}");
+    Ok(())
+}
+
+fn render_all_api_overviews(
+    manager: &ConfigManager<OsFileSystem>,
+    output: &Output,
+) -> Result<(), Error> {
     let specs = load_all_specs(manager)?;
     if specs.is_empty() {
         output.info("No API specifications configured.");
@@ -144,14 +172,7 @@ pub fn execute_overview_command(
         let operation_count = spec.commands.len();
         // ast-grep-ignore: no-println
         println!("   Operations: {operation_count}");
-        let mut method_counts = std::collections::BTreeMap::new();
-        for command in &spec.commands {
-            *method_counts.entry(command.method.clone()).or_insert(0) += 1;
-        }
-        let method_summary: Vec<String> = method_counts
-            .iter()
-            .map(|(method, count)| format!("{method}: {count}"))
-            .collect();
+        let method_summary = summarize_methods(&spec.commands);
         // ast-grep-ignore: no-println
         println!("   Methods: {}", method_summary.join(", "));
         // ast-grep-ignore: no-println
@@ -161,6 +182,30 @@ pub fn execute_overview_command(
     println!("\n{}", "=".repeat(60));
     output.tip("Use 'aperture overview <api>' for detailed information about a specific API");
     Ok(())
+}
+
+fn summarize_methods(spec_commands: &[crate::cache::models::CachedCommand]) -> Vec<String> {
+    let mut method_counts = std::collections::BTreeMap::new();
+    for command in spec_commands {
+        *method_counts.entry(command.method.clone()).or_insert(0) += 1;
+    }
+    method_counts
+        .iter()
+        .map(|(method, count)| format!("{method}: {count}"))
+        .collect()
+}
+
+fn print_overview_usage() -> ! {
+    // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
+    // ast-grep-ignore: no-println
+    eprintln!("Error: Must specify API name or use --all flag");
+    // ast-grep-ignore: no-println
+    eprintln!("Usage:");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture overview <api>");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture overview --all");
+    std::process::exit(1);
 }
 
 /// Load all cached specs from the manager

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -21,20 +21,7 @@ pub fn execute_search_command(
         return Ok(());
     }
 
-    let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
-    let mut all_specs = std::collections::BTreeMap::new();
-    for spec_name in &specs {
-        if api_filter.is_some_and(|filter| spec_name != filter) {
-            continue;
-        }
-        match loader::load_cached_spec(&cache_dir, spec_name) {
-            Ok(spec) => {
-                all_specs.insert(spec_name.clone(), spec);
-            }
-            Err(e) => tracing::warn!(spec = spec_name, error = %e, "could not load spec"),
-        }
-    }
-
+    let all_specs = load_search_specs(manager, api_filter, &specs);
     if all_specs.is_empty() {
         match api_filter {
             Some(filter) => {
@@ -53,4 +40,28 @@ pub fn execute_search_command(
         println!("{line}");
     }
     Ok(())
+}
+
+fn load_search_specs(
+    manager: &ConfigManager<OsFileSystem>,
+    api_filter: Option<&str>,
+    specs: &[String],
+) -> std::collections::BTreeMap<String, crate::cache::models::CachedSpec> {
+    let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
+    let mut all_specs = std::collections::BTreeMap::new();
+
+    for spec_name in specs {
+        if api_filter.is_some_and(|filter| spec_name != filter) {
+            continue;
+        }
+
+        match loader::load_cached_spec(&cache_dir, spec_name) {
+            Ok(spec) => {
+                all_specs.insert(spec_name.clone(), spec);
+            }
+            Err(e) => tracing::warn!(spec = spec_name, error = %e, "could not load spec"),
+        }
+    }
+
+    all_specs
 }

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -260,86 +260,106 @@ fn output_or_capture(message: &str, capture_output: bool) -> Option<String> {
 #[allow(clippy::unnecessary_wraps, clippy::too_many_lines)]
 fn print_as_table(json_value: &Value, capture_output: bool) -> Result<Option<String>, Error> {
     match json_value {
-        Value::Array(items) => {
-            if items.is_empty() {
-                return Ok(output_or_capture(constants::EMPTY_ARRAY, capture_output));
-            }
-
-            if items.len() > MAX_TABLE_ROWS {
-                let msg = format!(
-                    "Array too large: {} items (max {} for table display)\nUse --format json or --jq to process the full data",
-                    items.len(),
-                    MAX_TABLE_ROWS
-                );
-                return Ok(output_or_capture(&msg, capture_output));
-            }
-
-            let Some(Value::Object(_)) = items.first() else {
-                return Ok(print_numbered_list(items, capture_output));
-            };
-
-            let mut table_data: Vec<BTreeMap<String, String>> = Vec::new();
-
-            for item in items {
-                let Value::Object(obj) = item else {
-                    continue;
-                };
-                let mut row = BTreeMap::new();
-                for (key, value) in obj {
-                    row.insert(key.clone(), format_value_for_table(value));
-                }
-                table_data.push(row);
-            }
-
-            if table_data.is_empty() {
-                return Ok(print_numbered_list(items, capture_output));
-            }
-
-            let mut rows = Vec::new();
-            for (i, row) in table_data.iter().enumerate() {
-                if i > 0 {
-                    rows.push(TableRow {
-                        key: "---".to_string(),
-                        value: "---".to_string(),
-                    });
-                }
-                for (key, value) in row {
-                    rows.push(TableRow {
-                        key: key.clone(),
-                        value: value.clone(),
-                    });
-                }
-            }
-
-            let table = Table::new(&rows);
-            Ok(output_or_capture(&table.to_string(), capture_output))
-        }
-        Value::Object(obj) => {
-            if obj.len() > MAX_TABLE_ROWS {
-                let msg = format!(
-                    "Object too large: {} fields (max {} for table display)\nUse --format json or --jq to process the full data",
-                    obj.len(),
-                    MAX_TABLE_ROWS
-                );
-                return Ok(output_or_capture(&msg, capture_output));
-            }
-
-            let rows: Vec<KeyValue> = obj
-                .iter()
-                .map(|(key, value)| KeyValue {
-                    key: key.clone(),
-                    value: format_value_for_table(value),
-                })
-                .collect();
-
-            let table = Table::new(&rows);
-            Ok(output_or_capture(&table.to_string(), capture_output))
-        }
+        Value::Array(items) => Ok(render_array_as_table(items, capture_output)),
+        Value::Object(obj) => Ok(render_object_as_table(obj, capture_output)),
         _ => {
             let formatted = format_value_for_table(json_value);
             Ok(output_or_capture(&formatted, capture_output))
         }
     }
+}
+
+fn render_array_as_table(items: &[Value], capture_output: bool) -> Option<String> {
+    if items.is_empty() {
+        return output_or_capture(constants::EMPTY_ARRAY, capture_output);
+    }
+
+    if items.len() > MAX_TABLE_ROWS {
+        return output_or_capture(
+            &format_large_collection_message("Array", items.len()),
+            capture_output,
+        );
+    }
+
+    let Some(Value::Object(_)) = items.first() else {
+        return print_numbered_list(items, capture_output);
+    };
+
+    let table_data = collect_table_data(items);
+    if table_data.is_empty() {
+        return print_numbered_list(items, capture_output);
+    }
+
+    let rows = build_table_rows(&table_data);
+    let table = Table::new(&rows);
+    output_or_capture(&table.to_string(), capture_output)
+}
+
+fn render_object_as_table(
+    obj: &serde_json::Map<String, Value>,
+    capture_output: bool,
+) -> Option<String> {
+    if obj.len() > MAX_TABLE_ROWS {
+        return output_or_capture(
+            &format_large_collection_message("Object", obj.len()),
+            capture_output,
+        );
+    }
+
+    let rows: Vec<KeyValue> = obj
+        .iter()
+        .map(|(key, value)| KeyValue {
+            key: key.clone(),
+            value: format_value_for_table(value),
+        })
+        .collect();
+
+    let table = Table::new(&rows);
+    output_or_capture(&table.to_string(), capture_output)
+}
+
+fn collect_table_data(items: &[Value]) -> Vec<BTreeMap<String, String>> {
+    let mut table_data: Vec<BTreeMap<String, String>> = Vec::new();
+
+    for item in items {
+        let Value::Object(obj) = item else {
+            continue;
+        };
+        let mut row = BTreeMap::new();
+        for (key, value) in obj {
+            row.insert(key.clone(), format_value_for_table(value));
+        }
+        table_data.push(row);
+    }
+
+    table_data
+}
+
+fn build_table_rows(table_data: &[BTreeMap<String, String>]) -> Vec<TableRow> {
+    let mut rows = Vec::new();
+    for (i, row) in table_data.iter().enumerate() {
+        if i > 0 {
+            rows.push(TableRow {
+                key: "---".to_string(),
+                value: "---".to_string(),
+            });
+        }
+        for (key, value) in row {
+            rows.push(TableRow {
+                key: key.clone(),
+                value: value.clone(),
+            });
+        }
+    }
+    rows
+}
+
+fn format_large_collection_message(kind: &str, size: usize) -> String {
+    format!(
+        "{kind} too large: {size} {} (max {} for table display)\nUse --format json or --jq to process the full data",
+        if kind == "Array" { "items" } else { "fields" },
+        MAX_TABLE_ROWS
+    )
 }
 
 /// Formats a JSON value for display in a table cell.

--- a/src/cli/translate.rs
+++ b/src/cli/translate.rs
@@ -225,36 +225,42 @@ fn extract_body(has_request_body: bool, matches: &ArgMatches) -> Result<Option<S
         return Ok(None);
     }
 
-    // --body-file takes precedence when present (clap enforces mutual exclusion
-    // with --body via conflicts_with, so only one can appear at a time).
-    if let Ok(Some(path)) = matches.try_get_one::<String>("body-file") {
-        let raw = if path == "-" {
-            let mut buf = String::new();
-            std::io::stdin()
-                .read_to_string(&mut buf)
-                .map_err(|e| Error::io_error(format!("Failed to read body from stdin: {e}")))?;
-            buf
-        } else {
-            std::fs::read_to_string(path)
-                .map_err(|e| Error::io_error(format!("Failed to read body file '{path}': {e}")))?
-        };
-        // Trim trailing whitespace so files with a trailing newline are treated
-        // identically to the equivalent --body inline string.
-        let content = raw.trim_end();
-        let _: serde_json::Value =
-            serde_json::from_str(content).map_err(|e| Error::invalid_json_body(e.to_string()))?;
-        return Ok(Some(content.to_owned()));
+    if let Some(path) = matches.try_get_one::<String>("body-file").ok().flatten() {
+        return read_body_file(path).map(Some);
     }
 
     matches
         .get_one::<String>("body")
-        .map(|body_value| {
-            // Validate JSON
-            let _: serde_json::Value = serde_json::from_str(body_value)
-                .map_err(|e| Error::invalid_json_body(e.to_string()))?;
-            Ok(body_value.clone())
-        })
+        .map(|body_value| validate_inline_body(body_value))
         .transpose()
+}
+
+fn read_body_file(path: &str) -> Result<String, Error> {
+    let raw = if path == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| Error::io_error(format!("Failed to read body from stdin: {e}")))?;
+        buf
+    } else {
+        std::fs::read_to_string(path)
+            .map_err(|e| Error::io_error(format!("Failed to read body file '{path}': {e}")))?
+    };
+
+    let content = raw.trim_end();
+    validate_json_body(content)?;
+    Ok(content.to_owned())
+}
+
+fn validate_inline_body(body_value: &str) -> Result<String, Error> {
+    validate_json_body(body_value)?;
+    Ok(body_value.to_owned())
+}
+
+fn validate_json_body(body: &str) -> Result<(), Error> {
+    let _: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| Error::invalid_json_body(e.to_string()))?;
+    Ok(())
 }
 
 /// Extracts server variable arguments from CLI matches.

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -109,37 +109,28 @@ impl<F: FileSystem> ConfigManager<F> {
                 ReferenceOr::Item(item) => Some(item),
                 ReferenceOr::Reference { .. } => None,
             })
-            .map(|item| {
-                let mut count = 0;
-                if item.get.is_some() {
-                    count += 1;
-                }
-                if item.post.is_some() {
-                    count += 1;
-                }
-                if item.put.is_some() {
-                    count += 1;
-                }
-                if item.delete.is_some() {
-                    count += 1;
-                }
-                if item.patch.is_some() {
-                    count += 1;
-                }
-                if item.head.is_some() {
-                    count += 1;
-                }
-                if item.options.is_some() {
-                    count += 1;
-                }
-                if item.trace.is_some() {
-                    count += 1;
-                }
-                count
-            })
+            .map(count_path_item_operations)
             .sum()
     }
+}
 
+fn count_path_item_operations(item: &openapiv3::PathItem) -> usize {
+    [
+        item.get.as_ref(),
+        item.post.as_ref(),
+        item.put.as_ref(),
+        item.delete.as_ref(),
+        item.patch.as_ref(),
+        item.head.as_ref(),
+        item.options.as_ref(),
+        item.trace.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    .count()
+}
+
+impl<F: FileSystem> ConfigManager<F> {
     /// Display validation warnings with custom prefix
     #[must_use]
     pub fn format_validation_warnings(

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -38,39 +38,46 @@ pub fn parse_duration(s: &str) -> Result<Duration, Error> {
         ));
     }
 
-    // Try parsing with suffixes
-    if let Some(ms_str) = s.strip_suffix("ms") {
-        let ms: u64 = ms_str
-            .trim()
-            .parse()
-            .map_err(|_| Error::invalid_config(format!("Invalid milliseconds value: {ms_str}")))?;
-        return Ok(Duration::from_millis(ms));
+    if let Some(duration) = parse_duration_suffix(s, "ms", "milliseconds", Duration::from_millis)? {
+        return Ok(duration);
     }
 
-    if let Some(m_str) = s.strip_suffix('m') {
-        // Make sure it's not "ms" (already handled above)
-        let minutes: u64 = m_str
-            .trim()
-            .parse()
-            .map_err(|_| Error::invalid_config(format!("Invalid minutes value: {m_str}")))?;
-        return Ok(Duration::from_secs(minutes * 60));
+    if let Some(duration) = parse_duration_suffix(s, "m", "minutes", |minutes| {
+        Duration::from_secs(minutes * 60)
+    })? {
+        return Ok(duration);
     }
 
-    if let Some(s_str) = s.strip_suffix('s') {
-        let secs: u64 = s_str
-            .trim()
-            .parse()
-            .map_err(|_| Error::invalid_config(format!("Invalid seconds value: {s_str}")))?;
-        return Ok(Duration::from_secs(secs));
+    if let Some(duration) = parse_duration_suffix(s, "s", "seconds", Duration::from_secs)? {
+        return Ok(duration);
     }
 
-    // Plain number - treat as milliseconds
-    let ms: u64 = s.parse().map_err(|_| {
+    Ok(Duration::from_millis(parse_plain_millis(s)?))
+}
+
+fn parse_duration_suffix(
+    value: &str,
+    suffix: &str,
+    label: &str,
+    build: impl Fn(u64) -> Duration,
+) -> Result<Option<Duration>, Error> {
+    let Some(raw) = value.strip_suffix(suffix) else {
+        return Ok(None);
+    };
+
+    let amount: u64 = raw
+        .trim()
+        .parse()
+        .map_err(|_| Error::invalid_config(format!("Invalid {label} value: {raw}")))?;
+    Ok(Some(build(amount)))
+}
+
+fn parse_plain_millis(value: &str) -> Result<u64, Error> {
+    value.parse().map_err(|_| {
         Error::invalid_config(format!(
-            "Invalid duration format: {s}. Use format like '500ms', '1s', '30s', or '1m'"
+            "Invalid duration format: {value}. Use format like '500ms', '1s', '30s', or '1m'"
         ))
-    })?;
-    Ok(Duration::from_millis(ms))
+    })
 }
 
 #[cfg(test)]

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -6,7 +6,7 @@ use crate::error::Error;
 use crate::invocation::ExecutionResult;
 use crate::logging;
 use crate::resilience::{
-    calculate_retry_delay_with_header, is_retryable_status, parse_retry_after_value,
+    calculate_retry_delay_with_header, is_retryable_status, parse_retry_after_value, RetryConfig,
 };
 use crate::response_cache::{
     is_auth_header, scrub_auth_headers, CacheConfig, CacheKey, CachedRequestInfo, CachedResponse,
@@ -180,7 +180,6 @@ async fn send_request_with_retry(
 ) -> Result<(reqwest::StatusCode, HashMap<String, String>, String), Error> {
     use crate::resilience::RetryConfig;
 
-    // Log the request with secret redaction
     logging::log_request(
         method.as_str(),
         url,
@@ -189,18 +188,10 @@ async fn send_request_with_retry(
         secret_ctx,
     );
 
-    // If no retry context or retries disabled, just send once
-    let Some(ctx) = retry_context else {
-        let request = build_request(client, method, url, headers, body);
-        return send_request(request, secret_ctx).await;
+    let Some(ctx) = retry_context.filter(|ctx| ctx.is_enabled()) else {
+        return send_request_once(client, method, url, headers, body, secret_ctx).await;
     };
 
-    if !ctx.is_enabled() {
-        let request = build_request(client, method, url, headers, body);
-        return send_request(request, secret_ctx).await;
-    }
-
-    // Check if safe to retry non-GET requests
     if !ctx.is_safe_to_retry() {
         tracing::warn!(
             method = %method,
@@ -208,11 +199,9 @@ async fn send_request_with_retry(
             "Retries disabled - method is not idempotent and no idempotency key provided. \
              Use --force-retry or provide --idempotency-key"
         );
-        let request = build_request(client, method.clone(), url, headers, body);
-        return send_request(request, secret_ctx).await;
+        return send_request_once(client, method.clone(), url, headers, body, secret_ctx).await;
     }
 
-    // Create a RetryConfig from the RetryContext
     let retry_config = RetryConfig {
         max_attempts: ctx.max_attempts as usize,
         initial_delay_ms: ctx.initial_delay_ms,
@@ -221,6 +210,32 @@ async fn send_request_with_retry(
         jitter: true,
     };
 
+    retry_request_with_backoff(
+        client,
+        method,
+        url,
+        headers,
+        body,
+        ctx,
+        &retry_config,
+        operation,
+        secret_ctx,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn retry_request_with_backoff(
+    client: &reqwest::Client,
+    method: Method,
+    url: &str,
+    headers: HeaderMap,
+    body: Option<String>,
+    ctx: &RetryContext,
+    retry_config: &crate::resilience::RetryConfig,
+    operation: &CachedCommand,
+    secret_ctx: Option<&logging::SecretContext>,
+) -> Result<(reqwest::StatusCode, HashMap<String, String>, String), Error> {
     let max_attempts = ctx.max_attempts;
     let mut attempt: u32 = 0;
     let mut last_error: Option<Error> = None;
@@ -232,82 +247,75 @@ async fn send_request_with_retry(
         attempt += 1;
 
         let request = build_request(client, method.clone(), url, headers.clone(), body.clone());
-        let result = send_request(request, secret_ctx).await;
-
-        match result {
+        match send_request(request, secret_ctx).await {
             Ok((status, response_headers, response_text)) => {
-                // Success - return immediately
-                if status.is_success() {
-                    return Ok((status, response_headers, response_text));
+                match handle_retryable_http_response(
+                    retry_config,
+                    attempt,
+                    max_attempts,
+                    &method,
+                    operation,
+                    status,
+                    response_headers,
+                    response_text,
+                )
+                .await
+                {
+                    RetryableHttpResponse::Return(result) => return Ok(result),
+                    RetryableHttpResponse::Retry {
+                        status,
+                        response_headers,
+                        response_text,
+                    } => {
+                        last_status = Some(status);
+                        last_response_headers = Some(response_headers);
+                        last_response_text = Some(response_text);
+                    }
                 }
-
-                // Check if we should retry this status code
-                if !is_retryable_status(status.as_u16()) {
-                    return Ok((status, response_headers, response_text));
-                }
-
-                // Parse Retry-After header if present
-                let retry_after = response_headers
-                    .get("retry-after")
-                    .and_then(|v| parse_retry_after_value(v));
-
-                // Calculate delay using the retry config
-                let delay = calculate_retry_delay_with_header(
-                    &retry_config,
-                    (attempt - 1) as usize, // 0-indexed for delay calculation
-                    retry_after,
-                );
-
-                // Check if we have more attempts
-                if attempt < max_attempts {
-                    tracing::warn!(
-                        attempt,
-                        max_attempts,
-                        method = %method,
-                        operation_id = %operation.operation_id,
-                        status = status.as_u16(),
-                        delay_ms = delay.as_millis(),
-                        "Retrying after HTTP error"
-                    );
-                    sleep(delay).await;
-                }
-
-                // Save for potential final error
-                last_status = Some(status);
-                last_response_headers = Some(response_headers);
-                last_response_text = Some(response_text);
             }
-            Err(e) => {
-                // Network error - check if we should retry
-                let should_retry = matches!(&e, Error::Network(_));
-
-                if !should_retry {
-                    return Err(e);
+            Err(error) => match handle_retryable_network_error(
+                retry_config,
+                attempt,
+                max_attempts,
+                &method,
+                operation,
+                error,
+            )
+            .await
+            {
+                RetryableNetworkError::Return(error) => return Err(error),
+                RetryableNetworkError::Retry(error) => {
+                    last_error = Some(error);
                 }
-
-                // Calculate delay
-                let delay =
-                    calculate_retry_delay_with_header(&retry_config, (attempt - 1) as usize, None);
-
-                if attempt < max_attempts {
-                    tracing::warn!(
-                        attempt,
-                        max_attempts,
-                        method = %method,
-                        operation_id = %operation.operation_id,
-                        delay_ms = delay.as_millis(),
-                        error = %e,
-                        "Retrying after network error"
-                    );
-                    sleep(delay).await;
-                }
-
-                last_error = Some(e);
-            }
+            },
         }
     }
 
-    // All retries exhausted - return last result
+    finish_retry_result(
+        max_attempts,
+        attempt,
+        last_status,
+        last_response_headers,
+        last_response_text,
+        last_error,
+        ctx,
+        &method,
+        operation,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish_retry_result(
+    max_attempts: u32,
+    attempt: u32,
+    last_status: Option<reqwest::StatusCode>,
+    last_response_headers: Option<HashMap<String, String>>,
+    last_response_text: Option<String>,
+    last_error: Option<Error>,
+    ctx: &RetryContext,
+    method: &Method,
+    operation: &CachedCommand,
+) -> Result<(reqwest::StatusCode, HashMap<String, String>, String), Error> {
     if let (Some(status), Some(headers), Some(text)) =
         (last_status, last_response_headers, last_response_text)
     {
@@ -320,19 +328,17 @@ async fn send_request_with_retry(
         return Ok((status, headers, text));
     }
 
-    // Return detailed retry error if we have a last error
-    if let Some(e) = last_error {
+    if let Some(error) = last_error {
         tracing::warn!(
             method = %method,
             operation_id = %operation.operation_id,
             max_attempts,
             "Retry exhausted"
         );
-        // Return detailed retry error with full context
         return Err(Error::retry_limit_exceeded_detailed(
             max_attempts,
             attempt,
-            e.to_string(),
+            error.to_string(),
             ctx.initial_delay_ms,
             ctx.max_delay_ms,
             None,
@@ -340,7 +346,6 @@ async fn send_request_with_retry(
         ));
     }
 
-    // Should not happen, but handle gracefully
     Err(Error::retry_limit_exceeded_detailed(
         max_attempts,
         attempt,
@@ -350,6 +355,95 @@ async fn send_request_with_retry(
         None,
         &operation.operation_id,
     ))
+}
+
+enum RetryableHttpResponse {
+    Return((reqwest::StatusCode, HashMap<String, String>, String)),
+    Retry {
+        status: reqwest::StatusCode,
+        response_headers: HashMap<String, String>,
+        response_text: String,
+    },
+}
+
+enum RetryableNetworkError {
+    Return(Error),
+    Retry(Error),
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_retryable_http_response(
+    retry_config: &RetryConfig,
+    attempt: u32,
+    max_attempts: u32,
+    method: &Method,
+    operation: &CachedCommand,
+    status: reqwest::StatusCode,
+    response_headers: HashMap<String, String>,
+    response_text: String,
+) -> RetryableHttpResponse {
+    if status.is_success() {
+        return RetryableHttpResponse::Return((status, response_headers, response_text));
+    }
+
+    if !is_retryable_status(status.as_u16()) {
+        return RetryableHttpResponse::Return((status, response_headers, response_text));
+    }
+
+    let retry_after = response_headers
+        .get("retry-after")
+        .and_then(|value| parse_retry_after_value(value));
+    let delay =
+        calculate_retry_delay_with_header(retry_config, (attempt - 1) as usize, retry_after);
+
+    if attempt < max_attempts {
+        tracing::warn!(
+            attempt,
+            max_attempts,
+            method = %method,
+            operation_id = %operation.operation_id,
+            status = status.as_u16(),
+            delay_ms = delay.as_millis(),
+            "Retrying after HTTP error"
+        );
+        sleep(delay).await;
+    }
+
+    RetryableHttpResponse::Retry {
+        status,
+        response_headers,
+        response_text,
+    }
+}
+
+async fn handle_retryable_network_error(
+    retry_config: &RetryConfig,
+    attempt: u32,
+    max_attempts: u32,
+    method: &Method,
+    operation: &CachedCommand,
+    error: Error,
+) -> RetryableNetworkError {
+    if !matches!(&error, Error::Network(_)) {
+        return RetryableNetworkError::Return(error);
+    }
+
+    let delay = calculate_retry_delay_with_header(retry_config, (attempt - 1) as usize, None);
+
+    if attempt < max_attempts {
+        tracing::warn!(
+            attempt,
+            max_attempts,
+            method = %method,
+            operation_id = %operation.operation_id,
+            delay_ms = delay.as_millis(),
+            error = %error,
+            "Retrying after network error"
+        );
+        sleep(delay).await;
+    }
+
+    RetryableNetworkError::Retry(error)
 }
 
 /// Build a request from components
@@ -365,6 +459,18 @@ fn build_request(
         request = request.json(&json_body);
     }
     request
+}
+
+async fn send_request_once(
+    client: &reqwest::Client,
+    method: Method,
+    url: &str,
+    headers: HeaderMap,
+    body: Option<String>,
+    secret_ctx: Option<&logging::SecretContext>,
+) -> Result<(reqwest::StatusCode, HashMap<String, String>, String), Error> {
+    let request = build_request(client, method, url, headers, body);
+    send_request(request, secret_ctx).await
 }
 
 /// Handle HTTP error responses
@@ -857,6 +963,69 @@ pub async fn execute(
     call: crate::invocation::OperationCall,
     ctx: crate::invocation::ExecutionContext,
 ) -> Result<crate::invocation::ExecutionResult, Error> {
+    let prepared = prepare_execution(spec, call, &ctx)?;
+
+    if let Some(result) = resolve_pre_execution_result(
+        prepared.cache_context.as_ref(),
+        ctx.dry_run,
+        &prepared.method,
+        &prepared.url,
+        &prepared.headers_clone,
+        prepared.body.as_deref(),
+        &prepared.operation.operation_id,
+    )
+    .await?
+    {
+        return Ok(result);
+    }
+
+    let (status, response_headers, response_text) = send_request_with_retry(
+        &prepared.client,
+        prepared.method.clone(),
+        &prepared.url,
+        prepared.headers,
+        prepared.body.clone(),
+        prepared.retry_ctx.as_ref(),
+        prepared.operation,
+        Some(&prepared.secret_ctx),
+    )
+    .await?;
+
+    finalize_execution_result(
+        status,
+        response_headers,
+        response_text,
+        spec,
+        prepared.operation,
+        prepared.method,
+        prepared.url,
+        &prepared.headers_clone,
+        prepared.body.as_deref(),
+        prepared.cache_context,
+        prepared.cache_config,
+    )
+    .await
+}
+
+struct PreparedExecution<'a> {
+    operation: &'a CachedCommand,
+    method: Method,
+    url: String,
+    client: reqwest::Client,
+    headers: HeaderMap,
+    headers_clone: HeaderMap,
+    cache_context: Option<(CacheKey, ResponseCache)>,
+    retry_ctx: Option<RetryContext>,
+    secret_ctx: logging::SecretContext,
+    body: Option<String>,
+    cache_config: Option<&'a CacheConfig>,
+}
+
+fn prepare_execution<'a>(
+    spec: &'a CachedSpec,
+    call: crate::invocation::OperationCall,
+    ctx: &'a crate::invocation::ExecutionContext,
+) -> Result<PreparedExecution<'a>, Error> {
     let operation = find_operation_by_id(spec, &call.operation_id)?;
     let resolver = resolve_base_url_resolver(spec, ctx.global_config.as_ref());
     let base_url =
@@ -889,53 +1058,26 @@ pub async fn execute(
         &headers_clone,
         call.body.as_deref(),
     )?;
-
-    if let Some(result) = resolve_pre_execution_result(
-        cache_context.as_ref(),
-        ctx.dry_run,
-        &method,
-        &url,
-        &headers_clone,
-        call.body.as_deref(),
-        &operation.operation_id,
-    )
-    .await?
-    {
-        return Ok(result);
-    }
-
-    let retry_ctx = ctx.retry_context.map(|mut rc| {
+    let retry_ctx = ctx.retry_context.clone().map(|mut rc| {
         rc.method = Some(method.to_string());
         rc
     });
     let secret_ctx =
         logging::SecretContext::from_spec_and_config(spec, &spec.name, ctx.global_config.as_ref());
-    let (status, response_headers, response_text) = send_request_with_retry(
-        &client,
-        method.clone(),
-        &url,
-        headers,
-        call.body.clone(),
-        retry_ctx.as_ref(),
-        operation,
-        Some(&secret_ctx),
-    )
-    .await?;
 
-    finalize_execution_result(
-        status,
-        response_headers,
-        response_text,
-        spec,
+    Ok(PreparedExecution {
         operation,
         method,
         url,
-        &headers_clone,
-        call.body.as_deref(),
+        client,
+        headers,
+        headers_clone,
         cache_context,
-        ctx.cache_config.as_ref(),
-    )
-    .await
+        retry_ctx,
+        secret_ctx,
+        body: call.body,
+        cache_config: ctx.cache_config.as_ref(),
+    })
 }
 
 /// Finds an operation by its `operation_id` in the spec.
@@ -1007,16 +1149,27 @@ fn build_headers_from_params(
     api_name: &str,
     global_config: Option<&GlobalConfig>,
 ) -> Result<HeaderMap, Error> {
-    let mut headers = HeaderMap::new();
+    let mut headers = default_request_headers();
+    apply_header_parameters(&mut headers, header_params)?;
+    apply_security_headers(&mut headers, spec, operation, api_name, global_config)?;
+    apply_custom_headers(&mut headers, custom_headers)?;
+    Ok(headers)
+}
 
-    // Default headers
+fn default_request_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
     headers.insert("User-Agent", HeaderValue::from_static("aperture/0.1.0"));
     headers.insert(
         constants::HEADER_ACCEPT,
         HeaderValue::from_static(constants::CONTENT_TYPE_JSON),
     );
+    headers
+}
 
-    // Add header parameters from the pre-extracted map
+fn apply_header_parameters(
+    headers: &mut HeaderMap,
+    header_params: &HashMap<String, String>,
+) -> Result<(), Error> {
     for (name, value) in header_params {
         let header_name = HeaderName::from_str(name)
             .map_err(|e| Error::invalid_header_name(name, e.to_string()))?;
@@ -1024,16 +1177,26 @@ fn build_headers_from_params(
             .map_err(|e| Error::invalid_header_value(name, e.to_string()))?;
         headers.insert(header_name, header_value);
     }
+    Ok(())
+}
 
-    // Add authentication headers
+fn apply_security_headers(
+    headers: &mut HeaderMap,
+    spec: &CachedSpec,
+    operation: &CachedCommand,
+    api_name: &str,
+    global_config: Option<&GlobalConfig>,
+) -> Result<(), Error> {
     for security_scheme_name in &operation.security_requirements {
         let Some(security_scheme) = spec.security_schemes.get(security_scheme_name) else {
             continue;
         };
-        add_authentication_header(&mut headers, security_scheme, api_name, global_config)?;
+        add_authentication_header(headers, security_scheme, api_name, global_config)?;
     }
+    Ok(())
+}
 
-    // Add custom headers
+fn apply_custom_headers(headers: &mut HeaderMap, custom_headers: &[String]) -> Result<(), Error> {
     for header_str in custom_headers {
         let (name, value) = parse_custom_header(header_str)?;
         let header_name = HeaderName::from_str(&name)
@@ -1042,8 +1205,7 @@ fn build_headers_from_params(
             .map_err(|e| Error::invalid_header_value(&name, e.to_string()))?;
         headers.insert(header_name, header_value);
     }
-
-    Ok(headers)
+    Ok(())
 }
 
 /// Applies a JQ filter to the response text
@@ -1055,99 +1217,85 @@ fn build_headers_from_params(
 /// - The JQ filter expression is invalid
 /// - The filter execution fails
 pub fn apply_jq_filter(response_text: &str, filter: &str) -> Result<String, Error> {
-    // Parse the response as JSON
     let json_value: Value = serde_json::from_str(response_text)
         .map_err(|e| Error::jq_filter_error(filter, format!("Response is not valid JSON: {e}")))?;
 
-    #[cfg(feature = "jq")]
-    {
-        // Use jaq v2.x (pure Rust implementation)
-        use jaq_core::load::{Arena, File, Loader};
-        use jaq_core::Compiler;
+    apply_jq_filter_value(json_value, filter)
+}
 
-        // Create the program from the filter string
-        let program = File {
-            code: filter,
-            path: (),
-        };
+#[cfg(feature = "jq")]
+fn apply_jq_filter_value(json_value: Value, filter: &str) -> Result<String, Error> {
+    // Use jaq v2.x (pure Rust implementation)
+    use jaq_core::load::{Arena, File, Loader};
+    use jaq_core::Compiler;
 
-        // Collect both standard library and JSON definitions into vectors
-        // This avoids hanging issues with lazy iterator chains
-        let defs: Vec<_> = jaq_std::defs().chain(jaq_json::defs()).collect();
-        let funs: Vec<_> = jaq_std::funs().chain(jaq_json::funs()).collect();
+    let program = File {
+        code: filter,
+        path: (),
+    };
 
-        // Create loader with both standard library and JSON definitions
-        let loader = Loader::new(defs);
-        let arena = Arena::default();
+    let defs: Vec<_> = jaq_std::defs().chain(jaq_json::defs()).collect();
+    let funs: Vec<_> = jaq_std::funs().chain(jaq_json::funs()).collect();
 
-        // Parse the filter
-        let modules = match loader.load(&arena, program) {
-            Ok(modules) => modules,
-            Err(errs) => {
-                return Err(Error::jq_filter_error(
-                    filter,
-                    format!("Parse error: {:?}", errs),
-                ));
-            }
-        };
+    let loader = Loader::new(defs);
+    let arena = Arena::default();
 
-        // Compile the filter with both standard library and JSON functions
-        let filter_fn = match Compiler::default().with_funs(funs).compile(modules) {
-            Ok(filter) => filter,
-            Err(errs) => {
-                return Err(Error::jq_filter_error(
-                    filter,
-                    format!("Compilation error: {:?}", errs),
-                ));
-            }
-        };
-
-        // Convert serde_json::Value to jaq Val
-        let jaq_value = Val::from(json_value);
-
-        // Execute the filter
-        let inputs = RcIter::new(core::iter::empty());
-        let ctx = Ctx::new([], &inputs);
-
-        // Run the filter on the input value
-        let output = filter_fn.run((ctx, jaq_value));
-
-        // Collect all results
-        let results: Result<Vec<Val>, _> = output.collect();
-
-        match results {
-            Ok(vals) => {
-                if vals.is_empty() {
-                    return Ok(constants::NULL_VALUE.to_string());
-                }
-
-                if vals.len() == 1 {
-                    // Single result - convert back to JSON
-                    let json_val = serde_json::Value::from(vals[0].clone());
-                    return serde_json::to_string_pretty(&json_val).map_err(|e| {
-                        Error::serialization_error(format!("Failed to serialize result: {e}"))
-                    });
-                }
-
-                // Multiple results - return as JSON array
-                let json_vals: Vec<Value> = vals.into_iter().map(serde_json::Value::from).collect();
-                let array = Value::Array(json_vals);
-                serde_json::to_string_pretty(&array).map_err(|e| {
-                    Error::serialization_error(format!("Failed to serialize results: {e}"))
-                })
-            }
-            Err(e) => Err(Error::jq_filter_error(
-                format!("{:?}", filter),
-                format!("Filter execution error: {e}"),
-            )),
+    let modules = match loader.load(&arena, program) {
+        Ok(modules) => modules,
+        Err(errs) => {
+            return Err(Error::jq_filter_error(
+                filter,
+                format!("Parse error: {errs:?}"),
+            ));
         }
-    }
+    };
 
-    #[cfg(not(feature = "jq"))]
-    {
-        // Basic JQ-like functionality without full jq library
-        apply_basic_jq_filter(&json_value, filter)
+    let filter_fn = match Compiler::default().with_funs(funs).compile(modules) {
+        Ok(filter) => filter,
+        Err(errs) => {
+            return Err(Error::jq_filter_error(
+                filter,
+                format!("Compilation error: {errs:?}"),
+            ));
+        }
+    };
+
+    let jaq_value = Val::from(json_value);
+    let inputs = RcIter::new(core::iter::empty());
+    let ctx = Ctx::new([], &inputs);
+    let output = filter_fn.run((ctx, jaq_value));
+    let results: Result<Vec<Val>, _> = output.collect();
+
+    match results {
+        Ok(vals) => {
+            if vals.is_empty() {
+                return Ok(constants::NULL_VALUE.to_string());
+            }
+
+            if vals.len() == 1 {
+                let json_val = serde_json::Value::from(vals[0].clone());
+                return serde_json::to_string_pretty(&json_val).map_err(|e| {
+                    Error::serialization_error(format!("Failed to serialize result: {e}"))
+                });
+            }
+
+            let json_vals: Vec<Value> = vals.into_iter().map(serde_json::Value::from).collect();
+            let array = Value::Array(json_vals);
+            serde_json::to_string_pretty(&array).map_err(|e| {
+                Error::serialization_error(format!("Failed to serialize results: {e}"))
+            })
+        }
+        Err(e) => Err(Error::jq_filter_error(
+            format!("{filter:?}"),
+            format!("Filter execution error: {e}"),
+        )),
     }
+}
+
+#[cfg(not(feature = "jq"))]
+#[allow(clippy::needless_pass_by_value)]
+fn apply_jq_filter_value(json_value: Value, filter: &str) -> Result<String, Error> {
+    apply_basic_jq_filter(&json_value, filter)
 }
 
 #[cfg(not(feature = "jq"))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -266,22 +266,8 @@ impl Error {
             Option<Cow<'static, str>>,
             Option<serde_json::Value>,
         ) = match self {
-            Self::Io(io_err) => {
-                let context = match io_err.kind() {
-                    std::io::ErrorKind::NotFound => {
-                        Some(Cow::Borrowed(constants::ERR_FILE_NOT_FOUND))
-                    }
-                    std::io::ErrorKind::PermissionDenied => {
-                        Some(Cow::Borrowed(constants::ERR_PERMISSION))
-                    }
-                    _ => None,
-                };
-                ("FileSystem", io_err.to_string(), context, None)
-            }
-            Self::Network(req_err) => {
-                let context = network_error_context(req_err);
-                ("Network", req_err.to_string(), context, None)
-            }
+            Self::Io(io_err) => io_error_json_parts(io_err),
+            Self::Network(req_err) => network_error_json_parts(req_err),
             Self::Yaml(yaml_err) => (
                 "YAMLParsing",
                 yaml_err.to_string(),
@@ -304,11 +290,7 @@ impl Error {
                 kind,
                 message,
                 context: ctx,
-            } => {
-                let context = ctx.as_ref().and_then(|c| c.suggestion.clone());
-                let details = ctx.as_ref().and_then(|c| c.details.clone());
-                (kind.as_str(), message.to_string(), context, details)
-            }
+            } => internal_error_json_parts(kind, message.as_ref(), ctx.as_ref()),
             Self::Anyhow(anyhow_err) => ("Unknown", anyhow_err.to_string(), None, None),
         };
 
@@ -319,6 +301,53 @@ impl Error {
             details,
         }
     }
+}
+
+fn io_error_json_parts(
+    io_err: &std::io::Error,
+) -> (
+    &'static str,
+    String,
+    Option<Cow<'static, str>>,
+    Option<serde_json::Value>,
+) {
+    let context = match io_err.kind() {
+        std::io::ErrorKind::NotFound => Some(Cow::Borrowed(constants::ERR_FILE_NOT_FOUND)),
+        std::io::ErrorKind::PermissionDenied => Some(Cow::Borrowed(constants::ERR_PERMISSION)),
+        _ => None,
+    };
+    ("FileSystem", io_err.to_string(), context, None)
+}
+
+fn network_error_json_parts(
+    req_err: &reqwest::Error,
+) -> (
+    &'static str,
+    String,
+    Option<Cow<'static, str>>,
+    Option<serde_json::Value>,
+) {
+    (
+        "Network",
+        req_err.to_string(),
+        network_error_context(req_err),
+        None,
+    )
+}
+
+fn internal_error_json_parts(
+    kind: &ErrorKind,
+    message: &str,
+    context: Option<&ErrorContext>,
+) -> (
+    &'static str,
+    String,
+    Option<Cow<'static, str>>,
+    Option<serde_json::Value>,
+) {
+    let suggestion = context.and_then(|c| c.suggestion.clone());
+    let details = context.and_then(|c| c.details.clone());
+    (kind.as_str(), message.to_string(), suggestion, details)
 }
 
 impl Error {

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -347,6 +347,7 @@ pub fn select_from_options_with_io_and_timeout<T: InputOutput>(
     for attempt in 1..=MAX_RETRIES {
         match resolve_selection_attempt(options, io, timeout)? {
             SelectionOutcome::Selected(choice) => return Ok(choice),
+            SelectionOutcome::Continue => {}
             SelectionOutcome::Retry => {
                 if attempt < MAX_RETRIES {
                     io.println(&format!(
@@ -377,6 +378,7 @@ fn print_selection_options<T: InputOutput>(
 
 enum SelectionOutcome {
     Selected(String),
+    Continue,
     Retry,
 }
 
@@ -389,7 +391,7 @@ fn resolve_selection_attempt<T: InputOutput>(
         prompt_for_input_with_io_and_timeout("Enter your choice (number or name): ", io, timeout)?;
 
     match handle_empty_selection(&selection, io, timeout)? {
-        EmptySelectionResult::Continue => return Ok(SelectionOutcome::Retry),
+        EmptySelectionResult::Continue => return Ok(SelectionOutcome::Continue),
         EmptySelectionResult::Cancel => {
             return Err(Error::invalid_config("Selection cancelled by user"));
         }

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -135,7 +135,15 @@ pub fn confirm_with_timeout(prompt: &str, timeout: Duration) -> Result<bool, Err
 /// # Errors
 /// Returns an error if the environment variable name is invalid
 pub fn validate_env_var_name(name: &str) -> Result<(), Error> {
-    // Check if empty
+    validate_env_var_not_empty(name)?;
+    validate_env_var_length(name)?;
+    validate_env_var_not_reserved(name)?;
+    validate_env_var_start(name)?;
+    validate_env_var_characters(name)?;
+    Ok(())
+}
+
+fn validate_env_var_not_empty(name: &str) -> Result<(), Error> {
     if name.is_empty() {
         return Err(Error::invalid_environment_variable_name(
             name,
@@ -143,8 +151,10 @@ pub fn validate_env_var_name(name: &str) -> Result<(), Error> {
             "Provide a non-empty environment variable name like 'API_TOKEN'",
         ));
     }
+    Ok(())
+}
 
-    // Check length
+fn validate_env_var_length(name: &str) -> Result<(), Error> {
     if name.len() > MAX_INPUT_LENGTH {
         return Err(Error::invalid_environment_variable_name(
             name,
@@ -156,8 +166,10 @@ pub fn validate_env_var_name(name: &str) -> Result<(), Error> {
             format!("Shorten the name to {MAX_INPUT_LENGTH} characters or less"),
         ));
     }
+    Ok(())
+}
 
-    // Check for reserved names (case insensitive)
+fn validate_env_var_not_reserved(name: &str) -> Result<(), Error> {
     let name_upper = name.to_uppercase();
     if RESERVED_ENV_VARS
         .iter()
@@ -169,46 +181,51 @@ pub fn validate_env_var_name(name: &str) -> Result<(), Error> {
             "Use a different name like 'MY_API_TOKEN' or 'APP_SECRET'",
         ));
     }
+    Ok(())
+}
 
-    // Check format - must start with letter or underscore, followed by alphanumeric or underscore
-    if !name.chars().next().unwrap_or('_').is_ascii_alphabetic() && !name.starts_with('_') {
-        let first_char = name.chars().next().unwrap_or('?');
-        let suggested_name = if first_char.is_ascii_digit() {
-            format!("VAR_{name}")
-        } else {
-            format!("_{name}")
-        };
-        return Err(Error::invalid_environment_variable_name(
-            name,
-            "must start with a letter or underscore",
-            format!("Try '{suggested_name}' instead"),
-        ));
+fn validate_env_var_start(name: &str) -> Result<(), Error> {
+    if name.chars().next().unwrap_or('_').is_ascii_alphabetic() || name.starts_with('_') {
+        return Ok(());
     }
 
-    // Check all characters are valid - alphanumeric or underscore only
+    let first_char = name.chars().next().unwrap_or('?');
+    let suggested_name = if first_char.is_ascii_digit() {
+        format!("VAR_{name}")
+    } else {
+        format!("_{name}")
+    };
+    Err(Error::invalid_environment_variable_name(
+        name,
+        "must start with a letter or underscore",
+        format!("Try '{suggested_name}' instead"),
+    ))
+}
+
+fn validate_env_var_characters(name: &str) -> Result<(), Error> {
     let invalid_chars: Vec<char> = name
         .chars()
         .filter(|c| !c.is_ascii_alphanumeric() && *c != '_')
         .collect();
-    if !invalid_chars.is_empty() {
-        let invalid_chars_str: String = invalid_chars.iter().collect();
-        let suggested_name = name
-            .chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '_' {
-                    c
-                } else {
-                    '_'
-                }
-            })
-            .collect::<String>();
-        return Err(Error::interactive_invalid_characters(
-            &invalid_chars_str,
-            format!("Try '{suggested_name}' instead"),
-        ));
+    if invalid_chars.is_empty() {
+        return Ok(());
     }
 
-    Ok(())
+    let invalid_chars_str: String = invalid_chars.iter().collect();
+    let suggested_name = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    Err(Error::interactive_invalid_characters(
+        &invalid_chars_str,
+        format!("Try '{suggested_name}' instead"),
+    ))
 }
 
 /// Testable version of `prompt_for_input` that accepts an `InputOutput` trait
@@ -325,34 +342,19 @@ pub fn select_from_options_with_io_and_timeout<T: InputOutput>(
     }
 
     io.println(prompt)?;
-    for (i, (key, description)) in options.iter().enumerate() {
-        io.println(&format!("  {}: {} - {}", i + 1, key, description))?;
-    }
+    print_selection_options(options, io)?;
 
     for attempt in 1..=MAX_RETRIES {
-        let selection = prompt_for_input_with_io_and_timeout(
-            "Enter your choice (number or name): ",
-            io,
-            timeout,
-        )?;
-
-        match handle_empty_selection(&selection, io, timeout)? {
-            EmptySelectionResult::Continue => continue,
-            EmptySelectionResult::Cancel => {
-                return Err(Error::invalid_config("Selection cancelled by user"))
+        match resolve_selection_attempt(options, io, timeout)? {
+            SelectionOutcome::Selected(choice) => return Ok(choice),
+            SelectionOutcome::Retry => {
+                if attempt < MAX_RETRIES {
+                    io.println(&format!(
+                        "Invalid selection. Please enter a number (1-{}) or a valid name. (Attempt {attempt} of {MAX_RETRIES})",
+                        options.len()
+                    ))?;
+                }
             }
-            EmptySelectionResult::ProcessSelection => {}
-        }
-
-        if let Some(choice) = resolve_selection_choice(options, &selection) {
-            return Ok(choice);
-        }
-
-        if attempt < MAX_RETRIES {
-            io.println(&format!(
-                "Invalid selection. Please enter a number (1-{}) or a valid name. (Attempt {attempt} of {MAX_RETRIES})",
-                options.len()
-            ))?;
         }
     }
 
@@ -361,6 +363,44 @@ pub fn select_from_options_with_io_and_timeout<T: InputOutput>(
         "Invalid selection",
         &build_selection_suggestions(options),
     ))
+}
+
+fn print_selection_options<T: InputOutput>(
+    options: &[(String, String)],
+    io: &T,
+) -> Result<(), Error> {
+    for (i, (key, description)) in options.iter().enumerate() {
+        io.println(&format!("  {}: {} - {}", i + 1, key, description))?;
+    }
+    Ok(())
+}
+
+enum SelectionOutcome {
+    Selected(String),
+    Retry,
+}
+
+fn resolve_selection_attempt<T: InputOutput>(
+    options: &[(String, String)],
+    io: &T,
+    timeout: Duration,
+) -> Result<SelectionOutcome, Error> {
+    let selection =
+        prompt_for_input_with_io_and_timeout("Enter your choice (number or name): ", io, timeout)?;
+
+    match handle_empty_selection(&selection, io, timeout)? {
+        EmptySelectionResult::Continue => return Ok(SelectionOutcome::Retry),
+        EmptySelectionResult::Cancel => {
+            return Err(Error::invalid_config("Selection cancelled by user"));
+        }
+        EmptySelectionResult::ProcessSelection => {}
+    }
+
+    if let Some(choice) = resolve_selection_choice(options, &selection) {
+        return Ok(SelectionOutcome::Selected(choice));
+    }
+
+    Ok(SelectionOutcome::Retry)
 }
 
 /// Testable version of `confirm` that accepts an `InputOutput` trait

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,44 +111,32 @@ async fn run_non_config_command(
     output: &Output,
 ) -> Result<(), Error> {
     match &cli.command {
-        Commands::ListCommands { context } => {
-            run_list_commands(context, output)?;
-        }
-        Commands::Api { context, args } => {
-            run_api_command(cli, context, args).await?;
-        }
+        Commands::ListCommands { context } => run_list_commands(context, output),
+        Commands::Api { context, args } => run_api_command(cli, context, args).await,
         Commands::Search {
             query,
             api,
             verbose,
-        } => {
-            run_search_command(manager, query, api.as_deref(), *verbose, output)?;
-        }
-        Commands::Exec { args } => {
-            run_shortcut_command(manager, args, cli).await?;
-        }
+        } => run_search_command(manager, query, api.as_deref(), *verbose, output),
+        Commands::Exec { args } => run_shortcut_command(manager, args, cli).await,
         Commands::Docs {
             api,
             tag,
             operation,
             enhanced,
-        } => {
-            run_docs_command(
-                manager,
-                api.as_deref(),
-                tag.as_deref(),
-                operation.as_deref(),
-                *enhanced,
-                output,
-            )?;
-        }
+        } => run_docs_command(
+            manager,
+            api.as_deref(),
+            tag.as_deref(),
+            operation.as_deref(),
+            *enhanced,
+            output,
+        ),
         Commands::Overview { api, all } => {
-            run_overview_command(manager, api.as_deref(), *all, output)?;
+            run_overview_command(manager, api.as_deref(), *all, output)
         }
         Commands::Config { .. } => unreachable!("config commands are handled separately"),
     }
-
-    Ok(())
 }
 
 #[allow(clippy::too_many_lines, clippy::cognitive_complexity)]

--- a/src/response_cache.rs
+++ b/src/response_cache.rs
@@ -372,74 +372,18 @@ impl ResponseCache {
             let filename = entry.file_name();
             let filename_str = filename.to_string_lossy();
 
-            if !filename_str.ends_with(constants::CACHE_FILE_SUFFIX) {
-                continue;
-            }
-
-            // Check if this entry matches the requested API
-            let Some(target_api) = api_name else {
-                // No filter, include all entries
-                stats.total_entries += 1;
-
-                // Check if entry is expired
-                let Ok(metadata) = entry.metadata().await else {
-                    continue;
-                };
-
-                stats.total_size_bytes += metadata.len();
-
-                // Try to read the cache file to check expiration
-                let Ok(json_content) = tokio::fs::read_to_string(entry.path()).await else {
-                    continue;
-                };
-
-                let Ok(cached_response) = serde_json::from_str::<CachedResponse>(&json_content)
-                else {
-                    continue;
-                };
-
-                let now = SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .map_err(|e| Error::invalid_config(format!("System time error: {e}")))?
-                    .as_secs();
-
-                if now > cached_response.cached_at + cached_response.ttl_seconds {
-                    stats.expired_entries += 1;
-                } else {
-                    stats.valid_entries += 1;
-                }
-
-                continue;
-            };
-
-            if !filename_str.starts_with(&format!("{target_api}_")) {
+            if !Self::is_stats_entry(&filename_str, api_name) {
                 continue;
             }
 
             stats.total_entries += 1;
 
-            // Check if entry is expired
-            let Ok(metadata) = entry.metadata().await else {
+            let Some((size_bytes, is_expired)) = Self::inspect_stats_entry(&entry).await? else {
                 continue;
             };
 
-            stats.total_size_bytes += metadata.len();
-
-            // Try to read the cache file to check expiration
-            let Ok(json_content) = tokio::fs::read_to_string(entry.path()).await else {
-                continue;
-            };
-
-            let Ok(cached_response) = serde_json::from_str::<CachedResponse>(&json_content) else {
-                continue;
-            };
-
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map_err(|e| Error::invalid_config(format!("System time error: {e}")))?
-                .as_secs();
-
-            if now > cached_response.cached_at + cached_response.ttl_seconds {
+            stats.total_size_bytes += size_bytes;
+            if is_expired {
                 stats.expired_entries += 1;
             } else {
                 stats.valid_entries += 1;
@@ -447,6 +391,37 @@ impl ResponseCache {
         }
 
         Ok(stats)
+    }
+
+    fn is_stats_entry(filename: &str, api_name: Option<&str>) -> bool {
+        filename.ends_with(constants::CACHE_FILE_SUFFIX)
+            && api_name.is_none_or(|target| filename.starts_with(&format!("{target}_")))
+    }
+
+    async fn inspect_stats_entry(
+        entry: &tokio::fs::DirEntry,
+    ) -> Result<Option<(u64, bool)>, Error> {
+        let Ok(metadata) = entry.metadata().await else {
+            return Ok(None);
+        };
+
+        let Ok(json_content) = tokio::fs::read_to_string(entry.path()).await else {
+            return Ok(None);
+        };
+
+        let Ok(cached_response) = serde_json::from_str::<CachedResponse>(&json_content) else {
+            return Ok(None);
+        };
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| Error::invalid_config(format!("System time error: {e}")))?
+            .as_secs();
+
+        Ok(Some((
+            metadata.len(),
+            now > cached_response.cached_at + cached_response.ttl_seconds,
+        )))
     }
 
     /// Check whether a directory entry is a stale temp file (older than 1 hour)

--- a/src/response_cache.rs
+++ b/src/response_cache.rs
@@ -378,11 +378,15 @@ impl ResponseCache {
 
             stats.total_entries += 1;
 
-            let Some((size_bytes, is_expired)) = Self::inspect_stats_entry(&entry).await? else {
+            let Ok(metadata) = entry.metadata().await else {
+                continue;
+            };
+            stats.total_size_bytes += metadata.len();
+
+            let Some(is_expired) = Self::inspect_stats_entry(&entry).await? else {
                 continue;
             };
 
-            stats.total_size_bytes += size_bytes;
             if is_expired {
                 stats.expired_entries += 1;
             } else {
@@ -398,13 +402,7 @@ impl ResponseCache {
             && api_name.is_none_or(|target| filename.starts_with(&format!("{target}_")))
     }
 
-    async fn inspect_stats_entry(
-        entry: &tokio::fs::DirEntry,
-    ) -> Result<Option<(u64, bool)>, Error> {
-        let Ok(metadata) = entry.metadata().await else {
-            return Ok(None);
-        };
-
+    async fn inspect_stats_entry(entry: &tokio::fs::DirEntry) -> Result<Option<bool>, Error> {
         let Ok(json_content) = tokio::fs::read_to_string(entry.path()).await else {
             return Ok(None);
         };
@@ -418,10 +416,9 @@ impl ResponseCache {
             .map_err(|e| Error::invalid_config(format!("System time error: {e}")))?
             .as_secs();
 
-        Ok(Some((
-            metadata.len(),
+        Ok(Some(
             now > cached_response.cached_at + cached_response.ttl_seconds,
-        )))
+        ))
     }
 
     /// Check whether a directory entry is a stale temp file (older than 1 hour)
@@ -884,6 +881,29 @@ mod tests {
         assert_eq!(stats.valid_entries, 2);
         assert_eq!(stats.expired_entries, 0);
         assert!(stats.total_size_bytes > 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_stats_counts_corrupted_entry_size() {
+        let (config, _temp_dir) = create_test_cache_config();
+        let cache = ResponseCache::new(config).unwrap();
+
+        let key = CacheKey {
+            api_name: "api_corrupt".to_string(),
+            operation_id: "broken".to_string(),
+            request_hash: "hash".to_string(),
+        };
+        let cache_file = cache.config.cache_dir.join(key.to_filename());
+        tokio::fs::write(&cache_file, b"not valid json")
+            .await
+            .unwrap();
+
+        let expected_size = tokio::fs::metadata(&cache_file).await.unwrap().len();
+        let stats = cache.get_stats(Some("api_corrupt")).await.unwrap();
+        assert_eq!(stats.total_entries, 1);
+        assert_eq!(stats.valid_entries, 0);
+        assert_eq!(stats.expired_entries, 0);
+        assert_eq!(stats.total_size_bytes, expected_size);
     }
 
     #[tokio::test]

--- a/src/search.rs
+++ b/src/search.rs
@@ -285,33 +285,32 @@ impl CommandSearcher {
         for command in &spec.commands {
             let full_command = effective_command_path(command);
 
-            // Check fuzzy match score on the effective command path
-            match self.matcher.fuzzy_match(&full_command, input) {
-                Some(score) if score > 0 => suggestions.push((full_command.clone(), score)),
-                _ => {}
-            }
+            Self::push_fuzzy_match(
+                &mut suggestions,
+                &full_command,
+                self.matcher.fuzzy_match(&full_command, input),
+                0,
+            );
 
-            // Also check the effective subcommand name directly
             let effective_name = command
                 .display_name
                 .as_deref()
                 .map_or_else(|| to_kebab_case(&command.operation_id), to_kebab_case);
-            match self.matcher.fuzzy_match(&effective_name, input) {
-                Some(score) if score > 0 => {
-                    suggestions.push((full_command.clone(), score + 10));
-                }
-                _ => {}
-            }
+            Self::push_fuzzy_match(
+                &mut suggestions,
+                &full_command,
+                self.matcher.fuzzy_match(&effective_name, input),
+                10,
+            );
 
-            // Also check aliases
             for alias in &command.aliases {
                 let alias_kebab = to_kebab_case(alias);
-                match self.matcher.fuzzy_match(&alias_kebab, input) {
-                    Some(score) if score > 0 => {
-                        suggestions.push((full_command.clone(), score + 5));
-                    }
-                    _ => {}
-                }
+                Self::push_fuzzy_match(
+                    &mut suggestions,
+                    &full_command,
+                    self.matcher.fuzzy_match(&alias_kebab, input),
+                    5,
+                );
             }
         }
 
@@ -320,6 +319,18 @@ impl CommandSearcher {
         suggestions.truncate(max_results);
 
         suggestions
+    }
+
+    fn push_fuzzy_match(
+        suggestions: &mut Vec<(String, i64)>,
+        command: &str,
+        score: Option<i64>,
+        bonus: i64,
+    ) {
+        let Some(score) = score.filter(|score| *score > 0) else {
+            return;
+        };
+        suggestions.push((command.to_string(), score + bonus));
     }
 }
 

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -192,40 +192,39 @@ impl ShortcutResolver {
         candidates
     }
 
-    fn resolve_from_candidates(mut candidates: Vec<ResolvedShortcut>) -> ResolutionResult {
+    fn resolve_from_candidates(candidates: Vec<ResolvedShortcut>) -> ResolutionResult {
         match candidates.len() {
             0 => ResolutionResult::NotFound,
-            1 => candidates.into_iter().next().map_or_else(
-                || {
-                    // This should never happen given len() == 1, but handle defensively
-                    // ast-grep-ignore: no-println
-                    eprintln!("Warning: Expected exactly one candidate but found none");
-                    ResolutionResult::NotFound
-                },
-                |candidate| ResolutionResult::Resolved(Box::new(candidate)),
-            ),
-            _ => {
-                candidates.sort_by(|a, b| b.confidence.cmp(&a.confidence));
-
-                let has_high_confidence = candidates[0].confidence >= 85
-                    && (candidates.len() == 1
-                        || candidates[0].confidence > candidates[1].confidence + 10);
-
-                if !has_high_confidence {
-                    return ResolutionResult::Ambiguous(candidates);
-                }
-
-                candidates.into_iter().next().map_or_else(
-                    || {
-                        // This should never happen given we just accessed candidates[0], but handle defensively
-                        // ast-grep-ignore: no-println
-                        eprintln!("Warning: Expected candidates after sorting but found none");
-                        ResolutionResult::NotFound
-                    },
-                    |candidate| ResolutionResult::Resolved(Box::new(candidate)),
-                )
-            }
+            1 => Self::resolve_single_candidate(candidates),
+            _ => Self::resolve_best_candidate(candidates),
         }
+    }
+
+    fn resolve_single_candidate(candidates: Vec<ResolvedShortcut>) -> ResolutionResult {
+        candidates.into_iter().next().map_or_else(
+            || {
+                // This should never happen given len() == 1, but handle defensively
+                // ast-grep-ignore: no-println
+                eprintln!("Warning: Expected exactly one candidate but found none");
+                ResolutionResult::NotFound
+            },
+            |candidate| ResolutionResult::Resolved(Box::new(candidate)),
+        )
+    }
+
+    fn resolve_best_candidate(mut candidates: Vec<ResolvedShortcut>) -> ResolutionResult {
+        candidates.sort_by(|a, b| b.confidence.cmp(&a.confidence));
+
+        if !Self::has_high_confidence_candidate(&candidates) {
+            return ResolutionResult::Ambiguous(candidates);
+        }
+
+        Self::resolve_single_candidate(candidates)
+    }
+
+    fn has_high_confidence_candidate(candidates: &[ResolvedShortcut]) -> bool {
+        candidates[0].confidence >= 85
+            && (candidates.len() == 1 || candidates[0].confidence > candidates[1].confidence + 10)
     }
 
     #[must_use]

--- a/src/spec/mod.rs
+++ b/src/spec/mod.rs
@@ -44,6 +44,8 @@ pub const fn http_methods_iter(item: &PathItem) -> HttpMethodsIter<'_> {
 /// Maximum depth for resolving parameter references to prevent stack overflow
 pub const MAX_REFERENCE_DEPTH: usize = 10;
 
+const REFERENCE_PLACEHOLDER: &str = "{reference}";
+
 /// Resolves a parameter reference to its actual parameter definition
 ///
 /// # Arguments
@@ -121,46 +123,29 @@ fn resolve_schema_reference_with_visited(
     visited: &mut HashSet<String>,
     depth: usize,
 ) -> Result<openapiv3::Schema, Error> {
-    // Check depth limit
-    if depth >= MAX_REFERENCE_DEPTH {
-        return Err(Error::validation_error(format!(
-            "Maximum reference depth ({MAX_REFERENCE_DEPTH}) exceeded while resolving '{reference}'"
-        )));
-    }
-
-    // Check for circular references
-    if !visited.insert(reference.to_string()) {
-        return Err(Error::validation_error(format!(
-            "Circular reference detected: '{reference}' is part of a reference cycle"
-        )));
-    }
-
-    // Parse the reference path
-    // Expected format: #/components/schemas/{schema_name}
-    if !reference.starts_with("#/components/schemas/") {
-        return Err(Error::validation_error(format!(
+    let resolution = prepare_component_reference_resolution(
+        spec,
+        reference,
+        visited,
+        depth,
+        "#/components/schemas/",
+        format!(
             "Invalid schema reference format: '{reference}'. Expected format: #/components/schemas/{{name}}"
-        )));
-    }
+        ),
+        "Cannot resolve schema reference: OpenAPI spec has no components section",
+    )?;
 
-    let schema_name = reference
-        .strip_prefix("#/components/schemas/")
+    let schema_ref = resolution
+        .components
+        .schemas
+        .get(&resolution.name)
         .ok_or_else(|| {
-            Error::validation_error(format!("Invalid schema reference: '{reference}'"))
+            Error::validation_error(format!(
+                "Schema '{}' not found in components",
+                resolution.name
+            ))
         })?;
 
-    // Look up the schema in components
-    let components = spec.components.as_ref().ok_or_else(|| {
-        Error::validation_error(
-            "Cannot resolve schema reference: OpenAPI spec has no components section".to_string(),
-        )
-    })?;
-
-    let schema_ref = components.schemas.get(schema_name).ok_or_else(|| {
-        Error::validation_error(format!("Schema '{schema_name}' not found in components"))
-    })?;
-
-    // Handle nested references (reference pointing to another reference)
     match schema_ref {
         ReferenceOr::Item(schema) => Ok(schema.clone()),
         ReferenceOr::Reference {
@@ -176,51 +161,81 @@ fn resolve_parameter_reference_with_visited(
     visited: &mut HashSet<String>,
     depth: usize,
 ) -> Result<Parameter, Error> {
-    // Check depth limit
-    if depth >= MAX_REFERENCE_DEPTH {
-        return Err(Error::validation_error(format!(
-            "Maximum reference depth ({MAX_REFERENCE_DEPTH}) exceeded while resolving '{reference}'"
-        )));
-    }
-
-    // Check for circular references
-    if !visited.insert(reference.to_string()) {
-        return Err(Error::validation_error(format!(
-            "Circular reference detected: '{reference}' is part of a reference cycle"
-        )));
-    }
-
-    // Parse the reference path
-    // Expected format: #/components/parameters/{parameter_name}
-    if !reference.starts_with("#/components/parameters/") {
-        return Err(Error::validation_error(format!(
+    let resolution = prepare_component_reference_resolution(
+        spec,
+        reference,
+        visited,
+        depth,
+        "#/components/parameters/",
+        format!(
             "Invalid parameter reference format: '{reference}'. Expected format: #/components/parameters/{{name}}"
-        )));
-    }
+        ),
+        "Cannot resolve parameter reference: OpenAPI spec has no components section",
+    )?;
 
-    let param_name = reference
-        .strip_prefix("#/components/parameters/")
+    let param_ref = resolution
+        .components
+        .parameters
+        .get(&resolution.name)
         .ok_or_else(|| {
-            Error::validation_error(format!("Invalid parameter reference: '{reference}'"))
+            Error::validation_error(format!(
+                "Parameter '{}' not found in components",
+                resolution.name
+            ))
         })?;
 
-    // Look up the parameter in components
-    let components = spec.components.as_ref().ok_or_else(|| {
-        Error::validation_error(
-            "Cannot resolve parameter reference: OpenAPI spec has no components section"
-                .to_string(),
-        )
-    })?;
-
-    let param_ref = components.parameters.get(param_name).ok_or_else(|| {
-        Error::validation_error(format!("Parameter '{param_name}' not found in components"))
-    })?;
-
-    // Handle nested references (reference pointing to another reference)
     match param_ref {
         ReferenceOr::Item(param) => Ok(param.clone()),
         ReferenceOr::Reference {
             reference: nested_ref,
         } => resolve_parameter_reference_with_visited(spec, nested_ref, visited, depth + 1),
     }
+}
+
+struct ComponentReferenceResolution<'a> {
+    name: String,
+    components: &'a openapiv3::Components,
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn prepare_component_reference_resolution<'a>(
+    spec: &'a OpenAPI,
+    reference: &str,
+    visited: &mut HashSet<String>,
+    depth: usize,
+    prefix: &str,
+    invalid_format_message: String,
+    missing_components_message: &str,
+) -> Result<ComponentReferenceResolution<'a>, Error> {
+    if depth >= MAX_REFERENCE_DEPTH {
+        return Err(Error::validation_error(format!(
+            "Maximum reference depth ({MAX_REFERENCE_DEPTH}) exceeded while resolving '{reference}'"
+        )));
+    }
+
+    if !visited.insert(reference.to_string()) {
+        return Err(Error::validation_error(format!(
+            "Circular reference detected: '{reference}' is part of a reference cycle"
+        )));
+    }
+
+    if !reference.starts_with(prefix) {
+        return Err(Error::validation_error(
+            invalid_format_message.replace(REFERENCE_PLACEHOLDER, reference),
+        ));
+    }
+
+    let name = reference
+        .strip_prefix(prefix)
+        .ok_or_else(|| Error::validation_error(format!("Invalid reference: '{reference}'")))?;
+
+    let components = spec
+        .components
+        .as_ref()
+        .ok_or_else(|| Error::validation_error(missing_components_message.to_string()))?;
+
+    Ok(ComponentReferenceResolution {
+        name: name.to_string(),
+        components,
+    })
 }

--- a/src/spec/parser.rs
+++ b/src/spec/parser.rs
@@ -260,7 +260,7 @@ fn parse_with_oas3_direct_with_original(
     Ok(spec)
 }
 
-/// Restore security schemes to the OpenAPI spec if they were lost during conversion
+/// Restore security schemes to the `OpenAPI` spec if they were lost during conversion
 #[cfg(feature = "openapi31")]
 fn restore_security_schemes(
     spec: &mut OpenAPI,
@@ -269,23 +269,22 @@ fn restore_security_schemes(
     >,
 ) {
     if let Some(schemes) = security_schemes {
-        // Ensure components exists and add the security schemes
-        match spec.components {
-            Some(ref mut components) => {
+        spec.components = Some(match spec.components.take() {
+            Some(mut components) => {
                 components.security_schemes = schemes;
+                components
             }
-            None => {
-                let mut components = openapiv3::Components::default();
-                components.security_schemes = schemes;
-                spec.components = Some(components);
-            }
-        }
+            None => openapiv3::Components {
+                security_schemes: schemes,
+                ..Default::default()
+            },
+        });
     }
 }
 
 /// Extract security schemes from YAML/JSON content before any processing
 ///
-/// This function is needed because the oas3 library's conversion from OpenAPI 3.1 to 3.0
+/// This function is needed because the `oas3` library's conversion from `OpenAPI` 3.1 to 3.0
 /// sometimes loses security scheme definitions. We extract them from the original content
 /// to restore them after conversion.
 #[cfg(feature = "openapi31")]

--- a/src/spec/transformer.rs
+++ b/src/spec/transformer.rs
@@ -277,61 +277,25 @@ impl SpecTransformer {
         operation: &Operation,
         global_security_requirements: &[String],
     ) -> Result<CachedCommand, Error> {
-        // Extract operation metadata
         let operation_id = operation
             .operation_id
             .clone()
             .unwrap_or_else(|| format!("{method}_{path}"));
 
-        // Use first tag as command namespace, or "default" if no tags
         let name = operation
             .tags
             .first()
             .cloned()
             .unwrap_or_else(|| constants::DEFAULT_GROUP.to_string());
 
-        // Transform parameters
-        let mut parameters = Vec::new();
-        for param_ref in &operation.parameters {
-            match param_ref {
-                ReferenceOr::Item(param) => {
-                    parameters.push(Self::transform_parameter(param));
-                }
-                ReferenceOr::Reference { reference } => {
-                    let param = Self::resolve_parameter_reference(spec, reference)?;
-                    parameters.push(Self::transform_parameter(&param));
-                }
-            }
-        }
-
-        // Transform request body
+        let parameters = Self::collect_operation_parameters(spec, &operation.parameters)?;
         let request_body = operation
             .request_body
             .as_ref()
             .and_then(Self::transform_request_body);
-
-        // Transform responses
-        let responses = operation
-            .responses
-            .responses
-            .iter()
-            .map(|(code, response_ref)| {
-                Self::transform_response(spec, code.to_string(), response_ref)
-            })
-            .collect();
-
-        // Extract security requirements - use operation-level if defined, else global
-        let security_requirements = operation.security.as_ref().map_or_else(
-            || global_security_requirements.to_vec(),
-            |security_reqs| {
-                security_reqs
-                    .iter()
-                    .flat_map(|security_req| security_req.keys().cloned())
-                    .collect()
-            },
-        );
-
-        // Generate examples for this command
+        let responses = Self::collect_operation_responses(spec, &operation.responses.responses);
+        let security_requirements =
+            Self::resolve_security_requirements(operation, global_security_requirements);
         let examples = Self::generate_command_examples(
             &name,
             &operation_id,
@@ -340,8 +304,6 @@ impl SpecTransformer {
             &parameters,
             request_body.as_ref(),
         );
-
-        // Detect pagination strategy from the spec.
         let pagination = Self::detect_pagination(operation, spec);
 
         Ok(CachedCommand {
@@ -368,6 +330,49 @@ impl SpecTransformer {
             hidden: false,
             pagination,
         })
+    }
+
+    fn collect_operation_parameters(
+        spec: &OpenAPI,
+        parameters: &[ReferenceOr<Parameter>],
+    ) -> Result<Vec<CachedParameter>, Error> {
+        parameters
+            .iter()
+            .map(|param_ref| match param_ref {
+                ReferenceOr::Item(param) => Ok(Self::transform_parameter(param)),
+                ReferenceOr::Reference { reference } => {
+                    let param = Self::resolve_parameter_reference(spec, reference)?;
+                    Ok(Self::transform_parameter(&param))
+                }
+            })
+            .collect()
+    }
+
+    fn collect_operation_responses(
+        spec: &OpenAPI,
+        responses: &indexmap::IndexMap<openapiv3::StatusCode, ReferenceOr<openapiv3::Response>>,
+    ) -> Vec<CachedResponse> {
+        responses
+            .iter()
+            .map(|(code, response_ref)| {
+                Self::transform_response(spec, code.to_string(), response_ref)
+            })
+            .collect()
+    }
+
+    fn resolve_security_requirements(
+        operation: &Operation,
+        global_security_requirements: &[String],
+    ) -> Vec<String> {
+        operation.security.as_ref().map_or_else(
+            || global_security_requirements.to_vec(),
+            |security_reqs| {
+                security_reqs
+                    .iter()
+                    .flat_map(|security_req| security_req.keys().cloned())
+                    .collect()
+            },
+        )
     }
 
     /// Transforms a parameter into cached format
@@ -628,28 +633,10 @@ impl SpecTransformer {
     ) -> Option<CachedRequestBody> {
         match request_body {
             ReferenceOr::Item(body) => {
-                // Prefer JSON content if available
-                let content_type = if body.content.contains_key(constants::CONTENT_TYPE_JSON) {
-                    constants::CONTENT_TYPE_JSON
-                } else {
-                    body.content.keys().next()?
-                };
-
-                // Extract schema and example from the content
+                let content_type = Self::preferred_request_body_content_type(body)?;
                 let media_type = body.content.get(content_type)?;
-                let schema = media_type
-                    .schema
-                    .as_ref()
-                    .and_then(|schema_ref| match schema_ref {
-                        ReferenceOr::Item(schema) => serde_json::to_string(schema).ok(),
-                        ReferenceOr::Reference { .. } => None,
-                    })
-                    .unwrap_or_else(|| "{}".to_string());
-
-                let example = media_type
-                    .example
-                    .as_ref()
-                    .map(|ex| serde_json::to_string(ex).unwrap_or_else(|_| ex.to_string()));
+                let schema = Self::request_body_schema(media_type);
+                let example = Self::request_body_example(media_type);
 
                 Some(CachedRequestBody {
                     content_type: content_type.to_string(),
@@ -661,6 +648,32 @@ impl SpecTransformer {
             }
             ReferenceOr::Reference { .. } => None, // Skip references for now
         }
+    }
+
+    fn preferred_request_body_content_type(body: &RequestBody) -> Option<&str> {
+        if body.content.contains_key(constants::CONTENT_TYPE_JSON) {
+            Some(constants::CONTENT_TYPE_JSON)
+        } else {
+            body.content.keys().next().map(String::as_str)
+        }
+    }
+
+    fn request_body_schema(media_type: &openapiv3::MediaType) -> String {
+        media_type
+            .schema
+            .as_ref()
+            .and_then(|schema_ref| match schema_ref {
+                ReferenceOr::Item(schema) => serde_json::to_string(schema).ok(),
+                ReferenceOr::Reference { .. } => None,
+            })
+            .unwrap_or_else(|| "{}".to_string())
+    }
+
+    fn request_body_example(media_type: &openapiv3::MediaType) -> Option<String> {
+        media_type
+            .example
+            .as_ref()
+            .map(|ex| serde_json::to_string(ex).unwrap_or_else(|_| ex.to_string()))
     }
 
     /// Extracts and transforms security schemes from the `OpenAPI` spec
@@ -985,45 +998,54 @@ fn parse_aperture_pagination_extension(value: &serde_json::Value) -> Option<Pagi
     let strategy_str = obj.get("strategy")?.as_str()?;
 
     match strategy_str {
-        constants::PAGINATION_STRATEGY_CURSOR => {
-            let cursor_field = obj
-                .get("cursor_field")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let cursor_param = obj
-                .get("cursor_param")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            // Default cursor_param to the cursor_field name when not specified
-            let cursor_param = cursor_param.or_else(|| cursor_field.clone());
-            Some(PaginationInfo {
-                strategy: PaginationStrategy::Cursor,
-                cursor_field,
-                cursor_param,
-                ..Default::default()
-            })
-        }
-        constants::PAGINATION_STRATEGY_OFFSET => {
-            let page_param = obj
-                .get("page_param")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let limit_param = obj
-                .get("limit_param")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            Some(PaginationInfo {
-                strategy: PaginationStrategy::Offset,
-                page_param,
-                limit_param,
-                ..Default::default()
-            })
-        }
+        constants::PAGINATION_STRATEGY_CURSOR => Some(parse_cursor_pagination_extension(obj)),
+        constants::PAGINATION_STRATEGY_OFFSET => Some(parse_offset_pagination_extension(obj)),
         constants::PAGINATION_STRATEGY_LINK_HEADER => Some(PaginationInfo {
             strategy: PaginationStrategy::LinkHeader,
             ..Default::default()
         }),
         _ => None,
+    }
+}
+
+fn parse_cursor_pagination_extension(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> PaginationInfo {
+    let cursor_field = obj
+        .get("cursor_field")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let cursor_param = obj
+        .get("cursor_param")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .or_else(|| cursor_field.clone());
+
+    PaginationInfo {
+        strategy: PaginationStrategy::Cursor,
+        cursor_field,
+        cursor_param,
+        ..Default::default()
+    }
+}
+
+fn parse_offset_pagination_extension(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> PaginationInfo {
+    let page_param = obj
+        .get("page_param")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let limit_param = obj
+        .get("limit_param")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    PaginationInfo {
+        strategy: PaginationStrategy::Offset,
+        page_param,
+        limit_param,
+        ..Default::default()
     }
 }
 

--- a/src/spec/validator.rs
+++ b/src/spec/validator.rs
@@ -100,30 +100,80 @@ impl SpecValidator {
 
     /// Returns a human-readable reason for why a content type is not supported
     fn get_unsupported_content_type_reason(content_type: &str) -> &'static str {
-        match content_type {
-            // Binary file types
-            constants::CONTENT_TYPE_MULTIPART => "file uploads are not supported",
-            constants::CONTENT_TYPE_OCTET_STREAM => "binary data uploads are not supported",
-            ct if ct.starts_with(constants::CONTENT_TYPE_PREFIX_IMAGE) => {
-                "image uploads are not supported"
-            }
-            constants::CONTENT_TYPE_PDF => "PDF uploads are not supported",
-
-            // Alternative text formats
-            constants::CONTENT_TYPE_XML | constants::CONTENT_TYPE_TEXT_XML => {
-                "XML content is not supported"
-            }
-            constants::CONTENT_TYPE_FORM => "form-encoded data is not supported",
-            constants::CONTENT_TYPE_TEXT => "plain text content is not supported",
-            constants::CONTENT_TYPE_CSV => "CSV content is not supported",
-
-            // JSON-compatible formats
-            constants::CONTENT_TYPE_NDJSON => "newline-delimited JSON is not supported",
-            constants::CONTENT_TYPE_GRAPHQL => "GraphQL content is not supported",
-
-            // Generic fallback
-            _ => "is not supported",
+        if Self::is_multipart_content_type(content_type) {
+            return "file uploads are not supported";
         }
+        if Self::is_octet_stream_content_type(content_type) {
+            return "binary data uploads are not supported";
+        }
+        if Self::is_image_upload_content_type(content_type) {
+            return "image uploads are not supported";
+        }
+        if Self::is_pdf_content_type(content_type) {
+            return "PDF uploads are not supported";
+        }
+        if Self::is_xml_content_type(content_type) {
+            return "XML content is not supported";
+        }
+        if Self::is_form_content_type(content_type) {
+            return "form-encoded data is not supported";
+        }
+        if Self::is_text_content_type(content_type) {
+            return "plain text content is not supported";
+        }
+        if Self::is_csv_content_type(content_type) {
+            return "CSV content is not supported";
+        }
+        if Self::is_ndjson_content_type(content_type) {
+            return "newline-delimited JSON is not supported";
+        }
+        if Self::is_graphql_content_type(content_type) {
+            return "GraphQL content is not supported";
+        }
+        "is not supported"
+    }
+
+    fn is_multipart_content_type(content_type: &str) -> bool {
+        content_type == constants::CONTENT_TYPE_MULTIPART
+    }
+
+    fn is_octet_stream_content_type(content_type: &str) -> bool {
+        content_type == constants::CONTENT_TYPE_OCTET_STREAM
+    }
+
+    fn is_image_upload_content_type(content_type: &str) -> bool {
+        content_type.starts_with(constants::CONTENT_TYPE_PREFIX_IMAGE)
+    }
+
+    fn is_pdf_content_type(content_type: &str) -> bool {
+        content_type == constants::CONTENT_TYPE_PDF
+    }
+
+    fn is_xml_content_type(content_type: &str) -> bool {
+        matches!(
+            content_type,
+            constants::CONTENT_TYPE_XML | constants::CONTENT_TYPE_TEXT_XML
+        )
+    }
+
+    fn is_form_content_type(content_type: &str) -> bool {
+        content_type == constants::CONTENT_TYPE_FORM
+    }
+
+    fn is_text_content_type(content_type: &str) -> bool {
+        content_type == constants::CONTENT_TYPE_TEXT
+    }
+
+    fn is_csv_content_type(content_type: &str) -> bool {
+        content_type == constants::CONTENT_TYPE_CSV
+    }
+
+    fn is_ndjson_content_type(content_type: &str) -> bool {
+        content_type == constants::CONTENT_TYPE_NDJSON
+    }
+
+    fn is_graphql_content_type(content_type: &str) -> bool {
+        content_type == constants::CONTENT_TYPE_GRAPHQL
     }
 
     /// Validates an `OpenAPI` specification for Aperture compatibility
@@ -260,14 +310,46 @@ impl SpecValidator {
         name: &str,
         scheme: &SecurityScheme,
     ) -> Result<(), Error> {
-        let (SecurityScheme::APIKey { extensions, .. } | SecurityScheme::HTTP { extensions, .. }) =
-            scheme
-        else {
+        let Some(extensions) = Self::aperture_secret_extensions(scheme) else {
             return Ok(());
         };
 
-        let Some(aperture_secret) = extensions.get(crate::constants::EXT_APERTURE_SECRET) else {
+        let Some(secret_obj) = Self::aperture_secret_object(name, extensions)? else {
             return Ok(());
+        };
+
+        let source =
+            Self::required_secret_string_field(name, secret_obj, crate::constants::EXT_KEY_SOURCE)?;
+        if source != crate::constants::SOURCE_ENV {
+            return Err(Error::validation_error(format!(
+                "Unsupported source '{source}' in x-aperture-secret for security scheme '{name}'. Only 'env' is supported."
+            )));
+        }
+
+        let env_name =
+            Self::required_secret_string_field(name, secret_obj, crate::constants::EXT_KEY_NAME)?;
+
+        Self::validate_env_var_name(name, env_name)
+    }
+
+    #[allow(clippy::missing_const_for_fn)]
+    fn aperture_secret_extensions(
+        scheme: &SecurityScheme,
+    ) -> Option<&indexmap::IndexMap<String, serde_json::Value>> {
+        match scheme {
+            SecurityScheme::APIKey { extensions, .. } | SecurityScheme::HTTP { extensions, .. } => {
+                Some(extensions)
+            }
+            SecurityScheme::OAuth2 { .. } | SecurityScheme::OpenIDConnect { .. } => None,
+        }
+    }
+
+    fn aperture_secret_object<'a>(
+        name: &str,
+        extensions: &'a indexmap::IndexMap<String, serde_json::Value>,
+    ) -> Result<Option<&'a serde_json::Map<String, serde_json::Value>>, Error> {
+        let Some(aperture_secret) = extensions.get(crate::constants::EXT_APERTURE_SECRET) else {
+            return Ok(None);
         };
 
         let secret_obj = aperture_secret.as_object().ok_or_else(|| {
@@ -276,41 +358,27 @@ impl SpecValidator {
             ))
         })?;
 
-        let source = secret_obj
-            .get(crate::constants::EXT_KEY_SOURCE)
+        Ok(Some(secret_obj))
+    }
+
+    fn required_secret_string_field<'a>(
+        scheme_name: &str,
+        secret_obj: &'a serde_json::Map<String, serde_json::Value>,
+        field_name: &str,
+    ) -> Result<&'a str, Error> {
+        secret_obj
+            .get(field_name)
             .ok_or_else(|| {
                 Error::validation_error(format!(
-                    "Missing 'source' field in x-aperture-secret for security scheme '{name}'"
+                    "Missing '{field_name}' field in x-aperture-secret for security scheme '{scheme_name}'"
                 ))
             })?
             .as_str()
             .ok_or_else(|| {
                 Error::validation_error(format!(
-                    "Invalid 'source' field in x-aperture-secret for security scheme '{name}': must be a string"
+                    "Invalid '{field_name}' field in x-aperture-secret for security scheme '{scheme_name}': must be a string"
                 ))
-            })?;
-
-        if source != crate::constants::SOURCE_ENV {
-            return Err(Error::validation_error(format!(
-                "Unsupported source '{source}' in x-aperture-secret for security scheme '{name}'. Only 'env' is supported."
-            )));
-        }
-
-        let env_name = secret_obj
-            .get(crate::constants::EXT_KEY_NAME)
-            .ok_or_else(|| {
-                Error::validation_error(format!(
-                    "Missing 'name' field in x-aperture-secret for security scheme '{name}'"
-                ))
-            })?
-            .as_str()
-            .ok_or_else(|| {
-                Error::validation_error(format!(
-                    "Invalid 'name' field in x-aperture-secret for security scheme '{name}': must be a string"
-                ))
-            })?;
-
-        Self::validate_env_var_name(name, env_name)
+            })
     }
 
     fn validate_security_scheme(

--- a/tests/interactive_workflow_tests.rs
+++ b/tests/interactive_workflow_tests.rs
@@ -222,53 +222,7 @@ fn test_select_from_options_with_empty_input_continue() {
     let mut mock = MockInputOutputImpl::new();
     let options = vec![("option1".to_string(), "First option".to_string())];
 
-    mock.expect_println()
-        .with(eq("Choose:"))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_println()
-        .with(eq("  1: option1 - First option"))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    // First attempt - empty input
-    mock.expect_print()
-        .with(eq("Enter your choice (number or name): "))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_flush().times(1).returning(|| Ok(()));
-
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("\n".to_string()));
-
-    // Confirmation to continue
-    mock.expect_print()
-        .with(eq(
-            "Do you want to continue with the current operation? (y/n): ",
-        ))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_flush().times(1).returning(|| Ok(()));
-
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("y\n".to_string()));
-
-    // Second attempt - valid input after continuing
-    mock.expect_print()
-        .with(eq("Enter your choice (number or name): "))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_flush().times(1).returning(|| Ok(()));
-
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("1\n".to_string()));
+    expect_empty_selection_continue(&mut mock);
 
     let result = select_from_options_with_io("Choose:", &options, &mock);
     assert!(result.is_ok());
@@ -534,6 +488,66 @@ fn expect_invalid_selection_attempt(
             .times(1)
             .returning(|_| Ok(()));
     }
+}
+
+fn expect_empty_selection_continue(mock: &mut MockInputOutputImpl) {
+    expect_selection_prompt(mock);
+    expect_empty_selection_attempt(mock);
+    expect_continue_confirmation(mock);
+    expect_valid_selection_attempt(mock);
+}
+
+fn expect_selection_prompt(mock: &mut MockInputOutputImpl) {
+    mock.expect_println()
+        .with(eq("Choose:"))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_println()
+        .with(eq("  1: option1 - First option"))
+        .times(1)
+        .returning(|_| Ok(()));
+}
+
+fn expect_empty_selection_attempt(mock: &mut MockInputOutputImpl) {
+    mock.expect_print()
+        .with(eq("Enter your choice (number or name): "))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_flush().times(1).returning(|| Ok(()));
+
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(|_| Ok("\n".to_string()));
+}
+
+fn expect_continue_confirmation(mock: &mut MockInputOutputImpl) {
+    mock.expect_print()
+        .with(eq(
+            "Do you want to continue with the current operation? (y/n): ",
+        ))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_flush().times(1).returning(|| Ok(()));
+
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(|_| Ok("y\n".to_string()));
+}
+
+fn expect_valid_selection_attempt(mock: &mut MockInputOutputImpl) {
+    mock.expect_print()
+        .with(eq("Enter your choice (number or name): "))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_flush().times(1).returning(|| Ok(()));
+
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(|_| Ok("1\n".to_string()));
 }
 
 #[test]

--- a/tests/interactive_workflow_tests.rs
+++ b/tests/interactive_workflow_tests.rs
@@ -450,12 +450,39 @@ fn test_end_to_end_interactive_workflow() {
     assert!(confirmed.unwrap());
 }
 
+fn expect_invalid_selection_attempt(
+    mock: &mut MockInputOutputImpl,
+    attempt: usize,
+    input: &str,
+    should_print_retry_message: bool,
+) {
+    let input = input.to_string();
+
+    mock.expect_print()
+        .with(eq("Enter your choice (number or name): "))
+        .times(1)
+        .returning(|_| Ok(()));
+    mock.expect_flush().times(1).returning(|| Ok(()));
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(move |_| Ok(format!("{input}\n")));
+
+    if should_print_retry_message {
+        let expected = format!(
+            "Invalid selection. Please enter a number (1-1) or a valid name. (Attempt {attempt} of 3)"
+        );
+        mock.expect_println()
+            .with(eq(expected))
+            .times(1)
+            .returning(|_| Ok(()));
+    }
+}
+
 #[test]
 fn test_multiple_retry_attempts_until_max() {
     let mut mock = MockInputOutputImpl::new();
     let options = vec![("valid".to_string(), "Valid option".to_string())];
 
-    // Display options
     mock.expect_println()
         .with(eq("Choose:"))
         .times(1)
@@ -466,47 +493,9 @@ fn test_multiple_retry_attempts_until_max() {
         .times(1)
         .returning(|_| Ok(()));
 
-    // Attempt 1 - invalid
-    mock.expect_print()
-        .with(eq("Enter your choice (number or name): "))
-        .times(1)
-        .returning(|_| Ok(()));
-    mock.expect_flush().times(1).returning(|| Ok(()));
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("invalid1\n".to_string()));
-    mock.expect_println()
-        .with(eq(
-            "Invalid selection. Please enter a number (1-1) or a valid name. (Attempt 1 of 3)",
-        ))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    // Attempt 2 - invalid
-    mock.expect_print()
-        .with(eq("Enter your choice (number or name): "))
-        .times(1)
-        .returning(|_| Ok(()));
-    mock.expect_flush().times(1).returning(|| Ok(()));
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("invalid2\n".to_string()));
-    mock.expect_println()
-        .with(eq(
-            "Invalid selection. Please enter a number (1-1) or a valid name. (Attempt 2 of 3)",
-        ))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    // Attempt 3 - invalid (final attempt, no retry message)
-    mock.expect_print()
-        .with(eq("Enter your choice (number or name): "))
-        .times(1)
-        .returning(|_| Ok(()));
-    mock.expect_flush().times(1).returning(|| Ok(()));
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("invalid3\n".to_string()));
+    expect_invalid_selection_attempt(&mut mock, 1, "invalid1", true);
+    expect_invalid_selection_attempt(&mut mock, 2, "invalid2", true);
+    expect_invalid_selection_attempt(&mut mock, 3, "invalid3", false);
 
     let result = select_from_options_with_io("Choose:", &options, &mock);
     assert!(result.is_err());

--- a/tests/interactive_workflow_tests.rs
+++ b/tests/interactive_workflow_tests.rs
@@ -218,6 +218,64 @@ fn test_select_from_options_with_empty_input_and_cancellation() {
 }
 
 #[test]
+fn test_select_from_options_with_empty_input_continue() {
+    let mut mock = MockInputOutputImpl::new();
+    let options = vec![("option1".to_string(), "First option".to_string())];
+
+    mock.expect_println()
+        .with(eq("Choose:"))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_println()
+        .with(eq("  1: option1 - First option"))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    // First attempt - empty input
+    mock.expect_print()
+        .with(eq("Enter your choice (number or name): "))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_flush().times(1).returning(|| Ok(()));
+
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(|_| Ok("\n".to_string()));
+
+    // Confirmation to continue
+    mock.expect_print()
+        .with(eq(
+            "Do you want to continue with the current operation? (y/n): ",
+        ))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_flush().times(1).returning(|| Ok(()));
+
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(|_| Ok("y\n".to_string()));
+
+    // Second attempt - valid input after continuing
+    mock.expect_print()
+        .with(eq("Enter your choice (number or name): "))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_flush().times(1).returning(|| Ok(()));
+
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(|_| Ok("1\n".to_string()));
+
+    let result = select_from_options_with_io("Choose:", &options, &mock);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "option1");
+}
+
+#[test]
 fn test_select_from_options_with_invalid_input_retry() {
     let mut mock = MockInputOutputImpl::new();
     let options = vec![("option1".to_string(), "First option".to_string())];


### PR DESCRIPTION
## Summary
Reduce all `compl scan --threshold 12 . --jsonl` complexity violations by extracting focused helpers, flattening orchestration code, and simplifying validation/formatting routines.

## Validation
- `compl scan --threshold 12 . --jsonl`
- `cargo fmt --all`
- `cargo clippy`
- `cargo test`

## Notes
- The implementation was kept behavior-preserving; the refactors are mostly structural and supported by existing tests.
- Plan file: `/tmp/plans/aperture-complexity.md`
