### PR TITLE
refactor: reduce cyclomatic complexity hotspots under threshold 10

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -823,38 +823,10 @@ fn extract_security_schemes(spec: &CachedSpec) -> HashMap<String, SecurityScheme
     let mut security_schemes = HashMap::new();
 
     for (name, scheme) in &spec.security_schemes {
-        let details = match scheme.scheme_type.as_str() {
-            constants::SECURITY_TYPE_HTTP => match scheme.scheme.as_deref() {
-                Some(constants::AUTH_SCHEME_BEARER) => SecuritySchemeDetails::HttpBearer {
-                    bearer_format: scheme.bearer_format.clone(),
-                },
-                Some(constants::AUTH_SCHEME_BASIC) => SecuritySchemeDetails::HttpBasic,
-                _ => SecuritySchemeDetails::HttpBearer {
-                    bearer_format: None,
-                },
-            },
-            constants::AUTH_SCHEME_APIKEY => SecuritySchemeDetails::ApiKey {
-                location: scheme
-                    .location
-                    .clone()
-                    .unwrap_or_else(|| constants::LOCATION_HEADER.to_string()),
-                name: scheme
-                    .parameter_name
-                    .clone()
-                    .unwrap_or_else(|| constants::HEADER_AUTHORIZATION.to_string()),
-            },
-            _ => {
-                // Default to bearer for unknown types
-                SecuritySchemeDetails::HttpBearer {
-                    bearer_format: None,
-                }
-            }
-        };
-
         let scheme_info = SecuritySchemeInfo {
             scheme_type: scheme.scheme_type.clone(),
             description: scheme.description.clone(),
-            details,
+            details: cached_security_scheme_details(scheme),
             aperture_secret: scheme.aperture_secret.clone(),
         };
 
@@ -862,6 +834,42 @@ fn extract_security_schemes(spec: &CachedSpec) -> HashMap<String, SecurityScheme
     }
 
     security_schemes
+}
+
+fn cached_security_scheme_details(
+    scheme: &crate::cache::models::CachedSecurityScheme,
+) -> SecuritySchemeDetails {
+    match scheme.scheme_type.as_str() {
+        constants::SECURITY_TYPE_HTTP => cached_http_security_details(scheme),
+        constants::AUTH_SCHEME_APIKEY => SecuritySchemeDetails::ApiKey {
+            location: scheme
+                .location
+                .clone()
+                .unwrap_or_else(|| constants::LOCATION_HEADER.to_string()),
+            name: scheme
+                .parameter_name
+                .clone()
+                .unwrap_or_else(|| constants::HEADER_AUTHORIZATION.to_string()),
+        },
+        // Default to bearer for unknown types.
+        _ => SecuritySchemeDetails::HttpBearer {
+            bearer_format: None,
+        },
+    }
+}
+
+fn cached_http_security_details(
+    scheme: &crate::cache::models::CachedSecurityScheme,
+) -> SecuritySchemeDetails {
+    match scheme.scheme.as_deref() {
+        Some(constants::AUTH_SCHEME_BEARER) => SecuritySchemeDetails::HttpBearer {
+            bearer_format: scheme.bearer_format.clone(),
+        },
+        Some(constants::AUTH_SCHEME_BASIC) => SecuritySchemeDetails::HttpBasic,
+        _ => SecuritySchemeDetails::HttpBearer {
+            bearer_format: None,
+        },
+    }
 }
 
 fn operation_command_name(operation: &Operation, method: &str) -> String {
@@ -1094,28 +1102,31 @@ fn serialize_enum_value(v: &String) -> String {
 fn extract_schema_type_from_schema_kind(
     schema_kind: &openapiv3::SchemaKind,
 ) -> (String, Option<String>, Vec<String>) {
-    match schema_kind {
-        openapiv3::SchemaKind::Type(type_val) => match type_val {
-            openapiv3::Type::String(string_type) => {
-                let enum_values: Vec<String> = string_type
-                    .enumeration
-                    .iter()
-                    .filter_map(|v| v.as_ref())
-                    .map(serialize_enum_value)
-                    .collect();
-                (constants::SCHEMA_TYPE_STRING.to_string(), None, enum_values)
-            }
-            openapiv3::Type::Number(_) => (constants::SCHEMA_TYPE_NUMBER.to_string(), None, vec![]),
-            openapiv3::Type::Integer(_) => {
-                (constants::SCHEMA_TYPE_INTEGER.to_string(), None, vec![])
-            }
-            openapiv3::Type::Boolean(_) => {
-                (constants::SCHEMA_TYPE_BOOLEAN.to_string(), None, vec![])
-            }
-            openapiv3::Type::Array(_) => (constants::SCHEMA_TYPE_ARRAY.to_string(), None, vec![]),
-            openapiv3::Type::Object(_) => (constants::SCHEMA_TYPE_OBJECT.to_string(), None, vec![]),
-        },
-        _ => (constants::SCHEMA_TYPE_STRING.to_string(), None, vec![]),
+    let openapiv3::SchemaKind::Type(type_val) = schema_kind else {
+        return (constants::SCHEMA_TYPE_STRING.to_string(), None, vec![]);
+    };
+
+    extract_schema_type_from_openapi_type(type_val)
+}
+
+fn extract_schema_type_from_openapi_type(
+    type_val: &openapiv3::Type,
+) -> (String, Option<String>, Vec<String>) {
+    match type_val {
+        openapiv3::Type::String(string_type) => {
+            let enum_values: Vec<String> = string_type
+                .enumeration
+                .iter()
+                .filter_map(|v| v.as_ref())
+                .map(serialize_enum_value)
+                .collect();
+            (constants::SCHEMA_TYPE_STRING.to_string(), None, enum_values)
+        }
+        openapiv3::Type::Number(_) => (constants::SCHEMA_TYPE_NUMBER.to_string(), None, vec![]),
+        openapiv3::Type::Integer(_) => (constants::SCHEMA_TYPE_INTEGER.to_string(), None, vec![]),
+        openapiv3::Type::Boolean(_) => (constants::SCHEMA_TYPE_BOOLEAN.to_string(), None, vec![]),
+        openapiv3::Type::Array(_) => (constants::SCHEMA_TYPE_ARRAY.to_string(), None, vec![]),
+        openapiv3::Type::Object(_) => (constants::SCHEMA_TYPE_OBJECT.to_string(), None, vec![]),
     }
 }
 
@@ -1194,51 +1205,71 @@ fn convert_openapi_security_scheme(
             name: param_name,
             description,
             ..
-        } => {
-            let location_str = match location {
-                openapiv3::APIKeyLocation::Query => constants::PARAM_LOCATION_QUERY,
-                openapiv3::APIKeyLocation::Header => constants::PARAM_LOCATION_HEADER,
-                openapiv3::APIKeyLocation::Cookie => constants::PARAM_LOCATION_COOKIE,
-            };
-
-            let aperture_secret = extract_aperture_secret_from_extensions(scheme);
-
-            Some(SecuritySchemeInfo {
-                scheme_type: constants::AUTH_SCHEME_APIKEY.to_string(),
-                description: description.clone(),
-                details: SecuritySchemeDetails::ApiKey {
-                    location: location_str.to_string(),
-                    name: param_name.clone(),
-                },
-                aperture_secret,
-            })
-        }
+        } => Some(convert_openapi_api_key_security_scheme(
+            location,
+            param_name,
+            description.as_ref(),
+            extract_aperture_secret_from_extensions(scheme),
+        )),
         SecurityScheme::HTTP {
             scheme: http_scheme,
             bearer_format,
             description,
             ..
-        } => {
-            let details = match http_scheme.as_str() {
-                constants::AUTH_SCHEME_BEARER => SecuritySchemeDetails::HttpBearer {
-                    bearer_format: bearer_format.clone(),
-                },
-                constants::AUTH_SCHEME_BASIC => SecuritySchemeDetails::HttpBasic,
-                _ => SecuritySchemeDetails::HttpBearer {
-                    bearer_format: None,
-                },
-            };
-
-            let aperture_secret = extract_aperture_secret_from_extensions(scheme);
-
-            Some(SecuritySchemeInfo {
-                scheme_type: constants::SECURITY_TYPE_HTTP.to_string(),
-                description: description.clone(),
-                details,
-                aperture_secret,
-            })
-        }
+        } => Some(convert_openapi_http_security_scheme(
+            http_scheme,
+            bearer_format.as_ref(),
+            description.as_ref(),
+            extract_aperture_secret_from_extensions(scheme),
+        )),
         SecurityScheme::OAuth2 { .. } | SecurityScheme::OpenIDConnect { .. } => None,
+    }
+}
+
+fn convert_openapi_api_key_security_scheme(
+    location: &openapiv3::APIKeyLocation,
+    parameter_name: &str,
+    description: Option<&String>,
+    aperture_secret: Option<CachedApertureSecret>,
+) -> SecuritySchemeInfo {
+    let location_str = match location {
+        openapiv3::APIKeyLocation::Query => constants::PARAM_LOCATION_QUERY,
+        openapiv3::APIKeyLocation::Header => constants::PARAM_LOCATION_HEADER,
+        openapiv3::APIKeyLocation::Cookie => constants::PARAM_LOCATION_COOKIE,
+    };
+
+    SecuritySchemeInfo {
+        scheme_type: constants::AUTH_SCHEME_APIKEY.to_string(),
+        description: description.cloned(),
+        details: SecuritySchemeDetails::ApiKey {
+            location: location_str.to_string(),
+            name: parameter_name.to_string(),
+        },
+        aperture_secret,
+    }
+}
+
+fn convert_openapi_http_security_scheme(
+    http_scheme: &str,
+    bearer_format: Option<&String>,
+    description: Option<&String>,
+    aperture_secret: Option<CachedApertureSecret>,
+) -> SecuritySchemeInfo {
+    let details = match http_scheme {
+        constants::AUTH_SCHEME_BEARER => SecuritySchemeDetails::HttpBearer {
+            bearer_format: bearer_format.cloned(),
+        },
+        constants::AUTH_SCHEME_BASIC => SecuritySchemeDetails::HttpBasic,
+        _ => SecuritySchemeDetails::HttpBearer {
+            bearer_format: None,
+        },
+    };
+
+    SecuritySchemeInfo {
+        scheme_type: constants::SECURITY_TYPE_HTTP.to_string(),
+        description: description.cloned(),
+        details,
+        aperture_secret,
     }
 }
 
@@ -1246,29 +1277,35 @@ fn convert_openapi_security_scheme(
 fn extract_aperture_secret_from_extensions(
     scheme: &SecurityScheme,
 ) -> Option<CachedApertureSecret> {
-    let extensions = match scheme {
+    security_scheme_extensions(scheme)
+        .and_then(|extensions| extensions.get(constants::EXT_APERTURE_SECRET))
+        .and_then(parse_aperture_secret_extension)
+}
+
+const fn security_scheme_extensions(
+    scheme: &SecurityScheme,
+) -> Option<&indexmap::IndexMap<String, serde_json::Value>> {
+    match scheme {
         SecurityScheme::APIKey { extensions, .. } | SecurityScheme::HTTP { extensions, .. } => {
-            extensions
+            Some(extensions)
         }
-        SecurityScheme::OAuth2 { .. } | SecurityScheme::OpenIDConnect { .. } => return None,
-    };
+        SecurityScheme::OAuth2 { .. } | SecurityScheme::OpenIDConnect { .. } => None,
+    }
+}
 
-    extensions
-        .get(constants::EXT_APERTURE_SECRET)
-        .and_then(|value| {
-            let obj = value.as_object()?;
-            let source = obj.get(constants::EXT_KEY_SOURCE)?.as_str()?;
-            let name = obj.get(constants::EXT_KEY_NAME)?.as_str()?;
+fn parse_aperture_secret_extension(value: &serde_json::Value) -> Option<CachedApertureSecret> {
+    let obj = value.as_object()?;
+    let source = obj.get(constants::EXT_KEY_SOURCE)?.as_str()?;
+    let name = obj.get(constants::EXT_KEY_NAME)?.as_str()?;
 
-            if source != constants::SOURCE_ENV {
-                return None;
-            }
+    if source != constants::SOURCE_ENV {
+        return None;
+    }
 
-            Some(CachedApertureSecret {
-                source: source.to_string(),
-                name: name.to_string(),
-            })
-        })
+    Some(CachedApertureSecret {
+        source: source.to_string(),
+        name: name.to_string(),
+    })
 }
 
 #[cfg(test)]

--- a/src/batch/graph.rs
+++ b/src/batch/graph.rs
@@ -166,27 +166,8 @@ fn build_adjacency(
     let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
 
     for (i, op) in operations.iter().enumerate() {
-        let mut deps: HashSet<usize> = HashSet::new();
-
-        // Explicit depends_on
-        for dep_id in op.depends_on.iter().flatten() {
-            let &dep_idx = id_to_index.get(dep_id.as_str()).ok_or_else(|| {
-                Error::batch_missing_dependency(op.id.as_deref().unwrap_or("<unnamed>"), dep_id)
-            })?;
-            deps.insert(dep_idx);
-        }
-
-        // Implicit dependencies from variable references in args.
-        // For capture_append variables with multiple providers, this
-        // correctly adds edges from ALL providers to the consumer.
-        let implicit_deps = op
-            .args
-            .iter()
-            .flat_map(|arg| extract_variable_references(arg))
-            .filter_map(|var| capture_var_to_op.get(var))
-            .flat_map(|indices| indices.iter().copied())
-            .filter(|&idx| idx != i);
-        deps.extend(implicit_deps);
+        let mut deps = explicit_dependencies(op, id_to_index)?;
+        deps.extend(implicit_dependencies(op, i, capture_var_to_op));
 
         for dep_idx in deps {
             adj[dep_idx].push(i);
@@ -194,6 +175,36 @@ fn build_adjacency(
     }
 
     Ok(adj)
+}
+
+fn explicit_dependencies(
+    operation: &BatchOperation,
+    id_to_index: &HashMap<&str, usize>,
+) -> Result<HashSet<usize>, Error> {
+    let mut deps = HashSet::new();
+
+    for dep_id in operation.depends_on.iter().flatten() {
+        let &dep_idx = id_to_index.get(dep_id.as_str()).ok_or_else(|| {
+            Error::batch_missing_dependency(operation.id.as_deref().unwrap_or("<unnamed>"), dep_id)
+        })?;
+        deps.insert(dep_idx);
+    }
+
+    Ok(deps)
+}
+
+fn implicit_dependencies<'a>(
+    operation: &'a BatchOperation,
+    operation_index: usize,
+    capture_var_to_op: &'a HashMap<&str, Vec<usize>>,
+) -> impl Iterator<Item = usize> + 'a {
+    operation
+        .args
+        .iter()
+        .flat_map(|arg| extract_variable_references(arg))
+        .filter_map(|var| capture_var_to_op.get(var))
+        .flat_map(|indices| indices.iter().copied())
+        .filter(move |&idx| idx != operation_index)
 }
 
 /// Kahn's algorithm for topological sorting with cycle detection.

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -376,12 +376,47 @@ impl BatchProcessor {
         };
 
         let operation_start = std::time::Instant::now();
-
-        // Suppress output and skip jq_filter: capture needs JSON text that
-        // preserves the raw response structure regardless of caller formatting.
-        let result = Self::execute_single_operation(
+        let response = match Self::execute_dependent_operation(
             spec,
             &exec_op,
+            global_config,
+            base_url,
+            dry_run,
+        )
+        .await
+        {
+            Ok(resp) => resp,
+            Err(e) => {
+                let duration = operation_start.elapsed();
+                Self::log_progress(show_progress, || format!("Operation '{op_id}' failed: {e}"));
+                return Self::failed_batch_operation_result(exec_op, e.to_string(), None, duration);
+            }
+        };
+
+        let duration = operation_start.elapsed();
+        Self::finalize_dependent_operation_result(
+            operation,
+            store,
+            exec_op,
+            response,
+            duration,
+            op_id,
+            show_progress,
+        )
+    }
+
+    async fn execute_dependent_operation(
+        spec: &CachedSpec,
+        exec_op: &BatchOperation,
+        global_config: Option<&GlobalConfig>,
+        base_url: Option<&str>,
+        dry_run: bool,
+    ) -> Result<String, Error> {
+        // Suppress output and skip jq_filter: capture needs JSON text that
+        // preserves the raw response structure regardless of caller formatting.
+        Self::execute_single_operation(
+            spec,
+            exec_op,
             global_config,
             base_url,
             dry_run,
@@ -389,20 +424,18 @@ impl BatchProcessor {
             None,
             true,
         )
-        .await;
+        .await
+    }
 
-        let duration = operation_start.elapsed();
-
-        // From here on, store exec_op (with interpolated args) in results
-        // so callers see the actual values used, not {{templates}}.
-        let response = match result {
-            Ok(resp) => resp,
-            Err(e) => {
-                Self::log_progress(show_progress, || format!("Operation '{op_id}' failed: {e}"));
-                return Self::failed_batch_operation_result(exec_op, e.to_string(), None, duration);
-            }
-        };
-
+    fn finalize_dependent_operation_result(
+        operation: &BatchOperation,
+        store: &mut interpolation::VariableStore,
+        exec_op: BatchOperation,
+        response: String,
+        duration: std::time::Duration,
+        op_id: &str,
+        show_progress: bool,
+    ) -> BatchOperationResult {
         match capture::extract_captures(operation, &response, store) {
             Ok(()) => {
                 Self::log_progress(show_progress, || format!("Operation '{op_id}' completed"));

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -305,13 +305,25 @@ fn handle_clear_secrets(
         output.info(format!("No secrets configured for API '{api_name}'"));
         return Ok(());
     }
+
     if force {
-        manager.clear_secrets(&api_name)?;
-        output.success(format!(
-            "Cleared all secret configurations for API '{api_name}'"
-        ));
+        return clear_all_api_secrets(manager, &api_name, output);
+    }
+
+    announce_secret_clear(&api_name, &secrets, output);
+    if !crate::interactive::confirm("Are you sure you want to continue?")? {
+        output.info("Operation cancelled");
         return Ok(());
     }
+
+    clear_all_api_secrets(manager, &api_name, output)
+}
+
+fn announce_secret_clear(
+    api_name: &ApiContextName,
+    secrets: &std::collections::HashMap<String, crate::config::models::ApertureSecret>,
+    output: &Output,
+) {
     output.info(format!(
         "This will remove all {} secret configuration(s) for API '{api_name}':",
         secrets.len()
@@ -319,11 +331,14 @@ fn handle_clear_secrets(
     for scheme_name in secrets.keys() {
         output.info(format!("  - {scheme_name}"));
     }
-    if !crate::interactive::confirm("Are you sure you want to continue?")? {
-        output.info("Operation cancelled");
-        return Ok(());
-    }
-    manager.clear_secrets(&api_name)?;
+}
+
+fn clear_all_api_secrets(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: &ApiContextName,
+    output: &Output,
+) -> Result<(), Error> {
+    manager.clear_secrets(api_name)?;
     output.success(format!(
         "Cleared all secret configurations for API '{api_name}'"
     ));
@@ -402,6 +417,30 @@ async fn execute_specs_config_command(
     output: &Output,
 ) -> Result<(), Error> {
     match command {
+        crate::cli::ConfigCommands::Add { .. }
+        | crate::cli::ConfigCommands::List { .. }
+        | crate::cli::ConfigCommands::Remove { .. }
+        | crate::cli::ConfigCommands::Edit { .. } => {
+            execute_specs_catalog_command(manager, command, output).await
+        }
+        crate::cli::ConfigCommands::SetUrl { .. }
+        | crate::cli::ConfigCommands::GetUrl { .. }
+        | crate::cli::ConfigCommands::ListUrls {} => {
+            execute_specs_url_command(manager, command, output)
+        }
+        crate::cli::ConfigCommands::Reinit { context, all } => {
+            handle_reinit(manager, context, all, output)
+        }
+        _ => unreachable!("command family routing must be exhaustive"),
+    }
+}
+
+async fn execute_specs_catalog_command(
+    manager: &ConfigManager<OsFileSystem>,
+    command: crate::cli::ConfigCommands,
+    output: &Output,
+) -> Result<(), Error> {
+    match command {
         crate::cli::ConfigCommands::Add {
             name,
             file_or_url,
@@ -415,6 +454,16 @@ async fn execute_specs_config_command(
         crate::cli::ConfigCommands::Edit { name } => {
             handle_edit_spec_command(manager, name, output)
         }
+        _ => unreachable!("catalog command routing must be exhaustive"),
+    }
+}
+
+fn execute_specs_url_command(
+    manager: &ConfigManager<OsFileSystem>,
+    command: crate::cli::ConfigCommands,
+    output: &Output,
+) -> Result<(), Error> {
+    match command {
         crate::cli::ConfigCommands::SetUrl { name, url, env } => {
             handle_set_url(manager, name, url, env, output)
         }
@@ -422,10 +471,7 @@ async fn execute_specs_config_command(
             handle_get_url_command(manager, name, output)
         }
         crate::cli::ConfigCommands::ListUrls {} => handle_list_urls(manager, output),
-        crate::cli::ConfigCommands::Reinit { context, all } => {
-            handle_reinit(manager, context, all, output)
-        }
-        _ => unreachable!("command family routing must be exhaustive"),
+        _ => unreachable!("url command routing must be exhaustive"),
     }
 }
 

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -41,7 +41,7 @@ pub fn print_error(error: &Error) {
 /// redirecting the process-global stderr.
 fn write_internal_error<W: std::io::Write>(
     writer: &mut W,
-    kind: &crate::error::ErrorKind,
+    kind: crate::error::ErrorKind,
     message: &str,
     context: Option<&crate::error::ErrorContext>,
 ) {
@@ -99,15 +99,20 @@ fn write_network_error<W: std::io::Write>(writer: &mut W, req_err: &reqwest::Err
         write_error_with_hint(writer, "Timeout Error", req_err, constants::ERR_TIMEOUT);
         return;
     }
-    if !req_err.is_status() {
-        let _ = writeln!(writer, "Network Error\n{req_err}");
-        return;
-    }
-    let Some(status) = req_err.status() else {
+
+    let Some(status) = req_err.status().filter(|_| req_err.is_status()) else {
         let _ = writeln!(writer, "Network Error\n{req_err}");
         return;
     };
 
+    write_network_status_error(writer, req_err, status);
+}
+
+fn write_network_status_error<W: std::io::Write>(
+    writer: &mut W,
+    req_err: &reqwest::Error,
+    status: reqwest::StatusCode,
+) {
     match status.as_u16() {
         401 => write_error_with_hint(
             writer,
@@ -144,7 +149,7 @@ fn write_error<W: std::io::Write>(error: &Error, writer: &mut W) {
             kind,
             message,
             context,
-        } => write_internal_error(writer, kind, message, context.as_ref()),
+        } => write_internal_error(writer, *kind, message, context.as_ref()),
         Error::Io(io_err) => write_io_error(writer, io_err),
         Error::Network(req_err) => write_network_error(writer, req_err),
         Error::Yaml(yaml_err) => write_error_with_hint(

--- a/src/cli/legacy_execute.rs
+++ b/src/cli/legacy_execute.rs
@@ -36,19 +36,7 @@ pub async fn execute_request(
     use crate::cli::translate;
     use crate::invocation::ExecutionContext;
 
-    // Check --show-examples flag (CLI-only concern).
-    // NOTE: The primary path through `execute_api_command` also checks this
-    // flag before reaching here.  This duplicate check is intentional so that
-    // callers of the legacy `execute_request` API (tests, batch) still get
-    // correct behavior without depending on an outer guard.
-    if translate::has_show_examples_flag(matches) {
-        let operation_id = translate::matches_to_operation_id(spec, matches)?;
-        let operation = spec
-            .commands
-            .iter()
-            .find(|cmd| cmd.operation_id == operation_id)
-            .ok_or_else(|| Error::spec_not_found(&spec.name))?;
-        crate::cli::render::render_examples(operation);
+    if maybe_render_examples(spec, matches)? {
         return Ok(None);
     }
 
@@ -77,4 +65,26 @@ pub async fn execute_request(
         crate::cli::render::render_result(&result, output_format, jq_filter)?;
         Ok(None)
     }
+}
+
+fn maybe_render_examples(spec: &CachedSpec, matches: &ArgMatches) -> Result<bool, Error> {
+    use crate::cli::translate;
+
+    // Check --show-examples flag (CLI-only concern).
+    // NOTE: The primary path through `execute_api_command` also checks this
+    // flag before reaching here. This duplicate check is intentional so that
+    // callers of the legacy `execute_request` API (tests, batch) still get
+    // correct behavior without depending on an outer guard.
+    if !translate::has_show_examples_flag(matches) {
+        return Ok(false);
+    }
+
+    let operation_id = translate::matches_to_operation_id(spec, matches)?;
+    let operation = spec
+        .commands
+        .iter()
+        .find(|cmd| cmd.operation_id == operation_id)
+        .ok_or_else(|| Error::spec_not_found(&spec.name))?;
+    crate::cli::render::render_examples(operation);
+    Ok(true)
 }

--- a/src/cli/translate.rs
+++ b/src/cli/translate.rs
@@ -92,6 +92,20 @@ fn find_operation_from_matches<'a>(
     spec: &'a CachedSpec,
     matches: &'a ArgMatches,
 ) -> Result<(&'a CachedCommand, &'a ArgMatches), Error> {
+    let (subcommand_path, current_matches) = collect_subcommand_path(matches);
+
+    let operation_name = subcommand_path
+        .last()
+        .ok_or_else(|| operation_not_found_error(spec, "unknown"))?;
+    let group_name = group_name_from_subcommand_path(&subcommand_path);
+
+    let operation = resolve_operation_from_path(spec, group_name, operation_name)
+        .ok_or_else(|| operation_not_found_error(spec, operation_name))?;
+
+    Ok((operation, current_matches))
+}
+
+fn collect_subcommand_path(matches: &ArgMatches) -> (Vec<String>, &ArgMatches) {
     let mut current_matches = matches;
     let mut subcommand_path = Vec::new();
 
@@ -100,20 +114,23 @@ fn find_operation_from_matches<'a>(
         current_matches = sub_matches;
     }
 
-    let operation_name = subcommand_path.last().ok_or_else(|| {
-        let name = "unknown".to_string();
-        let suggestions = crate::suggestions::suggest_similar_operations(spec, &name);
-        Error::operation_not_found_with_suggestions(name, &suggestions)
-    })?;
+    (subcommand_path, current_matches)
+}
 
-    // Dynamic tree shape is: <group> <operation>
-    let group_name = subcommand_path
+fn group_name_from_subcommand_path(subcommand_path: &[String]) -> Option<&String> {
+    // Dynamic tree shape is: <group> <operation>.
+    subcommand_path
         .len()
         .checked_sub(2)
-        .and_then(|idx| subcommand_path.get(idx));
+        .and_then(|idx| subcommand_path.get(idx))
+}
 
-    let operation = spec
-        .commands
+fn resolve_operation_from_path<'a>(
+    spec: &'a CachedSpec,
+    group_name: Option<&String>,
+    operation_name: &str,
+) -> Option<&'a CachedCommand> {
+    spec.commands
         .iter()
         .find(|cmd| matches_effective_command_path(cmd, group_name, operation_name))
         // Backward-compatible fallback: resolve by operation name only.
@@ -124,12 +141,11 @@ fn find_operation_from_matches<'a>(
                 .iter()
                 .find(|cmd| matches_effective_command_path(cmd, None, operation_name))
         })
-        .ok_or_else(|| {
-            let suggestions = crate::suggestions::suggest_similar_operations(spec, operation_name);
-            Error::operation_not_found_with_suggestions(operation_name.clone(), &suggestions)
-        })?;
+}
 
-    Ok((operation, current_matches))
+fn operation_not_found_error(spec: &CachedSpec, operation_name: &str) -> Error {
+    let suggestions = crate::suggestions::suggest_similar_operations(spec, operation_name);
+    Error::operation_not_found_with_suggestions(operation_name.to_string(), &suggestions)
 }
 
 /// Returns true when a command matches a parsed group/operation subcommand path.

--- a/src/config/server_variable_resolver.rs
+++ b/src/config/server_variable_resolver.rs
@@ -310,6 +310,55 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_variables_duplicate_key_uses_last_value() {
+        let spec = create_test_spec_with_variables();
+        let resolver = ServerVariableResolver::new(&spec);
+
+        let args = vec![
+            "region=us".to_string(),
+            "region=eu".to_string(),
+            "env=prod".to_string(),
+        ];
+        let result = resolver.resolve_variables(&args).unwrap();
+
+        assert_eq!(result.get("region"), Some(&"eu".to_string()));
+        assert_eq!(result.get("env"), Some(&"prod".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_variables_trims_surrounding_whitespace() {
+        let spec = create_test_spec_with_variables();
+        let resolver = ServerVariableResolver::new(&spec);
+
+        let args = vec![" region = eu ".to_string(), " env = staging ".to_string()];
+        let result = resolver.resolve_variables(&args).unwrap();
+
+        assert_eq!(result.get("region"), Some(&"eu".to_string()));
+        assert_eq!(result.get("env"), Some(&"staging".to_string()));
+    }
+
+    #[test]
+    fn test_resolve_variables_rejects_whitespace_only_value() {
+        let spec = create_test_spec_with_variables();
+        let resolver = ServerVariableResolver::new(&spec);
+
+        let args = vec!["region=   ".to_string(), "env=prod".to_string()];
+        let result = resolver.resolve_variables(&args);
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            Error::Internal {
+                kind: ErrorKind::ServerVariable,
+                message,
+                ..
+            } => {
+                assert!(message.contains("Empty variable value"));
+            }
+            _ => panic!("Expected Internal ServerVariable error"),
+        }
+    }
+
+    #[test]
     fn test_resolve_variables_with_defaults() {
         let spec = create_test_spec_with_variables();
         let resolver = ServerVariableResolver::new(&spec);

--- a/src/config/server_variable_resolver.rs
+++ b/src/config/server_variable_resolver.rs
@@ -33,55 +33,66 @@ impl<'a> ServerVariableResolver<'a> {
         &self,
         server_var_args: &[String],
     ) -> Result<HashMap<String, String>, Error> {
-        let mut resolved_vars = HashMap::new();
+        let resolved_vars = Self::parse_resolved_vars(server_var_args)?;
+        self.validate_no_unknown_variables(&resolved_vars)?;
 
-        // Parse CLI arguments
+        let mut final_vars = HashMap::new();
+        for (var_name, var_def) in &self.spec.server_variables {
+            let value = Self::resolve_variable_value(var_name, var_def, &resolved_vars)?;
+            final_vars.insert(var_name.clone(), value);
+        }
+
+        Ok(final_vars)
+    }
+
+    fn parse_resolved_vars(server_var_args: &[String]) -> Result<HashMap<String, String>, Error> {
+        let mut resolved_vars = HashMap::new();
         for arg in server_var_args {
             let (key, value) = Self::parse_key_value(arg)?;
             resolved_vars.insert(key, value);
         }
+        Ok(resolved_vars)
+    }
 
-        // Validate and apply defaults
-        let mut final_vars = HashMap::new();
+    fn resolve_variable_value(
+        var_name: &str,
+        var_def: &ServerVariable,
+        resolved_vars: &HashMap<String, String>,
+    ) -> Result<String, Error> {
+        if let Some(provided_value) = resolved_vars.get(var_name) {
+            Self::validate_enum_constraint(var_name, provided_value, var_def)?;
+            return Ok(provided_value.clone());
+        }
 
-        for (var_name, var_def) in &self.spec.server_variables {
-            // Check if user provided a value
-            if let Some(provided_value) = resolved_vars.get(var_name) {
-                // Validate provided value against enum constraints
-                Self::validate_enum_constraint(var_name, provided_value, var_def)?;
-                final_vars.insert(var_name.clone(), provided_value.clone());
-                continue;
-            }
-
-            // Check if there's a default value
-            if let Some(default_value) = &var_def.default {
-                // Validate default value against enum constraints
-                Self::validate_enum_constraint(var_name, default_value, var_def)?;
-                // Use default value
-                final_vars.insert(var_name.clone(), default_value.clone());
-                continue;
-            }
-
-            // Required variable with no default - this is an error
+        let Some(default_value) = &var_def.default else {
             return Err(Error::missing_server_variable(var_name));
-        }
+        };
 
-        // Check for unknown variables provided by user
+        Self::validate_enum_constraint(var_name, default_value, var_def)?;
+        Ok(default_value.clone())
+    }
+
+    fn validate_no_unknown_variables(
+        &self,
+        resolved_vars: &HashMap<String, String>,
+    ) -> Result<(), Error> {
         for provided_var in resolved_vars.keys() {
-            if !self.spec.server_variables.contains_key(provided_var) {
-                return Err(Error::unknown_server_variable(
-                    provided_var,
-                    &self
-                        .spec
-                        .server_variables
-                        .keys()
-                        .cloned()
-                        .collect::<Vec<_>>(),
-                ));
+            if self.spec.server_variables.contains_key(provided_var) {
+                continue;
             }
+
+            return Err(Error::unknown_server_variable(
+                provided_var,
+                &self
+                    .spec
+                    .server_variables
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ));
         }
 
-        Ok(final_vars)
+        Ok(())
     }
 
     /// Substitutes server variables in a URL template

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -106,7 +106,17 @@ impl DocumentationGenerator {
 
         let effective_tag = Self::effective_group(command);
         let effective_operation = Self::effective_operation(command);
+        let (legacy_tag, legacy_operation) = Self::legacy_command_reference(command);
 
+        let tag_match = requested_tag == effective_tag || requested_tag == legacy_tag;
+        let operation_match = requested_operation == effective_operation
+            || requested_operation == legacy_operation
+            || Self::is_operation_alias_match(command, &requested_operation);
+
+        tag_match && operation_match
+    }
+
+    fn legacy_command_reference(command: &CachedCommand) -> (String, String) {
         let legacy_tag = command.tags.first().map_or_else(
             || {
                 if command.name.is_empty() {
@@ -115,7 +125,7 @@ impl DocumentationGenerator {
                     to_kebab_case(&command.name)
                 }
             },
-            |t| to_kebab_case(t),
+            |tag| to_kebab_case(tag),
         );
 
         let legacy_operation = if command.operation_id.is_empty() {
@@ -124,17 +134,14 @@ impl DocumentationGenerator {
             to_kebab_case(&command.operation_id)
         };
 
-        let alias_match = command
+        (legacy_tag, legacy_operation)
+    }
+
+    fn is_operation_alias_match(command: &CachedCommand, requested_operation: &str) -> bool {
+        command
             .aliases
             .iter()
-            .any(|alias| to_kebab_case(alias) == requested_operation);
-
-        let tag_match = requested_tag == effective_tag || requested_tag == legacy_tag;
-        let operation_match = requested_operation == effective_operation
-            || requested_operation == legacy_operation
-            || alias_match;
-
-        tag_match && operation_match
+            .any(|alias| to_kebab_case(alias) == requested_operation)
     }
 
     /// Add command header with title and description
@@ -333,28 +340,36 @@ impl DocumentationGenerator {
             .get(api_name)
             .ok_or_else(|| Error::spec_not_found(api_name))?;
 
-        let mut overview = String::new();
-
-        // API header
-        write!(overview, "# {} API\n\n", spec.name).ok();
-        writeln!(overview, "**Version**: {}", spec.version).ok();
-
-        if let Some(ref base_url) = spec.base_url {
-            writeln!(overview, "**Base URL**: {base_url}").ok();
-        }
-        overview.push('\n');
-
-        // Statistics (hidden commands are excluded from docs-style listings)
         let visible_commands: Vec<&CachedCommand> = spec
             .commands
             .iter()
             .filter(|command| !command.hidden)
             .collect();
-        let total_operations = visible_commands.len();
+
+        let mut overview = String::new();
+        Self::write_api_overview_header(&mut overview, spec);
+        Self::write_api_overview_statistics(&mut overview, &visible_commands);
+        Self::write_api_overview_quick_start(&mut overview, api_name);
+        Self::write_api_overview_samples(&mut overview, api_name, &visible_commands);
+
+        Ok(overview)
+    }
+
+    fn write_api_overview_header(overview: &mut String, spec: &CachedSpec) {
+        write!(overview, "# {} API\n\n", spec.name).ok();
+        writeln!(overview, "**Version**: {}", spec.version).ok();
+
+        if let Some(base_url) = spec.base_url.as_deref() {
+            writeln!(overview, "**Base URL**: {base_url}").ok();
+        }
+        overview.push('\n');
+    }
+
+    fn write_api_overview_statistics(overview: &mut String, visible_commands: &[&CachedCommand]) {
         let mut method_counts = BTreeMap::new();
         let mut tag_counts = BTreeMap::new();
 
-        for command in &visible_commands {
+        for command in visible_commands {
             *method_counts.entry(command.method.clone()).or_insert(0) += 1;
             *tag_counts
                 .entry(Self::effective_group(command))
@@ -362,7 +377,12 @@ impl DocumentationGenerator {
         }
 
         overview.push_str("## Statistics\n\n");
-        writeln!(overview, "- **Total Operations**: {total_operations}").ok();
+        writeln!(
+            overview,
+            "- **Total Operations**: {}",
+            visible_commands.len()
+        )
+        .ok();
         overview.push_str("- **Methods**:\n");
         for (method, count) in method_counts {
             writeln!(overview, "  - {method}: {count}").ok();
@@ -372,8 +392,9 @@ impl DocumentationGenerator {
             writeln!(overview, "  - {tag}: {count}").ok();
         }
         overview.push('\n');
+    }
 
-        // Quick start examples
+    fn write_api_overview_quick_start(overview: &mut String, api_name: &str) {
         overview.push_str("## Quick Start\n\n");
         write!(
             overview,
@@ -384,27 +405,33 @@ impl DocumentationGenerator {
         write!(
             overview,
             "Search for specific operations:\n```bash\naperture search \"keyword\" --api {api_name}\n```\n\n"
-        ).ok();
+        )
+        .ok();
+    }
 
-        // Show first few operations as examples
-        if !visible_commands.is_empty() {
-            overview.push_str("## Sample Operations\n\n");
-            for (i, command) in visible_commands.iter().take(3).enumerate() {
-                let tag = Self::effective_group(command);
-                let operation = Self::effective_operation(command);
-                write!(
-                    overview,
-                    "{}. **{}** ({})\n   ```bash\n   aperture api {api_name} {tag} {operation}\n   ```\n   {}\n\n",
-                    i + 1,
-                    command.summary.as_deref().unwrap_or(&operation),
-                    command.method.to_uppercase(),
-                    command.description.as_deref().unwrap_or("No description")
-                )
-                .ok();
-            }
+    fn write_api_overview_samples(
+        overview: &mut String,
+        api_name: &str,
+        visible_commands: &[&CachedCommand],
+    ) {
+        if visible_commands.is_empty() {
+            return;
         }
 
-        Ok(overview)
+        overview.push_str("## Sample Operations\n\n");
+        for (i, command) in visible_commands.iter().take(3).enumerate() {
+            let tag = Self::effective_group(command);
+            let operation = Self::effective_operation(command);
+            write!(
+                overview,
+                "{}. **{}** ({})\n   ```bash\n   aperture api {api_name} {tag} {operation}\n   ```\n   {}\n\n",
+                i + 1,
+                command.summary.as_deref().unwrap_or(&operation),
+                command.method.to_uppercase(),
+                command.description.as_deref().unwrap_or("No description")
+            )
+            .ok();
+        }
     }
 
     /// Generate interactive help menu

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -38,21 +38,27 @@ pub fn parse_duration(s: &str) -> Result<Duration, Error> {
         ));
     }
 
-    if let Some(duration) = parse_duration_suffix(s, "ms", "milliseconds", Duration::from_millis)? {
-        return Ok(duration);
-    }
-
-    if let Some(duration) = parse_duration_suffix(s, "m", "minutes", |minutes| {
-        Duration::from_secs(minutes * 60)
-    })? {
-        return Ok(duration);
-    }
-
-    if let Some(duration) = parse_duration_suffix(s, "s", "seconds", Duration::from_secs)? {
+    if let Some(duration) = parse_duration_with_suffixes(s)? {
         return Ok(duration);
     }
 
     Ok(Duration::from_millis(parse_plain_millis(s)?))
+}
+
+fn parse_duration_with_suffixes(value: &str) -> Result<Option<Duration>, Error> {
+    if let Some(duration) =
+        parse_duration_suffix(value, "ms", "milliseconds", Duration::from_millis)?
+    {
+        return Ok(Some(duration));
+    }
+
+    if let Some(duration) = parse_duration_suffix(value, "m", "minutes", |minutes| {
+        Duration::from_secs(minutes * 60)
+    })? {
+        return Ok(Some(duration));
+    }
+
+    parse_duration_suffix(value, "s", "seconds", Duration::from_secs)
 }
 
 fn parse_duration_suffix(

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -674,31 +674,39 @@ fn resolve_authentication_secret(
     api_name: &str,
     global_config: Option<&GlobalConfig>,
 ) -> Result<Option<ResolvedAuthenticationSecret>, Error> {
-    let secret_config = global_config
+    let configured_secret = global_config
         .and_then(|config| config.api_configs.get(api_name))
         .and_then(|api_config| api_config.secrets.get(&security_scheme.name));
 
-    match (secret_config, &security_scheme.aperture_secret) {
-        (Some(config_secret), _) => {
-            let value = std::env::var(&config_secret.name)
-                .map_err(|_| Error::secret_not_set(&security_scheme.name, &config_secret.name))?;
-            Ok(Some(ResolvedAuthenticationSecret {
-                value,
-                env_var_name: config_secret.name.clone(),
-                source: "config",
-            }))
-        }
-        (None, Some(aperture_secret)) => {
-            let value = std::env::var(&aperture_secret.name)
-                .map_err(|_| Error::secret_not_set(&security_scheme.name, &aperture_secret.name))?;
-            Ok(Some(ResolvedAuthenticationSecret {
-                value,
-                env_var_name: aperture_secret.name.clone(),
-                source: "x-aperture-secret",
-            }))
-        }
-        (None, None) => Ok(None),
+    if let Some(secret) = configured_secret {
+        return resolve_secret_from_env(&security_scheme.name, &secret.name, "config").map(Some);
     }
+
+    let Some(aperture_secret) = &security_scheme.aperture_secret else {
+        return Ok(None);
+    };
+
+    resolve_secret_from_env(
+        &security_scheme.name,
+        &aperture_secret.name,
+        "x-aperture-secret",
+    )
+    .map(Some)
+}
+
+fn resolve_secret_from_env(
+    scheme_name: &str,
+    env_var_name: &str,
+    source: &'static str,
+) -> Result<ResolvedAuthenticationSecret, Error> {
+    let value = std::env::var(env_var_name)
+        .map_err(|_| Error::secret_not_set(scheme_name, env_var_name))?;
+
+    Ok(ResolvedAuthenticationSecret {
+        value,
+        env_var_name: env_var_name.to_string(),
+        source,
+    })
 }
 
 fn insert_api_key_header(

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,8 @@ pub enum Error {
 /// This enum represents the 8 primary error categories used throughout
 /// the application. All internal errors are mapped to one of these categories
 /// to provide consistent error handling and reporting.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(usize)]
 pub enum ErrorKind {
     /// Specification-related errors (not found, already exists, cache issues)
     Specification,
@@ -134,20 +135,22 @@ impl ErrorContext {
 }
 
 impl ErrorKind {
+    const NAMES: [&'static str; 9] = [
+        "Specification",
+        "Authentication",
+        "Validation",
+        "Network",
+        "HttpError",
+        "Headers",
+        "Interactive",
+        "ServerVariable",
+        "Runtime",
+    ];
+
     /// Get the string identifier for this error kind
     #[must_use]
     pub const fn as_str(&self) -> &'static str {
-        match self {
-            Self::Specification => "Specification",
-            Self::Authentication => "Authentication",
-            Self::Validation => "Validation",
-            Self::Network => "Network",
-            Self::HttpRequest => "HttpError",
-            Self::Headers => "Headers",
-            Self::Interactive => "Interactive",
-            Self::ServerVariable => "ServerVariable",
-            Self::Runtime => "Runtime",
-        }
+        Self::NAMES[*self as usize]
     }
 }
 
@@ -290,7 +293,7 @@ impl Error {
                 kind,
                 message,
                 context: ctx,
-            } => internal_error_json_parts(kind, message.as_ref(), ctx.as_ref()),
+            } => internal_error_json_parts(*kind, message.as_ref(), ctx.as_ref()),
             Self::Anyhow(anyhow_err) => ("Unknown", anyhow_err.to_string(), None, None),
         };
 
@@ -336,7 +339,7 @@ fn network_error_json_parts(
 }
 
 fn internal_error_json_parts(
-    kind: &ErrorKind,
+    kind: ErrorKind,
     message: &str,
     context: Option<&ErrorContext>,
 ) -> (

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -344,6 +344,14 @@ pub fn select_from_options_with_io_and_timeout<T: InputOutput>(
     io.println(prompt)?;
     print_selection_options(options, io)?;
 
+    run_selection_attempts(options, io, timeout)
+}
+
+fn run_selection_attempts<T: InputOutput>(
+    options: &[(String, String)],
+    io: &T,
+    timeout: Duration,
+) -> Result<String, Error> {
     for attempt in 1..=MAX_RETRIES {
         match resolve_selection_attempt(options, io, timeout)? {
             SelectionOutcome::Selected(choice) => return Ok(choice),
@@ -352,11 +360,15 @@ pub fn select_from_options_with_io_and_timeout<T: InputOutput>(
         }
     }
 
-    Err(Error::interactive_retries_exhausted(
+    Err(selection_retries_exhausted(options))
+}
+
+fn selection_retries_exhausted(options: &[(String, String)]) -> Error {
+    Error::interactive_retries_exhausted(
         MAX_RETRIES,
         "Invalid selection",
         &build_selection_suggestions(options),
-    ))
+    )
 }
 
 fn report_invalid_selection<T: InputOutput>(

--- a/src/response_cache.rs
+++ b/src/response_cache.rs
@@ -194,21 +194,13 @@ impl ResponseCache {
             return Ok(());
         }
 
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|e| Error::invalid_config(format!("System time error: {e}")))?
-            .as_secs();
-
-        let ttl_seconds = ttl.unwrap_or(self.config.default_ttl).as_secs();
-
-        let cached_response = CachedResponse {
-            body: body.to_string(),
+        let cached_response = Self::build_cached_response(
+            body,
             status_code,
-            headers: headers.clone(),
-            cached_at: now,
-            ttl_seconds,
+            headers,
             request_info,
-        };
+            ttl.unwrap_or(self.config.default_ttl),
+        )?;
 
         let cache_file = self.config.cache_dir.join(key.to_filename());
         let json_content = serde_json::to_string_pretty(&cached_response).map_err(|e| {
@@ -230,6 +222,30 @@ impl ResponseCache {
         Ok(())
     }
 
+    fn build_cached_response(
+        body: &str,
+        status_code: u16,
+        headers: &HashMap<String, String>,
+        request_info: CachedRequestInfo,
+        ttl: Duration,
+    ) -> Result<CachedResponse, Error> {
+        Ok(CachedResponse {
+            body: body.to_string(),
+            status_code,
+            headers: headers.clone(),
+            cached_at: Self::current_unix_timestamp()?,
+            ttl_seconds: ttl.as_secs(),
+            request_info,
+        })
+    }
+
+    fn current_unix_timestamp() -> Result<u64, Error> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| Error::invalid_config(format!("System time error: {e}")))
+            .map(|duration| duration.as_secs())
+    }
+
     /// Retrieve a response from the cache if it exists and is still valid
     ///
     /// # Errors
@@ -243,25 +259,12 @@ impl ResponseCache {
         }
 
         let cache_file = self.config.cache_dir.join(key.to_filename());
-
         if !cache_file.exists() {
             return Ok(None);
         }
 
-        let json_content = tokio::fs::read_to_string(&cache_file)
-            .await
-            .map_err(|e| Error::io_error(format!("Failed to read cache file: {e}")))?;
-        let cached_response: CachedResponse = serde_json::from_str(&json_content).map_err(|e| {
-            Error::serialization_error(format!("Failed to deserialize cached response: {e}"))
-        })?;
-
-        // Check if the cache entry is still valid
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|e| Error::invalid_config(format!("System time error: {e}")))?
-            .as_secs();
-
-        if now > cached_response.cached_at + cached_response.ttl_seconds {
+        let cached_response = Self::read_cached_response(&cache_file).await?;
+        if Self::is_expired(&cached_response)? {
             // Cache entry has expired — don't eagerly delete here because
             // deletion is a mutating operation that should be coordinated
             // under the advisory lock. Expired entries are cleaned up by
@@ -270,6 +273,21 @@ impl ResponseCache {
         }
 
         Ok(Some(cached_response))
+    }
+
+    async fn read_cached_response(cache_file: &std::path::Path) -> Result<CachedResponse, Error> {
+        let json_content = tokio::fs::read_to_string(cache_file)
+            .await
+            .map_err(|e| Error::io_error(format!("Failed to read cache file: {e}")))?;
+
+        serde_json::from_str(&json_content).map_err(|e| {
+            Error::serialization_error(format!("Failed to deserialize cached response: {e}"))
+        })
+    }
+
+    fn is_expired(cached_response: &CachedResponse) -> Result<bool, Error> {
+        Ok(Self::current_unix_timestamp()?
+            > cached_response.cached_at + cached_response.ttl_seconds)
     }
 
     /// Check if a response is cached and valid for the given key
@@ -291,33 +309,11 @@ impl ResponseCache {
     /// Returns an error if cache files cannot be removed
     pub async fn clear_api_cache(&self, api_name: &str) -> Result<usize, Error> {
         let _lock = self.acquire_lock().await?;
-
-        let mut cleared_count = 0;
-        let mut entries = tokio::fs::read_dir(&self.config.cache_dir)
-            .await
-            .map_err(|e| Error::io_error(format!("I/O operation failed: {e}")))?;
-
-        while let Some(entry) = entries
-            .next_entry()
-            .await
-            .map_err(|e| Error::io_error(format!("I/O operation failed: {e}")))?
-        {
-            let filename = entry.file_name();
-            if Self::is_api_cache_entry(api_name, &filename) {
-                tokio::fs::remove_file(entry.path())
-                    .await
-                    .map_err(|e| Error::io_error(format!("I/O operation failed: {e}")))?;
-                cleared_count += 1;
-            }
-        }
-
-        Ok(cleared_count)
-    }
-
-    fn is_api_cache_entry(api_name: &str, filename: &std::ffi::OsStr) -> bool {
-        let filename = filename.to_string_lossy();
-        filename.starts_with(&format!("{api_name}_"))
-            && filename.ends_with(constants::CACHE_FILE_SUFFIX)
+        self.clear_matching_entries(|filename| {
+            filename.starts_with(&format!("{api_name}_"))
+                && filename.ends_with(constants::CACHE_FILE_SUFFIX)
+        })
+        .await
     }
 
     /// Clear all cached responses
@@ -330,7 +326,14 @@ impl ResponseCache {
     /// Returns an error if cache directory cannot be cleared
     pub async fn clear_all(&self) -> Result<usize, Error> {
         let _lock = self.acquire_lock().await?;
+        self.clear_matching_entries(|filename| filename.ends_with(constants::CACHE_FILE_SUFFIX))
+            .await
+    }
 
+    async fn clear_matching_entries(
+        &self,
+        should_remove: impl Fn(&str) -> bool,
+    ) -> Result<usize, Error> {
         let mut cleared_count = 0;
         let mut entries = tokio::fs::read_dir(&self.config.cache_dir)
             .await
@@ -342,14 +345,14 @@ impl ResponseCache {
             .map_err(|e| Error::io_error(format!("I/O operation failed: {e}")))?
         {
             let filename = entry.file_name();
-            let filename_str = filename.to_string_lossy();
-
-            if filename_str.ends_with(constants::CACHE_FILE_SUFFIX) {
-                tokio::fs::remove_file(entry.path())
-                    .await
-                    .map_err(|e| Error::io_error(format!("I/O operation failed: {e}")))?;
-                cleared_count += 1;
+            if !should_remove(&filename.to_string_lossy()) {
+                continue;
             }
+
+            tokio::fs::remove_file(entry.path())
+                .await
+                .map_err(|e| Error::io_error(format!("I/O operation failed: {e}")))?;
+            cleared_count += 1;
         }
 
         Ok(cleared_count)
@@ -515,20 +518,31 @@ impl ResponseCache {
             .await;
         }
 
-        for path in &stale_tmp_files {
-            let _ = tokio::fs::remove_file(path).await;
-        }
-
-        if entries.len() > self.config.max_entries {
-            entries.sort_by_key(|(_, modified)| *modified);
-            let to_remove = entries.len() - self.config.max_entries;
-
-            for (path, _) in entries.iter().take(to_remove) {
-                let _ = tokio::fs::remove_file(path).await;
-            }
-        }
+        Self::remove_files_ignoring_errors(&stale_tmp_files).await;
+        Self::trim_cache_entries(entries, self.config.max_entries).await;
 
         Ok(())
+    }
+
+    async fn remove_files_ignoring_errors(paths: &[std::path::PathBuf]) {
+        for path in paths {
+            let _ = tokio::fs::remove_file(path).await;
+        }
+    }
+
+    async fn trim_cache_entries(
+        mut entries: Vec<(std::path::PathBuf, SystemTime)>,
+        max_entries: usize,
+    ) {
+        if entries.len() <= max_entries {
+            return;
+        }
+
+        entries.sort_by_key(|(_, modified)| *modified);
+        let to_remove = entries.len() - max_entries;
+        for (path, _) in entries.iter().take(to_remove) {
+            let _ = tokio::fs::remove_file(path).await;
+        }
     }
 }
 

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -81,87 +81,122 @@ impl ShortcutResolver {
 
     /// Index all available commands for shortcut resolution
     pub fn index_specs(&mut self, specs: &BTreeMap<String, CachedSpec>) {
-        // Clear existing indexes
-        self.operation_map.clear();
-        self.method_path_map.clear();
-        self.tag_map.clear();
+        self.clear_indexes();
 
         for (api_name, spec) in specs {
             for command in &spec.commands {
-                // Index by operation ID (both original and kebab-case)
-                let operation_kebab = to_kebab_case(&command.operation_id);
-
-                // Original operation ID
-                if !command.operation_id.is_empty() {
-                    self.operation_map
-                        .entry(command.operation_id.clone())
-                        .or_default()
-                        .push((api_name.clone(), spec.clone(), command.clone()));
-                }
-
-                // Kebab-case operation ID
-                if operation_kebab != command.operation_id {
-                    self.operation_map
-                        .entry(operation_kebab.clone())
-                        .or_default()
-                        .push((api_name.clone(), spec.clone(), command.clone()));
-                }
-
-                // Index by HTTP method + path
-                let method = command.method.to_uppercase();
-                let path = &command.path;
-                let method_path_key = format!("{method} {path}");
-                self.method_path_map
-                    .entry(method_path_key)
-                    .or_default()
-                    .push((api_name.clone(), spec.clone(), command.clone()));
-
-                // Index by display name (custom command name override)
-                if let Some(ref display_name) = command.display_name {
-                    let display_kebab = to_kebab_case(display_name);
-                    self.operation_map.entry(display_kebab).or_default().push((
-                        api_name.clone(),
-                        spec.clone(),
-                        command.clone(),
-                    ));
-                }
-
-                // Index by aliases
-                for alias in &command.aliases {
-                    let alias_kebab = to_kebab_case(alias);
-                    self.operation_map.entry(alias_kebab).or_default().push((
-                        api_name.clone(),
-                        spec.clone(),
-                        command.clone(),
-                    ));
-                }
-
-                // Index by tags (and display_group override)
-                let mut effective_tags: Vec<String> =
-                    command.tags.iter().map(|t| to_kebab_case(t)).collect();
-                if let Some(dg) = &command.display_group {
-                    effective_tags.push(to_kebab_case(dg));
-                }
-
-                let effective_name = command.display_name.as_deref().unwrap_or(&operation_kebab);
-
-                for tag_key in &effective_tags {
-                    self.tag_map.entry(tag_key.clone()).or_default().push((
-                        api_name.clone(),
-                        spec.clone(),
-                        command.clone(),
-                    ));
-
-                    // Also index tag + operation combinations (with effective name)
-                    let tag_operation_key = format!("{tag_key} {}", to_kebab_case(effective_name));
-                    self.tag_map.entry(tag_operation_key).or_default().push((
-                        api_name.clone(),
-                        spec.clone(),
-                        command.clone(),
-                    ));
-                }
+                self.index_single_command(api_name, spec, command);
             }
         }
+    }
+
+    fn clear_indexes(&mut self) {
+        self.operation_map.clear();
+        self.method_path_map.clear();
+        self.tag_map.clear();
+    }
+
+    fn index_single_command(&mut self, api_name: &str, spec: &CachedSpec, command: &CachedCommand) {
+        let operation_kebab = to_kebab_case(&command.operation_id);
+        self.index_operation_identifiers(api_name, spec, command, &operation_kebab);
+        self.index_method_path(api_name, spec, command);
+        self.index_display_and_aliases(api_name, spec, command);
+        self.index_tags(api_name, spec, command, &operation_kebab);
+    }
+
+    fn index_operation_identifiers(
+        &mut self,
+        api_name: &str,
+        spec: &CachedSpec,
+        command: &CachedCommand,
+        operation_kebab: &str,
+    ) {
+        if !command.operation_id.is_empty() {
+            self.push_operation_entry(&command.operation_id, api_name, spec, command);
+        }
+
+        if operation_kebab != command.operation_id {
+            self.push_operation_entry(operation_kebab, api_name, spec, command);
+        }
+    }
+
+    fn index_method_path(&mut self, api_name: &str, spec: &CachedSpec, command: &CachedCommand) {
+        let method_path_key = format!("{} {}", command.method.to_uppercase(), command.path);
+        self.method_path_map
+            .entry(method_path_key)
+            .or_default()
+            .push((api_name.to_string(), spec.clone(), command.clone()));
+    }
+
+    fn index_display_and_aliases(
+        &mut self,
+        api_name: &str,
+        spec: &CachedSpec,
+        command: &CachedCommand,
+    ) {
+        if let Some(display_name) = command.display_name.as_deref() {
+            self.push_operation_entry(&to_kebab_case(display_name), api_name, spec, command);
+        }
+
+        for alias in &command.aliases {
+            self.push_operation_entry(&to_kebab_case(alias), api_name, spec, command);
+        }
+    }
+
+    fn index_tags(
+        &mut self,
+        api_name: &str,
+        spec: &CachedSpec,
+        command: &CachedCommand,
+        operation_kebab: &str,
+    ) {
+        let mut effective_tags: Vec<String> =
+            command.tags.iter().map(|tag| to_kebab_case(tag)).collect();
+        if let Some(display_group) = command.display_group.as_deref() {
+            effective_tags.push(to_kebab_case(display_group));
+        }
+
+        let effective_name = command
+            .display_name
+            .as_deref()
+            .map_or_else(|| operation_kebab.to_string(), to_kebab_case);
+
+        for tag_key in effective_tags {
+            self.push_tag_entry(&tag_key, api_name, spec, command);
+            self.push_tag_entry(
+                &format!("{tag_key} {effective_name}"),
+                api_name,
+                spec,
+                command,
+            );
+        }
+    }
+
+    fn push_operation_entry(
+        &mut self,
+        key: &str,
+        api_name: &str,
+        spec: &CachedSpec,
+        command: &CachedCommand,
+    ) {
+        self.operation_map
+            .entry(key.to_string())
+            .or_default()
+            .push((api_name.to_string(), spec.clone(), command.clone()));
+    }
+
+    fn push_tag_entry(
+        &mut self,
+        key: &str,
+        api_name: &str,
+        spec: &CachedSpec,
+        command: &CachedCommand,
+    ) {
+        self.tag_map.entry(key.to_string()).or_default().push((
+            api_name.to_string(),
+            spec.clone(),
+            command.clone(),
+        ));
     }
 
     /// Resolve a command shortcut to full command path

--- a/src/spec/parser.rs
+++ b/src/spec/parser.rs
@@ -138,38 +138,50 @@ fn fix_component_indentation(content: &str) -> String {
 /// - Webhooks are not supported
 /// - JSON Schema 2020-12 features may not be preserved
 pub fn parse_openapi(content: &str) -> Result<OpenAPI, Error> {
-    // Always preprocess for compatibility issues
+    // Always preprocess for compatibility issues.
     let mut preprocessed = preprocess_for_compatibility(content);
 
-    // Check if this looks like OpenAPI 3.1.x (both YAML and JSON formats)
-    if content.contains("openapi: 3.1")
-        || content.contains("openapi: \"3.1")
-        || content.contains("openapi: '3.1")
-        || content.contains(r#""openapi":"3.1"#)
-        || content.contains(r#""openapi": "3.1"#)
-    {
+    let is_openapi_31 = looks_like_openapi_31(content);
+    if is_openapi_31 {
         // For OpenAPI 3.1 specs, also fix potential indentation issues
-        // (some 3.1 specs like OpenProject have malformed indentation)
+        // (some 3.1 specs like OpenProject have malformed indentation).
         preprocessed = fix_component_indentation(&preprocessed);
+    }
 
-        // Try oas3 first for 3.1 specs - pass original content for security scheme extraction
-        match parse_with_oas3_direct_with_original(&preprocessed, content) {
-            Ok(spec) => return Ok(spec),
-            #[cfg(not(feature = "openapi31"))]
-            Err(e) => return Err(e), // Return the "not enabled" error immediately
-            #[cfg(feature = "openapi31")]
-            Err(_) => {} // Fall through to try regular parsing
+    #[cfg(feature = "openapi31")]
+    {
+        let parsed_openapi_31 = if is_openapi_31 {
+            parse_with_oas3_direct_with_original(&preprocessed, content).ok()
+        } else {
+            None
+        };
+
+        if let Some(spec) = parsed_openapi_31 {
+            return Ok(spec);
         }
     }
 
-    // Try parsing as OpenAPI 3.0.x (most common case)
-    // Detect format based on content structure
+    #[cfg(not(feature = "openapi31"))]
+    if is_openapi_31 {
+        return parse_with_oas3_direct_with_original(&preprocessed, content);
+    }
+
+    // Try parsing as OpenAPI 3.0.x (most common case).
+    // Detect format based on content structure.
     let trimmed = content.trim();
     if trimmed.starts_with('{') {
         parse_json_with_fallback(&preprocessed)
     } else {
         parse_yaml_with_fallback(&preprocessed)
     }
+}
+
+fn looks_like_openapi_31(content: &str) -> bool {
+    content.contains("openapi: 3.1")
+        || content.contains("openapi: \"3.1")
+        || content.contains("openapi: '3.1")
+        || content.contains(r#""openapi":"3.1"#)
+        || content.contains(r#""openapi": "3.1"#)
 }
 
 /// Parse JSON content with YAML fallback

--- a/src/spec/parser.rs
+++ b/src/spec/parser.rs
@@ -397,6 +397,36 @@ paths: {}
     }
 
     #[test]
+    fn test_parse_openapi_31_json_format() {
+        let spec_31_json = r#"{"openapi": "3.1.0", "info": {"title": "Test API", "version": "1.0.0"}, "paths": {}}"#;
+
+        let result = parse_openapi(spec_31_json);
+
+        #[cfg(feature = "openapi31")]
+        {
+            assert!(result.is_ok());
+            if let Ok(spec) = result {
+                assert!(spec.openapi.starts_with("3."));
+            }
+        }
+
+        #[cfg(not(feature = "openapi31"))]
+        {
+            assert!(result.is_err());
+            if let Err(Error::Internal {
+                kind: crate::error::ErrorKind::Validation,
+                message,
+                ..
+            }) = result
+            {
+                assert!(message.contains("OpenAPI 3.1 support is not enabled"));
+            } else {
+                panic!("Expected validation error about missing 3.1 support");
+            }
+        }
+    }
+
+    #[test]
     fn test_parse_invalid_yaml() {
         let invalid_yaml = "not: valid: yaml: at: all:";
 

--- a/src/spec/transformer.rs
+++ b/src/spec/transformer.rs
@@ -150,22 +150,35 @@ impl SpecTransformer {
         skip_endpoints: &[(String, String)],
         warnings: &[crate::spec::validator::ValidationWarning],
     ) -> Result<CachedSpec, Error> {
-        let mut commands = Vec::new();
-
-        // Extract version from info
-        let version = spec.info.version.clone();
-
-        // Extract server URLs
-        let servers: Vec<String> = spec.servers.iter().map(|s| s.url.clone()).collect();
-        let base_url = servers.first().cloned();
-
-        // Extract server variables from the first server (if any)
-        let server_variables: HashMap<String, crate::cache::models::ServerVariable> = spec
+        let servers: Vec<String> = spec
             .servers
+            .iter()
+            .map(|server| server.url.clone())
+            .collect();
+        let commands = Self::collect_commands(spec, skip_endpoints)?;
+
+        Ok(CachedSpec {
+            cache_format_version: CACHE_FORMAT_VERSION,
+            name: name.to_string(),
+            version: spec.info.version.clone(),
+            commands,
+            base_url: servers.first().cloned(),
+            servers,
+            security_schemes: Self::extract_security_schemes(spec),
+            skipped_endpoints: Self::build_skipped_endpoints(warnings),
+            server_variables: Self::extract_server_variables(spec),
+        })
+    }
+
+    fn extract_server_variables(
+        spec: &OpenAPI,
+    ) -> HashMap<String, crate::cache::models::ServerVariable> {
+        spec.servers
             .first()
             .and_then(|server| server.variables.as_ref())
-            .map(|vars| {
-                vars.iter()
+            .map(|variables| {
+                variables
+                    .iter()
                     .map(|(name, variable)| {
                         (
                             name.clone(),
@@ -178,20 +191,27 @@ impl SpecTransformer {
                     })
                     .collect()
             })
-            .unwrap_or_default();
+            .unwrap_or_default()
+    }
 
-        // Extract global security requirements
-        let global_security_requirements: Vec<String> = spec
-            .security
+    fn extract_global_security_requirements(spec: &OpenAPI) -> Vec<String> {
+        spec.security
             .iter()
-            .flat_map(|security_vec| {
-                security_vec
+            .flat_map(|security_group| {
+                security_group
                     .iter()
                     .flat_map(|security_req| security_req.keys().cloned())
             })
-            .collect();
+            .collect()
+    }
 
-        // Process all paths and operations
+    fn collect_commands(
+        spec: &OpenAPI,
+        skip_endpoints: &[(String, String)],
+    ) -> Result<Vec<CachedCommand>, Error> {
+        let global_security_requirements = Self::extract_global_security_requirements(spec);
+        let mut commands = Vec::new();
+
         for (path, path_item) in spec.paths.iter() {
             Self::process_path_item(
                 spec,
@@ -203,31 +223,21 @@ impl SpecTransformer {
             )?;
         }
 
-        // Extract security schemes
-        let security_schemes = Self::extract_security_schemes(spec);
+        Ok(commands)
+    }
 
-        // Convert warnings to skipped endpoints
-        let skipped_endpoints: Vec<SkippedEndpoint> = warnings
+    fn build_skipped_endpoints(
+        warnings: &[crate::spec::validator::ValidationWarning],
+    ) -> Vec<SkippedEndpoint> {
+        warnings
             .iter()
-            .map(|w| SkippedEndpoint {
-                path: w.endpoint.path.clone(),
-                method: w.endpoint.method.clone(),
-                content_type: w.endpoint.content_type.clone(),
-                reason: w.reason.clone(),
+            .map(|warning| SkippedEndpoint {
+                path: warning.endpoint.path.clone(),
+                method: warning.endpoint.method.clone(),
+                content_type: warning.endpoint.content_type.clone(),
+                reason: warning.reason.clone(),
             })
-            .collect();
-
-        Ok(CachedSpec {
-            cache_format_version: CACHE_FORMAT_VERSION,
-            name: name.to_string(),
-            version,
-            commands,
-            base_url,
-            servers,
-            security_schemes,
-            skipped_endpoints,
-            server_variables,
-        })
+            .collect()
     }
 
     /// Process a single path item and its operations
@@ -754,33 +764,35 @@ impl SpecTransformer {
 
     /// Extracts x-aperture-secret extension from a security scheme
     fn extract_aperture_secret(scheme: &SecurityScheme) -> Option<CachedApertureSecret> {
-        // Get extensions from the security scheme
-        let extensions = match scheme {
+        Self::security_scheme_extensions(scheme)
+            .and_then(|extensions| extensions.get(crate::constants::EXT_APERTURE_SECRET))
+            .and_then(Self::parse_aperture_secret_extension)
+    }
+
+    const fn security_scheme_extensions(
+        scheme: &SecurityScheme,
+    ) -> Option<&indexmap::IndexMap<String, serde_json::Value>> {
+        match scheme {
             SecurityScheme::APIKey { extensions, .. } | SecurityScheme::HTTP { extensions, .. } => {
-                extensions
+                Some(extensions)
             }
-            SecurityScheme::OAuth2 { .. } | SecurityScheme::OpenIDConnect { .. } => return None,
-        };
+            SecurityScheme::OAuth2 { .. } | SecurityScheme::OpenIDConnect { .. } => None,
+        }
+    }
 
-        // Parse the x-aperture-secret extension
-        extensions
-            .get(crate::constants::EXT_APERTURE_SECRET)
-            .and_then(|value| {
-                // The extension should be an object with "source" and "name" fields
-                let obj = value.as_object()?;
-                let source = obj.get(crate::constants::EXT_KEY_SOURCE)?.as_str()?;
-                let name = obj.get(crate::constants::EXT_KEY_NAME)?.as_str()?;
+    fn parse_aperture_secret_extension(value: &serde_json::Value) -> Option<CachedApertureSecret> {
+        let obj = value.as_object()?;
+        let source = obj.get(crate::constants::EXT_KEY_SOURCE)?.as_str()?;
+        let name = obj.get(crate::constants::EXT_KEY_NAME)?.as_str()?;
 
-                // Currently only "env" source is supported
-                if source != constants::SOURCE_ENV {
-                    return None;
-                }
+        if source != constants::SOURCE_ENV {
+            return None;
+        }
 
-                Some(CachedApertureSecret {
-                    source: source.to_string(),
-                    name: name.to_string(),
-                })
-            })
+        Some(CachedApertureSecret {
+            source: source.to_string(),
+            name: name.to_string(),
+        })
     }
 
     /// Resolves a parameter reference to its actual parameter definition
@@ -1157,43 +1169,50 @@ fn detect_offset_from_parameters(
     let mut limit_param: Option<String> = None;
 
     for param_ref in params {
-        let param = match param_ref {
-            openapiv3::ReferenceOr::Item(p) => std::borrow::Cow::Borrowed(p),
-            openapiv3::ReferenceOr::Reference { reference } => {
-                let Ok(resolved) = crate::spec::resolve_parameter_reference(spec, reference) else {
-                    continue;
-                };
-                std::borrow::Cow::Owned(resolved)
-            }
-        };
-
-        // Only consider query parameters
-        let openapiv3::Parameter::Query { parameter_data, .. } = param.as_ref() else {
+        let Some(param) = resolve_parameter_for_pagination(param_ref, spec) else {
             continue;
         };
 
-        let name = parameter_data.name.as_str();
-        match () {
-            () if constants::PAGINATION_PAGE_PARAMS.contains(&name) => {
-                page_param = Some(name.to_string());
-            }
-            () if constants::PAGINATION_LIMIT_PARAMS.contains(&name) => {
-                limit_param = Some(name.to_string());
-            }
-            () => {}
+        update_offset_pagination_params(param.as_ref(), &mut page_param, &mut limit_param);
+    }
+
+    page_param.map(|page_param| PaginationInfo {
+        strategy: PaginationStrategy::Offset,
+        page_param: Some(page_param),
+        limit_param,
+        ..Default::default()
+    })
+}
+
+fn resolve_parameter_for_pagination<'a>(
+    param_ref: &'a openapiv3::ReferenceOr<openapiv3::Parameter>,
+    spec: &'a OpenAPI,
+) -> Option<std::borrow::Cow<'a, openapiv3::Parameter>> {
+    match param_ref {
+        openapiv3::ReferenceOr::Item(param) => Some(std::borrow::Cow::Borrowed(param)),
+        openapiv3::ReferenceOr::Reference { reference } => {
+            crate::spec::resolve_parameter_reference(spec, reference)
+                .ok()
+                .map(std::borrow::Cow::Owned)
         }
     }
+}
 
-    if page_param.is_some() {
-        return Some(PaginationInfo {
-            strategy: PaginationStrategy::Offset,
-            page_param,
-            limit_param,
-            ..Default::default()
-        });
+fn update_offset_pagination_params(
+    parameter: &openapiv3::Parameter,
+    page_param: &mut Option<String>,
+    limit_param: &mut Option<String>,
+) {
+    let openapiv3::Parameter::Query { parameter_data, .. } = parameter else {
+        return;
+    };
+
+    let name = parameter_data.name.as_str();
+    if constants::PAGINATION_PAGE_PARAMS.contains(&name) {
+        *page_param = Some(name.to_string());
+    } else if constants::PAGINATION_LIMIT_PARAMS.contains(&name) {
+        *limit_param = Some(name.to_string());
     }
-
-    None
 }
 
 #[cfg(test)]

--- a/tests/interactive_workflow_tests.rs
+++ b/tests/interactive_workflow_tests.rs
@@ -234,47 +234,9 @@ fn test_select_from_options_with_invalid_input_retry() {
     let mut mock = MockInputOutputImpl::new();
     let options = vec![("option1".to_string(), "First option".to_string())];
 
-    mock.expect_println()
-        .with(eq("Choose:"))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_println()
-        .with(eq("  1: option1 - First option"))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    // First attempt - invalid input
-    mock.expect_print()
-        .with(eq("Enter your choice (number or name): "))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_flush().times(1).returning(|| Ok(()));
-
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("invalid\n".to_string()));
-
-    // Error message
-    mock.expect_println()
-        .with(eq(
-            "Invalid selection. Please enter a number (1-1) or a valid name. (Attempt 1 of 3)",
-        ))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    // Second attempt - valid input
-    mock.expect_print()
-        .with(eq("Enter your choice (number or name): "))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_flush().times(1).returning(|| Ok(()));
-
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("1\n".to_string()));
+    expect_selection_prompt(&mut mock);
+    expect_invalid_selection_attempt(&mut mock, 1, "invalid", true);
+    expect_valid_selection_attempt(&mut mock);
 
     let result = select_from_options_with_io("Choose:", &options, &mock);
     assert!(result.is_ok());
@@ -411,45 +373,8 @@ fn test_end_to_end_interactive_workflow() {
         ("apiKey".to_string(), "API key".to_string()),
     ];
 
-    // Display options
-    mock.expect_println()
-        .with(eq("Select authentication method:"))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_println()
-        .with(eq("  1: bearerAuth - Bearer token"))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_println()
-        .with(eq("  2: apiKey - API key"))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    // User selects bearerAuth
-    mock.expect_print()
-        .with(eq("Enter your choice (number or name): "))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_flush().times(1).returning(|| Ok(()));
-
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("bearerAuth\n".to_string()));
-
-    // Confirm selection
-    mock.expect_print()
-        .with(eq("Use bearerAuth authentication? (y/n): "))
-        .times(1)
-        .returning(|_| Ok(()));
-
-    mock.expect_flush().times(1).returning(|| Ok(()));
-
-    mock.expect_read_line_with_timeout()
-        .times(1)
-        .returning(|_| Ok("y\n".to_string()));
+    expect_auth_method_selection_flow(&mut mock);
+    expect_yes_confirmation(&mut mock, "Use bearerAuth authentication? (y/n): ");
 
     // Execute the workflow
     let selected = select_from_options_with_io("Select authentication method:", &options, &mock);
@@ -548,6 +473,64 @@ fn expect_valid_selection_attempt(mock: &mut MockInputOutputImpl) {
     mock.expect_read_line_with_timeout()
         .times(1)
         .returning(|_| Ok("1\n".to_string()));
+}
+
+fn expect_auth_method_selection_flow(mock: &mut MockInputOutputImpl) {
+    expect_selection_prompt_with_options(
+        mock,
+        "Select authentication method:",
+        &["  1: bearerAuth - Bearer token", "  2: apiKey - API key"],
+    );
+    expect_named_selection_attempt(mock, "bearerAuth");
+}
+
+fn expect_selection_prompt_with_options(
+    mock: &mut MockInputOutputImpl,
+    prompt: &str,
+    option_lines: &[&str],
+) {
+    let prompt = prompt.to_string();
+    mock.expect_println()
+        .with(eq(prompt))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    for option_line in option_lines {
+        let option_line = (*option_line).to_string();
+        mock.expect_println()
+            .with(eq(option_line))
+            .times(1)
+            .returning(|_| Ok(()));
+    }
+}
+
+fn expect_named_selection_attempt(mock: &mut MockInputOutputImpl, selection: &str) {
+    let selection = selection.to_string();
+
+    mock.expect_print()
+        .with(eq("Enter your choice (number or name): "))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_flush().times(1).returning(|| Ok(()));
+
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(move |_| Ok(format!("{selection}\n")));
+}
+
+fn expect_yes_confirmation(mock: &mut MockInputOutputImpl, prompt: &str) {
+    let prompt = prompt.to_string();
+    mock.expect_print()
+        .with(eq(prompt))
+        .times(1)
+        .returning(|_| Ok(()));
+
+    mock.expect_flush().times(1).returning(|| Ok(()));
+
+    mock.expect_read_line_with_timeout()
+        .times(1)
+        .returning(|_| Ok("y\n".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- ran `compl scan --threshold 10` (after correcting the CLI flag typo from `--treshold`) and refactored every reported hotspot
- extracted focused helper functions across agent, batch, CLI, config, docs, cache, parser, transformer, and shortcuts modules to reduce per-function complexity while preserving behavior
- simplified interactive workflow tests by consolidating repeated mock setup into reusable helper routines

## Validation
- `compl scan --threshold 10` (0 hotspots)
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test`
