### PR TITLE
refactor: reduce cyclomatic complexity hotspots

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1007,37 +1007,46 @@ fn extract_response_schema_from_response(
         return None;
     };
 
-    // Prefer application/json content type
-    let content_type = if response.content.contains_key(constants::CONTENT_TYPE_JSON) {
-        constants::CONTENT_TYPE_JSON
-    } else {
-        // Fall back to first available content type
-        response.content.keys().next().map(String::as_str)?
-    };
-
+    let content_type = select_response_content_type(response)?;
     let media_type = response.content.get(content_type)?;
-    let schema_ref = media_type.schema.as_ref()?;
-
-    // Resolve schema reference if necessary
-    let schema_value = match schema_ref {
-        ReferenceOr::Item(schema) => serde_json::to_value(schema).ok()?,
-        ReferenceOr::Reference { reference } => {
-            let resolved = resolve_schema_reference(spec, reference).ok()?;
-            serde_json::to_value(&resolved).ok()?
-        }
-    };
-
-    // Extract example if available
-    let example = media_type
-        .example
-        .as_ref()
-        .and_then(|ex| serde_json::to_value(ex).ok());
+    let schema_value = extract_schema_value(media_type, spec)?;
+    let example = extract_response_example(media_type);
 
     Some(ResponseSchemaInfo {
         content_type: content_type.to_string(),
         schema: schema_value,
         example,
     })
+}
+
+fn select_response_content_type(response: &openapiv3::Response) -> Option<&str> {
+    response
+        .content
+        .get(constants::CONTENT_TYPE_JSON)
+        .map(|_| constants::CONTENT_TYPE_JSON)
+        .or_else(|| response.content.keys().next().map(String::as_str))
+}
+
+fn extract_schema_value(
+    media_type: &openapiv3::MediaType,
+    spec: &OpenAPI,
+) -> Option<serde_json::Value> {
+    let schema_ref = media_type.schema.as_ref()?;
+
+    match schema_ref {
+        ReferenceOr::Item(schema) => serde_json::to_value(schema).ok(),
+        ReferenceOr::Reference { reference } => {
+            let resolved = resolve_schema_reference(spec, reference).ok()?;
+            serde_json::to_value(&resolved).ok()
+        }
+    }
+}
+
+fn extract_response_example(media_type: &openapiv3::MediaType) -> Option<serde_json::Value> {
+    media_type
+        .example
+        .as_ref()
+        .and_then(|ex| serde_json::to_value(ex).ok())
 }
 
 /// Extracts schema information from a parameter format

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -363,43 +363,18 @@ impl BatchProcessor {
             .as_deref()
             .unwrap_or(crate::constants::DEFAULT_OPERATION_NAME);
 
-        // Interpolate variables in args and body_file — if this fails the
-        // operation cannot proceed.
-        let interpolated_args = match interpolation::interpolate_args(&operation.args, store, op_id)
-        {
-            Ok(args) => args,
+        let exec_op = match Self::interpolate_batch_operation(operation, store, op_id) {
+            Ok(operation) => operation,
             Err(e) => {
-                return BatchOperationResult {
-                    operation: operation.clone(),
-                    success: false,
-                    error: Some(e.to_string()),
-                    response: None,
-                    duration: std::time::Duration::ZERO,
-                };
+                return Self::failed_batch_operation_result(
+                    operation.clone(),
+                    e.to_string(),
+                    None,
+                    std::time::Duration::ZERO,
+                );
             }
         };
 
-        let interpolated_body_file = match operation
-            .body_file
-            .as_deref()
-            .map(|p| interpolation::interpolate_string(p, store, op_id))
-            .transpose()
-        {
-            Ok(path) => path,
-            Err(e) => {
-                return BatchOperationResult {
-                    operation: operation.clone(),
-                    success: false,
-                    error: Some(e.to_string()),
-                    response: None,
-                    duration: std::time::Duration::ZERO,
-                };
-            }
-        };
-
-        let mut exec_op = operation.clone();
-        exec_op.args = interpolated_args;
-        exec_op.body_file = interpolated_body_file;
         let operation_start = std::time::Instant::now();
 
         // Suppress output and skip jq_filter: capture needs JSON text that
@@ -424,37 +399,70 @@ impl BatchProcessor {
             Ok(resp) => resp,
             Err(e) => {
                 Self::log_progress(show_progress, || format!("Operation '{op_id}' failed: {e}"));
-                return BatchOperationResult {
-                    operation: exec_op,
-                    success: false,
-                    error: Some(e.to_string()),
-                    response: None,
-                    duration,
-                };
+                return Self::failed_batch_operation_result(exec_op, e.to_string(), None, duration);
             }
         };
 
-        // Extract captures — failure is treated as an operation failure.
-        // Note: capture queries are on the original operation, not exec_op.
-        let capture_result = capture::extract_captures(operation, &response, store);
-        let Err(capture_err) = capture_result else {
-            Self::log_progress(show_progress, || format!("Operation '{op_id}' completed"));
-            return BatchOperationResult {
-                operation: exec_op,
-                success: true,
-                error: None,
-                response: Some(response),
-                duration,
-            };
-        };
+        match capture::extract_captures(operation, &response, store) {
+            Ok(()) => {
+                Self::log_progress(show_progress, || format!("Operation '{op_id}' completed"));
+                Self::successful_batch_operation_result(exec_op, response, duration)
+            }
+            Err(capture_err) => {
+                Self::log_progress(show_progress, || {
+                    format!("Operation '{op_id}' capture failed: {capture_err}")
+                });
+                Self::failed_batch_operation_result(
+                    exec_op,
+                    capture_err.to_string(),
+                    Some(response),
+                    duration,
+                )
+            }
+        }
+    }
 
-        Self::log_progress(show_progress, || {
-            format!("Operation '{op_id}' capture failed: {capture_err}")
-        });
+    fn interpolate_batch_operation(
+        operation: &BatchOperation,
+        store: &interpolation::VariableStore,
+        op_id: &str,
+    ) -> Result<BatchOperation, Error> {
+        let mut exec_op = operation.clone();
+        exec_op.args = interpolation::interpolate_args(&operation.args, store, op_id)?;
+        exec_op.body_file = operation
+            .body_file
+            .as_deref()
+            .map(|path| interpolation::interpolate_string(path, store, op_id))
+            .transpose()?;
+        Ok(exec_op)
+    }
+
+    #[allow(clippy::missing_const_for_fn)]
+    fn failed_batch_operation_result(
+        operation: BatchOperation,
+        error: String,
+        response: Option<String>,
+        duration: std::time::Duration,
+    ) -> BatchOperationResult {
         BatchOperationResult {
-            operation: exec_op,
+            operation,
             success: false,
-            error: Some(capture_err.to_string()),
+            error: Some(error),
+            response,
+            duration,
+        }
+    }
+
+    #[allow(clippy::missing_const_for_fn)]
+    fn successful_batch_operation_result(
+        operation: BatchOperation,
+        response: String,
+        duration: std::time::Duration,
+    ) -> BatchOperationResult {
+        BatchOperationResult {
+            operation,
+            success: true,
+            error: None,
             response: Some(response),
             duration,
         }
@@ -811,35 +819,24 @@ fn build_batch_retry_context(
     operation: &BatchOperation,
     global_config: Option<&GlobalConfig>,
 ) -> Result<Option<RetryContext>, Error> {
-    // Get retry defaults from global config
     let defaults = global_config.map(|c| &c.retry_defaults);
-
-    // Determine max_attempts: operation > global config > 0 (disabled)
     let max_attempts = operation
         .retry
         .or_else(|| defaults.map(|d| d.max_attempts))
         .unwrap_or(0);
 
-    // If retries are disabled, return None
     if max_attempts == 0 {
         return Ok(None);
     }
 
-    // Determine initial_delay_ms: operation > global config > 500ms default
-    // Truncation is safe: delay values in practice are well under u64::MAX milliseconds
-    let initial_delay_ms = if let Some(ref delay_str) = operation.retry_delay {
-        parse_duration(delay_str)?.as_millis() as u64
-    } else {
-        defaults.map_or(500, |d| d.initial_delay_ms)
-    };
-
-    // Determine max_delay_ms: operation > global config > 30000ms default
-    // Truncation is safe: delay values in practice are well under u64::MAX milliseconds
-    let max_delay_ms = if let Some(ref delay_str) = operation.retry_max_delay {
-        parse_duration(delay_str)?.as_millis() as u64
-    } else {
-        defaults.map_or(30_000, |d| d.max_delay_ms)
-    };
+    let initial_delay_ms = resolve_retry_delay_ms(
+        operation.retry_delay.as_deref(),
+        defaults.map_or(500, |d| d.initial_delay_ms),
+    )?;
+    let max_delay_ms = resolve_retry_delay_ms(
+        operation.retry_max_delay.as_deref(),
+        defaults.map_or(30_000, |d| d.max_delay_ms),
+    )?;
 
     Ok(Some(RetryContext {
         max_attempts,
@@ -849,6 +846,14 @@ fn build_batch_retry_context(
         method: None,               // Will be determined in executor
         has_idempotency_key: false, // Batch operations don't support idempotency keys yet
     }))
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn resolve_retry_delay_ms(delay: Option<&str>, default_ms: u64) -> Result<u64, Error> {
+    match delay {
+        Some(delay_str) => Ok(parse_duration(delay_str)?.as_millis() as u64),
+        None => Ok(default_ms),
+    }
 }
 
 #[cfg(test)]
@@ -945,5 +950,67 @@ operations:
         let processor = BatchProcessor::new(config);
         assert_eq!(processor.semaphore.available_permits(), 10);
         assert!(processor.rate_limiter.is_some());
+    }
+
+    #[test]
+    fn test_build_batch_retry_context_prefers_operation_values() {
+        let operation = BatchOperation {
+            retry: Some(3),
+            retry_delay: Some("2s".to_string()),
+            retry_max_delay: Some("5s".to_string()),
+            force_retry: true,
+            ..Default::default()
+        };
+
+        let mut global_config = GlobalConfig::default();
+        global_config.retry_defaults.max_attempts = 7;
+        global_config.retry_defaults.initial_delay_ms = 1_000;
+        global_config.retry_defaults.max_delay_ms = 10_000;
+
+        let retry_context = build_batch_retry_context(&operation, Some(&global_config))
+            .expect("retry context should build")
+            .expect("retry should be enabled");
+
+        assert_eq!(retry_context.max_attempts, 3);
+        assert_eq!(retry_context.initial_delay_ms, 2_000);
+        assert_eq!(retry_context.max_delay_ms, 5_000);
+        assert!(retry_context.force_retry);
+        assert!(!retry_context.has_idempotency_key);
+    }
+
+    #[test]
+    fn test_build_batch_retry_context_uses_global_defaults() {
+        let operation = BatchOperation {
+            retry: None,
+            retry_delay: None,
+            retry_max_delay: None,
+            force_retry: false,
+            ..Default::default()
+        };
+
+        let mut global_config = GlobalConfig::default();
+        global_config.retry_defaults.max_attempts = 4;
+        global_config.retry_defaults.initial_delay_ms = 750;
+        global_config.retry_defaults.max_delay_ms = 5_500;
+
+        let retry_context = build_batch_retry_context(&operation, Some(&global_config))
+            .expect("retry context should build")
+            .expect("retry should be enabled");
+
+        assert_eq!(retry_context.max_attempts, 4);
+        assert_eq!(retry_context.initial_delay_ms, 750);
+        assert_eq!(retry_context.max_delay_ms, 5_500);
+        assert!(!retry_context.force_retry);
+        assert!(!retry_context.has_idempotency_key);
+    }
+
+    #[test]
+    fn test_build_batch_retry_context_disables_when_attempts_are_zero() {
+        let operation = BatchOperation::default();
+        let global_config = GlobalConfig::default();
+
+        assert!(build_batch_retry_context(&operation, Some(&global_config))
+            .expect("retry context should build")
+            .is_none());
     }
 }

--- a/src/cli/translate.rs
+++ b/src/cli/translate.rs
@@ -341,30 +341,20 @@ fn build_retry_context(
     global_config: Option<&GlobalConfig>,
 ) -> Result<Option<RetryContext>, Error> {
     let defaults = global_config.map(|c| &c.retry_defaults);
-
-    let max_attempts = cli
-        .retry
-        .or_else(|| defaults.map(|d| d.max_attempts))
-        .unwrap_or(0);
+    let max_attempts = resolve_retry_attempts(cli.retry, defaults.map(|d| d.max_attempts));
 
     if max_attempts == 0 {
         return Ok(None);
     }
 
-    // Truncation is safe: delay values in practice are well under u64::MAX milliseconds
-    let initial_delay_ms = if let Some(ref delay_str) = cli.retry_delay {
-        parse_duration(delay_str)?.as_millis() as u64
-    } else {
-        defaults.map_or(500, |d| d.initial_delay_ms)
-    };
-
-    let max_delay_ms = if let Some(ref delay_str) = cli.retry_max_delay {
-        parse_duration(delay_str)?.as_millis() as u64
-    } else {
-        defaults.map_or(30_000, |d| d.max_delay_ms)
-    };
-
-    let has_idempotency_key = cli.idempotency_key.is_some();
+    let initial_delay_ms = resolve_retry_delay_ms(
+        cli.retry_delay.as_deref(),
+        defaults.map_or(500, |d| d.initial_delay_ms),
+    )?;
+    let max_delay_ms = resolve_retry_delay_ms(
+        cli.retry_max_delay.as_deref(),
+        defaults.map_or(30_000, |d| d.max_delay_ms),
+    )?;
 
     Ok(Some(RetryContext {
         max_attempts,
@@ -372,6 +362,18 @@ fn build_retry_context(
         max_delay_ms,
         force_retry: cli.force_retry,
         method: None, // Determined by executor at execution time
-        has_idempotency_key,
+        has_idempotency_key: cli.idempotency_key.is_some(),
     }))
+}
+
+fn resolve_retry_attempts(explicit: Option<u32>, default: Option<u32>) -> u32 {
+    explicit.or(default).unwrap_or(0)
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn resolve_retry_delay_ms(delay: Option<&str>, default_ms: u64) -> Result<u64, Error> {
+    match delay {
+        Some(delay_str) => Ok(parse_duration(delay_str)?.as_millis() as u64),
+        None => Ok(default_ms),
+    }
 }

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -1,5 +1,6 @@
 use crate::cache::fingerprint::{compute_content_hash, get_file_mtime_secs};
 use crate::cache::metadata::CacheMetadataManager;
+use crate::cache::models::CachedSecurityScheme;
 use crate::config::context_name::ApiContextName;
 use crate::config::models::{ApertureSecret, ApiConfig, GlobalConfig, SecretSource};
 use crate::config::url_resolver::BaseUrlResolver;
@@ -1558,43 +1559,71 @@ impl<F: FileSystem> ConfigManager<F> {
             .security_schemes
             .values()
             .map(|scheme| {
-                let mut description = format!("{} ({})", scheme.scheme_type, scheme.name);
-
-                // Add type-specific details
-                match scheme.scheme_type.as_str() {
-                    constants::AUTH_SCHEME_APIKEY => {
-                        if let (Some(location), Some(param)) =
-                            (&scheme.location, &scheme.parameter_name)
-                        {
-                            description = format!("{description} - {location} parameter: {param}");
-                        }
-                    }
-                    "http" => {
-                        if let Some(http_scheme) = &scheme.scheme {
-                            description = format!("{description} - {http_scheme} authentication");
-                        }
-                    }
-                    _ => {}
-                }
-
-                // Show current configuration status - use match to avoid nested if
-                description = match (
-                    current_secrets.contains_key(&scheme.name),
-                    &scheme.aperture_secret,
-                ) {
-                    (true, _) => format!("{description} [CONFIGURED]"),
-                    (false, Some(_)) => format!("{description} [x-aperture-secret]"),
-                    (false, None) => format!("{description} [NOT CONFIGURED]"),
-                };
-
-                // Add OpenAPI description if available
-                if let Some(openapi_desc) = &scheme.description {
-                    description = format!("{description} - {openapi_desc}");
-                }
-
-                (scheme.name.clone(), description)
+                (
+                    scheme.name.clone(),
+                    Self::describe_security_scheme_option(scheme, current_secrets),
+                )
             })
             .collect()
+    }
+
+    fn describe_security_scheme_option(
+        scheme: &CachedSecurityScheme,
+        current_secrets: &std::collections::HashMap<String, ApertureSecret>,
+    ) -> String {
+        let description = Self::format_security_scheme_base_description(scheme);
+        let description = Self::apply_security_scheme_type_details(&description, scheme);
+        let description = Self::apply_security_scheme_status(&description, scheme, current_secrets);
+        Self::append_security_scheme_description(&description, scheme)
+    }
+
+    fn format_security_scheme_base_description(scheme: &CachedSecurityScheme) -> String {
+        format!("{} ({})", scheme.scheme_type, scheme.name)
+    }
+
+    fn apply_security_scheme_type_details(
+        description: &str,
+        scheme: &CachedSecurityScheme,
+    ) -> String {
+        match scheme.scheme_type.as_str() {
+            constants::AUTH_SCHEME_APIKEY => {
+                if let (Some(location), Some(param)) = (&scheme.location, &scheme.parameter_name) {
+                    format!("{description} - {location} parameter: {param}")
+                } else {
+                    description.to_owned()
+                }
+            }
+            "http" => scheme.scheme.as_ref().map_or_else(
+                || description.to_owned(),
+                |http_scheme| format!("{description} - {http_scheme} authentication"),
+            ),
+            _ => description.to_owned(),
+        }
+    }
+
+    fn apply_security_scheme_status(
+        description: &str,
+        scheme: &CachedSecurityScheme,
+        current_secrets: &std::collections::HashMap<String, ApertureSecret>,
+    ) -> String {
+        match (
+            current_secrets.contains_key(&scheme.name),
+            &scheme.aperture_secret,
+        ) {
+            (true, _) => format!("{description} [CONFIGURED]"),
+            (false, Some(_)) => format!("{description} [x-aperture-secret]"),
+            (false, None) => format!("{description} [NOT CONFIGURED]"),
+        }
+    }
+
+    fn append_security_scheme_description(
+        description: &str,
+        scheme: &CachedSecurityScheme,
+    ) -> String {
+        scheme.description.as_ref().map_or_else(
+            || description.to_owned(),
+            |openapi_desc| format!("{description} - {openapi_desc}"),
+        )
     }
 
     /// Runs the interactive configuration loop

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -1021,11 +1021,59 @@ struct PreparedExecution<'a> {
     cache_config: Option<&'a CacheConfig>,
 }
 
+struct PreparedRequest<'a> {
+    operation: &'a CachedCommand,
+    method: Method,
+    url: String,
+    client: reqwest::Client,
+    headers: HeaderMap,
+    headers_clone: HeaderMap,
+    body: Option<String>,
+}
+
+struct PreparedRuntimeContext<'a> {
+    cache_context: Option<(CacheKey, ResponseCache)>,
+    retry_ctx: Option<RetryContext>,
+    secret_ctx: logging::SecretContext,
+    cache_config: Option<&'a CacheConfig>,
+}
+
 fn prepare_execution<'a>(
     spec: &'a CachedSpec,
     call: crate::invocation::OperationCall,
     ctx: &'a crate::invocation::ExecutionContext,
 ) -> Result<PreparedExecution<'a>, Error> {
+    let request = prepare_request(spec, call, ctx)?;
+    let runtime = prepare_runtime_context(
+        spec,
+        request.operation,
+        &request.method,
+        &request.url,
+        &request.headers_clone,
+        request.body.as_deref(),
+        ctx,
+    )?;
+
+    Ok(PreparedExecution {
+        operation: request.operation,
+        method: request.method,
+        url: request.url,
+        client: request.client,
+        headers: request.headers,
+        headers_clone: request.headers_clone,
+        cache_context: runtime.cache_context,
+        retry_ctx: runtime.retry_ctx,
+        secret_ctx: runtime.secret_ctx,
+        body: request.body,
+        cache_config: runtime.cache_config,
+    })
+}
+
+fn prepare_request<'a>(
+    spec: &'a CachedSpec,
+    call: crate::invocation::OperationCall,
+    ctx: &'a crate::invocation::ExecutionContext,
+) -> Result<PreparedRequest<'a>, Error> {
     let operation = find_operation_by_id(spec, &call.operation_id)?;
     let resolver = resolve_base_url_resolver(spec, ctx.global_config.as_ref());
     let base_url =
@@ -1049,14 +1097,35 @@ fn prepare_execution<'a>(
     let method = Method::from_str(&operation.method)
         .map_err(|_| Error::invalid_http_method(&operation.method))?;
     let headers_clone = headers.clone();
+
+    Ok(PreparedRequest {
+        operation,
+        method,
+        url,
+        client,
+        headers,
+        headers_clone,
+        body: call.body,
+    })
+}
+
+fn prepare_runtime_context<'a>(
+    spec: &'a CachedSpec,
+    operation: &'a CachedCommand,
+    method: &Method,
+    url: &str,
+    headers: &HeaderMap,
+    body: Option<&str>,
+    ctx: &'a crate::invocation::ExecutionContext,
+) -> Result<PreparedRuntimeContext<'a>, Error> {
     let cache_context = prepare_cache_context(
         ctx.cache_config.as_ref(),
         &spec.name,
         &operation.operation_id,
-        &method,
-        &url,
-        &headers_clone,
-        call.body.as_deref(),
+        method,
+        url,
+        headers,
+        body,
     )?;
     let retry_ctx = ctx.retry_context.clone().map(|mut rc| {
         rc.method = Some(method.to_string());
@@ -1065,17 +1134,10 @@ fn prepare_execution<'a>(
     let secret_ctx =
         logging::SecretContext::from_spec_and_config(spec, &spec.name, ctx.global_config.as_ref());
 
-    Ok(PreparedExecution {
-        operation,
-        method,
-        url,
-        client,
-        headers,
-        headers_clone,
+    Ok(PreparedRuntimeContext {
         cache_context,
         retry_ctx,
         secret_ctx,
-        body: call.body,
         cache_config: ctx.cache_config.as_ref(),
     })
 }
@@ -1240,25 +1302,14 @@ fn apply_jq_filter_value(json_value: Value, filter: &str) -> Result<String, Erro
     let loader = Loader::new(defs);
     let arena = Arena::default();
 
-    let modules = match loader.load(&arena, program) {
-        Ok(modules) => modules,
-        Err(errs) => {
-            return Err(Error::jq_filter_error(
-                filter,
-                format!("Parse error: {errs:?}"),
-            ));
-        }
-    };
+    let modules = loader
+        .load(&arena, program)
+        .map_err(|errs| Error::jq_filter_error(filter, format!("Parse error: {errs:?}")))?;
 
-    let filter_fn = match Compiler::default().with_funs(funs).compile(modules) {
-        Ok(filter) => filter,
-        Err(errs) => {
-            return Err(Error::jq_filter_error(
-                filter,
-                format!("Compilation error: {errs:?}"),
-            ));
-        }
-    };
+    let filter_fn = Compiler::default()
+        .with_funs(funs)
+        .compile(modules)
+        .map_err(|errs| Error::jq_filter_error(filter, format!("Compilation error: {errs:?}")))?;
 
     let jaq_value = Val::from(json_value);
     let inputs = RcIter::new(core::iter::empty());
@@ -1266,19 +1317,22 @@ fn apply_jq_filter_value(json_value: Value, filter: &str) -> Result<String, Erro
     let output = filter_fn.run((ctx, jaq_value));
     let results: Result<Vec<Val>, _> = output.collect();
 
+    format_jaq_results(results, filter)
+}
+
+#[cfg(feature = "jq")]
+fn format_jaq_results<E: std::fmt::Display>(
+    results: Result<Vec<Val>, E>,
+    filter: &str,
+) -> Result<String, Error> {
     match results {
+        Ok(vals) if vals.is_empty() => Ok(constants::NULL_VALUE.to_string()),
+        Ok(vals) if vals.len() == 1 => {
+            let json_val = serde_json::Value::from(vals[0].clone());
+            serde_json::to_string_pretty(&json_val)
+                .map_err(|e| Error::serialization_error(format!("Failed to serialize result: {e}")))
+        }
         Ok(vals) => {
-            if vals.is_empty() {
-                return Ok(constants::NULL_VALUE.to_string());
-            }
-
-            if vals.len() == 1 {
-                let json_val = serde_json::Value::from(vals[0].clone());
-                return serde_json::to_string_pretty(&json_val).map_err(|e| {
-                    Error::serialization_error(format!("Failed to serialize result: {e}"))
-                });
-            }
-
             let json_vals: Vec<Value> = vals.into_iter().map(serde_json::Value::from).collect();
             let array = Value::Array(json_vals);
             serde_json::to_string_pretty(&array).map_err(|e| {
@@ -1375,57 +1429,34 @@ fn apply_basic_jq_filter(json_value: &Value, filter: &str) -> Result<String, Err
 #[cfg(not(feature = "jq"))]
 /// Get a nested field from JSON using dot notation
 fn get_nested_field(json_value: &Value, field_path: &str) -> Value {
-    let parts: Vec<&str> = field_path.split('.').collect();
-    let mut current = json_value;
+    field_path
+        .split('.')
+        .filter(|part| !part.is_empty())
+        .try_fold(json_value, resolve_nested_field_segment)
+        .cloned()
+        .unwrap_or(Value::Null)
+}
 
-    for part in parts {
-        if part.is_empty() {
-            continue;
-        }
-
-        // Handle array index notation like [0]
-        if part.starts_with('[') && part.ends_with(']') {
-            let index_str = &part[1..part.len() - 1];
-            let Ok(index) = index_str.parse::<usize>() else {
-                return Value::Null;
-            };
-
-            match current {
-                Value::Array(arr) => {
-                    let Some(item) = arr.get(index) else {
-                        return Value::Null;
-                    };
-                    current = item;
-                }
-                _ => return Value::Null,
-            }
-            continue;
-        }
-
-        match current {
-            Value::Object(obj) => {
-                if let Some(field) = obj.get(part) {
-                    current = field;
-                } else {
-                    return Value::Null;
-                }
-            }
-            Value::Array(arr) => {
-                // Handle numeric string as array index
-                let Ok(index) = part.parse::<usize>() else {
-                    return Value::Null;
-                };
-
-                let Some(item) = arr.get(index) else {
-                    return Value::Null;
-                };
-                current = item;
-            }
-            _ => return Value::Null,
-        }
+#[cfg(not(feature = "jq"))]
+fn resolve_nested_field_segment<'a>(current: &'a Value, part: &str) -> Option<&'a Value> {
+    if let Some(index) = parse_bracket_index(part) {
+        return current.as_array().and_then(|arr| arr.get(index));
     }
 
-    current.clone()
+    match current {
+        Value::Object(obj) => obj.get(part),
+        Value::Array(arr) => part.parse::<usize>().ok().and_then(|index| arr.get(index)),
+        _ => None,
+    }
+}
+
+#[cfg(not(feature = "jq"))]
+fn parse_bracket_index(part: &str) -> Option<usize> {
+    if part.starts_with('[') && part.ends_with(']') {
+        part[1..part.len() - 1].parse::<usize>().ok()
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/engine/generator.rs
+++ b/src/engine/generator.rs
@@ -273,116 +273,91 @@ fn effective_subcommand_name(command: &CachedCommand) -> String {
 ///
 /// This differs from non-boolean parameters which require explicit values (e.g., `--id 123`).
 fn create_arg_from_parameter(param: &CachedParameter, use_positional_args: bool) -> Arg {
-    let param_name_static = to_static_str(param.name.clone());
-    let mut arg = Arg::new(param_name_static);
-
-    // Check if this is a boolean parameter (type: "boolean" in OpenAPI schema)
     let is_boolean = param.schema_type.as_ref().is_some_and(|t| t == "boolean");
 
     match param.location.as_str() {
-        "path" => {
-            match (use_positional_args, is_boolean) {
-                (true, true) => {
-                    // Boolean path parameters must use SetTrue even in positional mode
-                    // because executor always reads them via get_flag()
-                    // They remain as flags, not positional args, to avoid clap panic
-                    let long_name = to_static_str(to_kebab_case(&param.name));
-                    arg = arg
-                        .long(long_name)
-                        .help(format!("Path parameter: {}", param.name))
-                        .required(false)
-                        .action(ArgAction::SetTrue);
-                }
-                (true, false) => {
-                    // Legacy mode: path parameters are positional arguments (non-boolean)
-                    let value_name = to_static_str(param.name.to_uppercase());
-                    arg = arg
-                        .help(format!("{} parameter", param.name))
-                        .value_name(value_name)
-                        .required(param.required)
-                        .action(ArgAction::Set);
-                }
-                (false, true) => {
-                    // Default mode: Boolean path parameters are treated as flags
-                    // Always optional: flag presence = true, absence = false (substituted in path)
-                    // This provides consistent UX regardless of OpenAPI required field
-                    let long_name = to_static_str(to_kebab_case(&param.name));
-                    arg = arg
-                        .long(long_name)
-                        .help(format!("Path parameter: {}", param.name))
-                        .required(false)
-                        .action(ArgAction::SetTrue);
-                }
-                (false, false) => {
-                    // Default mode: non-boolean path parameters
-                    let long_name = to_static_str(to_kebab_case(&param.name));
-                    let value_name = to_static_str(param.name.to_uppercase());
-                    arg = arg
-                        .long(long_name)
-                        .help(format!("Path parameter: {}", param.name))
-                        .value_name(value_name)
-                        .required(param.required)
-                        .action(ArgAction::Set);
-                }
-            }
-        }
-        "query" | "header" => {
-            // Query and header parameters are flags
-            let long_name = to_static_str(to_kebab_case(&param.name));
-
-            if is_boolean {
-                // Boolean parameters are proper flags
-                // Required booleans must be provided; optional booleans default to false when absent
-                arg = arg
-                    .long(long_name)
-                    .help(format!(
-                        "{} {} parameter",
-                        capitalize_first(&param.location),
-                        param.name
-                    ))
-                    .required(param.required)
-                    .action(ArgAction::SetTrue);
-                return arg;
-            }
-
-            let value_name = to_static_str(param.name.to_uppercase());
-            arg = arg
-                .long(long_name)
-                .help(format!(
-                    "{} {} parameter",
-                    capitalize_first(&param.location),
-                    param.name
-                ))
-                .value_name(value_name)
-                .required(param.required)
-                .action(ArgAction::Set);
-        }
-        _ => {
-            // Unknown location, treat as flag
-            let long_name = to_static_str(to_kebab_case(&param.name));
-
-            if is_boolean {
-                // Boolean parameters are proper flags
-                // Required booleans must be provided; optional booleans default to false when absent
-                arg = arg
-                    .long(long_name)
-                    .help(format!("{} parameter", param.name))
-                    .required(param.required)
-                    .action(ArgAction::SetTrue);
-                return arg;
-            }
-
-            let value_name = to_static_str(param.name.to_uppercase());
-            arg = arg
-                .long(long_name)
-                .help(format!("{} parameter", param.name))
-                .value_name(value_name)
-                .required(param.required)
-                .action(ArgAction::Set);
-        }
+        "path" => create_path_parameter_arg(param, use_positional_args, is_boolean),
+        "query" | "header" => create_scoped_parameter_arg(param, is_boolean),
+        _ => create_generic_parameter_arg(param, is_boolean),
     }
+}
 
-    arg
+fn create_path_parameter_arg(
+    param: &CachedParameter,
+    use_positional_args: bool,
+    is_boolean: bool,
+) -> Arg {
+    let param_name_static = to_static_str(param.name.clone());
+    let arg = Arg::new(param_name_static);
+
+    if is_boolean {
+        let long_name = to_static_str(to_kebab_case(&param.name));
+        arg.long(long_name)
+            .help(format!("Path parameter: {}", param.name))
+            .required(false)
+            .action(ArgAction::SetTrue)
+    } else if use_positional_args {
+        let value_name = to_static_str(param.name.to_uppercase());
+        arg.help(format!("{} parameter", param.name))
+            .value_name(value_name)
+            .required(param.required)
+            .action(ArgAction::Set)
+    } else {
+        let long_name = to_static_str(to_kebab_case(&param.name));
+        let value_name = to_static_str(param.name.to_uppercase());
+        arg.long(long_name)
+            .help(format!("Path parameter: {}", param.name))
+            .value_name(value_name)
+            .required(param.required)
+            .action(ArgAction::Set)
+    }
+}
+
+fn create_scoped_parameter_arg(param: &CachedParameter, is_boolean: bool) -> Arg {
+    let param_name_static = to_static_str(param.name.clone());
+    let long_name = to_static_str(to_kebab_case(&param.name));
+    let help = format!(
+        "{} {} parameter",
+        capitalize_first(&param.location),
+        param.name
+    );
+
+    if is_boolean {
+        Arg::new(param_name_static)
+            .long(long_name)
+            .help(help)
+            .required(param.required)
+            .action(ArgAction::SetTrue)
+    } else {
+        let value_name = to_static_str(param.name.to_uppercase());
+        Arg::new(param_name_static)
+            .long(long_name)
+            .help(help)
+            .value_name(value_name)
+            .required(param.required)
+            .action(ArgAction::Set)
+    }
+}
+
+fn create_generic_parameter_arg(param: &CachedParameter, is_boolean: bool) -> Arg {
+    let param_name_static = to_static_str(param.name.clone());
+    let long_name = to_static_str(to_kebab_case(&param.name));
+
+    if is_boolean {
+        Arg::new(param_name_static)
+            .long(long_name)
+            .help(format!("{} parameter", param.name))
+            .required(param.required)
+            .action(ArgAction::SetTrue)
+    } else {
+        let value_name = to_static_str(param.name.to_uppercase());
+        Arg::new(param_name_static)
+            .long(long_name)
+            .help(format!("{} parameter", param.name))
+            .value_name(value_name)
+            .required(param.required)
+            .action(ArgAction::Set)
+    }
 }
 
 /// Capitalizes the first letter of a string

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -348,14 +348,7 @@ pub fn select_from_options_with_io_and_timeout<T: InputOutput>(
         match resolve_selection_attempt(options, io, timeout)? {
             SelectionOutcome::Selected(choice) => return Ok(choice),
             SelectionOutcome::Continue => {}
-            SelectionOutcome::Retry => {
-                if attempt < MAX_RETRIES {
-                    io.println(&format!(
-                        "Invalid selection. Please enter a number (1-{}) or a valid name. (Attempt {attempt} of {MAX_RETRIES})",
-                        options.len()
-                    ))?;
-                }
-            }
+            SelectionOutcome::Retry => report_invalid_selection(attempt, options, io)?,
         }
     }
 
@@ -364,6 +357,21 @@ pub fn select_from_options_with_io_and_timeout<T: InputOutput>(
         "Invalid selection",
         &build_selection_suggestions(options),
     ))
+}
+
+fn report_invalid_selection<T: InputOutput>(
+    attempt: usize,
+    options: &[(String, String)],
+    io: &T,
+) -> Result<(), Error> {
+    if attempt < MAX_RETRIES {
+        io.println(&format!(
+            "Invalid selection. Please enter a number (1-{}) or a valid name. (Attempt {attempt} of {MAX_RETRIES})",
+            options.len()
+        ))?;
+    }
+
+    Ok(())
 }
 
 fn print_selection_options<T: InputOutput>(

--- a/src/response_cache.rs
+++ b/src/response_cache.rs
@@ -303,11 +303,7 @@ impl ResponseCache {
             .map_err(|e| Error::io_error(format!("I/O operation failed: {e}")))?
         {
             let filename = entry.file_name();
-            let filename_str = filename.to_string_lossy();
-
-            if filename_str.starts_with(&format!("{api_name}_"))
-                && filename_str.ends_with(constants::CACHE_FILE_SUFFIX)
-            {
+            if Self::is_api_cache_entry(api_name, &filename) {
                 tokio::fs::remove_file(entry.path())
                     .await
                     .map_err(|e| Error::io_error(format!("I/O operation failed: {e}")))?;
@@ -316,6 +312,12 @@ impl ResponseCache {
         }
 
         Ok(cleared_count)
+    }
+
+    fn is_api_cache_entry(api_name: &str, filename: &std::ffi::OsStr) -> bool {
+        let filename = filename.to_string_lossy();
+        filename.starts_with(&format!("{api_name}_"))
+            && filename.ends_with(constants::CACHE_FILE_SUFFIX)
     }
 
     /// Clear all cached responses

--- a/src/spec/validator.rs
+++ b/src/spec/validator.rs
@@ -4,6 +4,8 @@ use crate::error::{Error, ErrorKind};
 use openapiv3::{OpenAPI, Operation, Parameter, ReferenceOr, RequestBody, SecurityScheme};
 use std::collections::HashMap;
 
+type ContentTypeReasonRule = (fn(&str) -> bool, &'static str);
+
 /// Result of validating an `OpenAPI` specification
 #[derive(Debug, Default)]
 pub struct ValidationResult {
@@ -100,37 +102,53 @@ impl SpecValidator {
 
     /// Returns a human-readable reason for why a content type is not supported
     fn get_unsupported_content_type_reason(content_type: &str) -> &'static str {
-        if Self::is_multipart_content_type(content_type) {
-            return "file uploads are not supported";
-        }
-        if Self::is_octet_stream_content_type(content_type) {
-            return "binary data uploads are not supported";
-        }
-        if Self::is_image_upload_content_type(content_type) {
-            return "image uploads are not supported";
-        }
-        if Self::is_pdf_content_type(content_type) {
-            return "PDF uploads are not supported";
-        }
-        if Self::is_xml_content_type(content_type) {
-            return "XML content is not supported";
-        }
-        if Self::is_form_content_type(content_type) {
-            return "form-encoded data is not supported";
-        }
-        if Self::is_text_content_type(content_type) {
-            return "plain text content is not supported";
-        }
-        if Self::is_csv_content_type(content_type) {
-            return "CSV content is not supported";
-        }
-        if Self::is_ndjson_content_type(content_type) {
-            return "newline-delimited JSON is not supported";
-        }
-        if Self::is_graphql_content_type(content_type) {
-            return "GraphQL content is not supported";
-        }
-        "is not supported"
+        let reason_rules: [ContentTypeReasonRule; 10] = [
+            (
+                Self::is_multipart_content_type as fn(&str) -> bool,
+                "file uploads are not supported",
+            ),
+            (
+                Self::is_octet_stream_content_type as fn(&str) -> bool,
+                "binary data uploads are not supported",
+            ),
+            (
+                Self::is_image_upload_content_type as fn(&str) -> bool,
+                "image uploads are not supported",
+            ),
+            (
+                Self::is_pdf_content_type as fn(&str) -> bool,
+                "PDF uploads are not supported",
+            ),
+            (
+                Self::is_xml_content_type as fn(&str) -> bool,
+                "XML content is not supported",
+            ),
+            (
+                Self::is_form_content_type as fn(&str) -> bool,
+                "form-encoded data is not supported",
+            ),
+            (
+                Self::is_text_content_type as fn(&str) -> bool,
+                "plain text content is not supported",
+            ),
+            (
+                Self::is_csv_content_type as fn(&str) -> bool,
+                "CSV content is not supported",
+            ),
+            (
+                Self::is_ndjson_content_type as fn(&str) -> bool,
+                "newline-delimited JSON is not supported",
+            ),
+            (
+                Self::is_graphql_content_type as fn(&str) -> bool,
+                "GraphQL content is not supported",
+            ),
+        ];
+
+        reason_rules
+            .iter()
+            .find_map(|(matches, reason)| matches(content_type).then_some(*reason))
+            .unwrap_or("is not supported")
     }
 
     fn is_multipart_content_type(content_type: &str) -> bool {
@@ -480,21 +498,23 @@ impl SpecValidator {
         reqs.iter()
             .flat_map(|req| req.keys())
             .filter_map(|scheme_name| {
-                unsupported_schemes.get(scheme_name).map(|msg| {
-                    // Extract the specific reason from the validation message
-                    match () {
-                        () if msg.contains("OAuth2") => format!("{scheme_name} (OAuth2)"),
-                        () if msg.contains("OpenID Connect") => {
-                            format!("{scheme_name} (OpenID Connect)")
-                        }
-                        () if msg.contains("complex authentication flows") => {
-                            format!("{scheme_name} (requires complex flow)")
-                        }
-                        () => scheme_name.clone(),
-                    }
-                })
+                unsupported_schemes
+                    .get(scheme_name)
+                    .map(|msg| Self::format_unsupported_scheme_detail(scheme_name, msg))
             })
             .collect()
+    }
+
+    fn format_unsupported_scheme_detail(scheme_name: &str, msg: &str) -> String {
+        if msg.contains("OAuth2") {
+            format!("{scheme_name} (OAuth2)")
+        } else if msg.contains("OpenID Connect") {
+            format!("{scheme_name} (OpenID Connect)")
+        } else if msg.contains("complex authentication flows") {
+            format!("{scheme_name} (requires complex flow)")
+        } else {
+            scheme_name.to_string()
+        }
     }
 
     /// Formats the reason message for authentication-related skips


### PR DESCRIPTION
## Summary
- Refactored all `compl` violations at threshold 11 into smaller helpers
- Kept behavior unchanged while simplifying retry, selection, parsing, and request-preparation logic
- Added batch retry-context tests to cover the refactor path

## Verification
- `compl scan --threshold 11 . --jsonl` → 0 findings
- `cargo test -q`
- `cargo clippy -q --all-targets --all-features -- -D warnings`
- `cargo fmt --all`