### PR TITLE
fix: treat dynamic help and examples as successful control flow

### DIFF
--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -225,6 +225,46 @@ async fn execute_standard_api_runtime(
     Ok(())
 }
 
+fn parse_dynamic_matches(
+    spec: &CachedSpec,
+    args: &[String],
+    use_positional_args: bool,
+) -> Result<clap::ArgMatches, clap::Error> {
+    generator::generate_command_tree_with_flags(spec, use_positional_args).try_get_matches_from(
+        std::iter::once(constants::CLI_ROOT_COMMAND.to_string()).chain(args.iter().cloned()),
+    )
+}
+
+fn parse_dynamic_matches_relaxed(
+    spec: &CachedSpec,
+    args: &[String],
+    use_positional_args: bool,
+) -> Result<clap::ArgMatches, clap::Error> {
+    generator::generate_command_tree_with_flags(spec, use_positional_args)
+        .ignore_errors(true)
+        .try_get_matches_from(
+            std::iter::once(constants::CLI_ROOT_COMMAND.to_string()).chain(args.iter().cloned()),
+        )
+}
+
+fn is_help_control_flow(error: &clap::Error) -> bool {
+    matches!(
+        error.kind(),
+        clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+    )
+}
+
+fn should_attempt_examples_fallback(args: &[String], parse_error: &clap::Error) -> bool {
+    args.iter().any(|arg| arg == "--show-examples")
+        && parse_error.kind() == clap::error::ErrorKind::MissingRequiredArgument
+}
+
+fn render_clap_control_flow_output(parse_error: &clap::Error) -> Result<(), Error> {
+    parse_error
+        .print()
+        .map_err(|e| Error::io_error(format!("Failed to print command help: {e}")))
+}
+
 #[allow(clippy::too_many_lines)]
 pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) -> Result<(), Error> {
     let command_context = load_api_command_context(context)?;
@@ -237,12 +277,26 @@ pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) ->
         return handle_batch_file_command(context, batch_file_path, &command_context, cli).await;
     }
 
-    // Generate the dynamic command tree and parse arguments
-    let command =
-        generator::generate_command_tree_with_flags(&command_context.spec, cli.positional_args);
-    let matches = command
-        .try_get_matches_from(std::iter::once(constants::CLI_ROOT_COMMAND.to_string()).chain(args))
-        .map_err(|e| Error::invalid_command(context, e.to_string()))?;
+    let matches = match parse_dynamic_matches(&command_context.spec, &args, cli.positional_args) {
+        Ok(matches) => matches,
+        Err(parse_error) if is_help_control_flow(&parse_error) => {
+            render_clap_control_flow_output(&parse_error)?;
+            return Ok(());
+        }
+        Err(parse_error) if should_attempt_examples_fallback(&args, &parse_error) => {
+            let relaxed_matches =
+                parse_dynamic_matches_relaxed(&command_context.spec, &args, cli.positional_args)
+                    .map_err(|e| Error::invalid_command(context, e.to_string()))?;
+
+            if crate::cli::translate::has_show_examples_flag(&relaxed_matches) {
+                handle_show_examples_command(context, &relaxed_matches, &command_context)?;
+                return Ok(());
+            }
+
+            return Err(Error::invalid_command(context, parse_error.to_string()));
+        }
+        Err(parse_error) => return Err(Error::invalid_command(context, parse_error.to_string())),
+    };
 
     // Check --show-examples flag
     if crate::cli::translate::has_show_examples_flag(&matches) {

--- a/tests/dynamic_help_examples_integration_tests.rs
+++ b/tests/dynamic_help_examples_integration_tests.rs
@@ -78,6 +78,21 @@ fn combined_output(output: &Output) -> String {
     )
 }
 
+fn assert_failure_with_validation_framing(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "expected failure; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let combined = combined_output(output);
+    assert!(
+        combined.contains("Validation: Invalid command"),
+        "expected invalid command framing for malformed input; got {combined}"
+    );
+}
+
 #[test]
 fn api_group_help_is_successful_control_flow() {
     let temp_dir = TempDir::new().unwrap();
@@ -136,6 +151,113 @@ fn api_show_examples_succeeds_without_required_runtime_arguments() {
         combined.contains("Command: get-user-by-id")
             && (combined.contains("No examples available") || combined.contains("Examples:")),
         "expected example output; got {combined}"
+    );
+}
+
+#[test]
+fn api_show_examples_rejects_unknown_extra_flags() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(
+        &temp_dir,
+        &[
+            "api",
+            "test-api",
+            "users",
+            "get-user-by-id",
+            "--show-examples",
+            "--bogus",
+        ],
+    );
+
+    assert_failure_with_validation_framing(&output);
+    assert!(
+        combined_output(&output).contains("--bogus"),
+        "expected malformed flag details in output"
+    );
+}
+
+#[test]
+fn api_show_examples_rejects_duplicate_flags() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(
+        &temp_dir,
+        &[
+            "api",
+            "test-api",
+            "users",
+            "get-user-by-id",
+            "--show-examples",
+            "--show-examples",
+        ],
+    );
+
+    assert_failure_with_validation_framing(&output);
+    assert!(
+        combined_output(&output).contains("cannot be used multiple times"),
+        "expected duplicate flag error details in output"
+    );
+}
+
+#[test]
+fn api_show_examples_rejects_invalid_flag_value() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(
+        &temp_dir,
+        &[
+            "api",
+            "test-api",
+            "users",
+            "get-user-by-id",
+            "--show-examples=foo",
+        ],
+    );
+
+    assert_failure_with_validation_framing(&output);
+    assert!(
+        combined_output(&output).contains("unexpected value 'foo'"),
+        "expected invalid value details in output"
+    );
+}
+
+#[test]
+fn api_show_examples_rejects_missing_operation_target() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(&temp_dir, &["api", "test-api", "users", "--show-examples"]);
+
+    assert_failure_with_validation_framing(&output);
+    assert!(
+        combined_output(&output).contains("unexpected argument '--show-examples'"),
+        "expected missing operation parse failure details in output"
+    );
+}
+
+#[test]
+fn api_show_examples_rejects_whitespace_operation_name() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(
+        &temp_dir,
+        &["api", "test-api", "users", " ", "--show-examples"],
+    );
+
+    assert_failure_with_validation_framing(&output);
+    assert!(
+        combined_output(&output).contains("unrecognized subcommand ' '"),
+        "expected whitespace operation parse failure details in output"
     );
 }
 

--- a/tests/dynamic_help_examples_integration_tests.rs
+++ b/tests/dynamic_help_examples_integration_tests.rs
@@ -1,0 +1,173 @@
+#![cfg(feature = "integration")]
+
+mod common;
+
+use common::aperture_cmd;
+use std::fs;
+use std::process::Output;
+use tempfile::TempDir;
+
+fn create_required_param_spec(temp_dir: &TempDir) -> std::path::PathBuf {
+    let spec_content = r"
+openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{id}:
+    get:
+      tags:
+        - users
+      operationId: getUserById
+      summary: Get user by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+";
+
+    let spec_file = temp_dir.path().join("spec.yaml");
+    fs::write(&spec_file, spec_content).expect("failed to write test spec");
+    spec_file
+}
+
+fn add_spec(temp_dir: &TempDir, spec_file: &std::path::Path) {
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "add", "test-api", spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+fn run_with_config_dir(temp_dir: &TempDir, args: &[&str]) -> Output {
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(args)
+        .output()
+        .expect("failed to execute aperture command")
+}
+
+fn assert_success_without_validation_framing(output: &Output) {
+    assert!(
+        output.status.success(),
+        "expected success; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stdout.contains("Validation: Invalid command")
+            && !stderr.contains("Validation: Invalid command"),
+        "help/examples should not be wrapped as validation failure; stdout={stdout} stderr={stderr}"
+    );
+}
+
+fn combined_output(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn api_group_help_is_successful_control_flow() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(&temp_dir, &["api", "test-api", "users", "--help"]);
+    assert_success_without_validation_framing(&output);
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("Usage: api users") || combined.contains("users operations"),
+        "expected group help output; got {combined}"
+    );
+}
+
+#[test]
+fn api_operation_help_succeeds_without_required_runtime_arguments() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(
+        &temp_dir,
+        &["api", "test-api", "users", "get-user-by-id", "--help"],
+    );
+    assert_success_without_validation_framing(&output);
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("--id <ID>") || combined.contains("Path parameter: id"),
+        "expected operation help output; got {combined}"
+    );
+}
+
+#[test]
+fn api_show_examples_succeeds_without_required_runtime_arguments() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(
+        &temp_dir,
+        &[
+            "api",
+            "test-api",
+            "users",
+            "get-user-by-id",
+            "--show-examples",
+        ],
+    );
+    assert_success_without_validation_framing(&output);
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("Command: get-user-by-id")
+            && (combined.contains("No examples available") || combined.contains("Examples:")),
+        "expected example output; got {combined}"
+    );
+}
+
+#[test]
+fn exec_help_resolves_shortcut_and_succeeds_without_required_runtime_arguments() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(&temp_dir, &["exec", "get-user-by-id", "--help"]);
+    assert_success_without_validation_framing(&output);
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("Usage: api users get-user-by-id")
+            || combined.contains("Resolved shortcut to:"),
+        "expected resolved help output; got {combined}"
+    );
+}
+
+#[test]
+fn exec_show_examples_succeeds_without_required_runtime_arguments() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec(&temp_dir, &spec_file);
+
+    let output = run_with_config_dir(&temp_dir, &["exec", "get-user-by-id", "--show-examples"]);
+    assert_success_without_validation_framing(&output);
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("Resolved shortcut to:") && combined.contains("Command: get-user-by-id"),
+        "expected resolved examples output; got {combined}"
+    );
+}

--- a/tests/hidden_flags_tests.rs
+++ b/tests/hidden_flags_tests.rs
@@ -130,35 +130,49 @@ fn test_global_flags_hidden_from_dynamic_command_tree() {
         .assert()
         .success();
 
-    // Check help at the operation level - this is the dynamic command tree help
-    // Note: Due to how clap handles dynamic commands, --help outputs to stderr
-    // and returns a non-zero exit code, but the help content is still shown
+    // Check help at the operation level - this is the dynamic command tree help.
+    // Help is a successful control-flow path and should not be wrapped as a validation error.
     let output = aperture_cmd()
         .env("APERTURE_CONFIG_DIR", temp_dir.path())
         .args(["api", "test-api", "users", "list-users", "--help"])
         .output()
         .expect("Failed to execute command");
 
-    // The help is output to stderr in this case
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "Expected --help to exit successfully; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     // Verify we got some help output (contains Options section)
     assert!(
-        stderr.contains("Options:") || stderr.contains("-h, --help"),
+        combined.contains("Options:") || combined.contains("-h, --help"),
         "Expected help output to contain Options section"
+    );
+
+    assert!(
+        !combined.contains("Validation: Invalid command"),
+        "Expected help output to avoid validation framing"
     );
 
     // The hidden flags should NOT appear in the dynamic command help
     assert!(
-        !stderr.contains("--jq"),
+        !combined.contains("--jq"),
         "Expected --jq to be hidden from dynamic command help"
     );
     assert!(
-        !stderr.contains("--format ") && !stderr.contains("--format\n"),
+        !combined.contains("--format ") && !combined.contains("--format\n"),
         "Expected --format to be hidden from dynamic command help"
     );
     assert!(
-        !stderr.contains("--server-var"),
+        !combined.contains("--server-var"),
         "Expected --server-var to be hidden from dynamic command help"
     );
 }


### PR DESCRIPTION
## Summary
- treat dynamic clap help/version output as successful control flow in execute_api_command
- allow --show-examples to bypass required runtime arguments by reparsing in relaxed mode
- add integration coverage for api and exec help/examples success semantics and update hidden-flags help expectations

## Validation
- cargo test && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings
- cargo test --features integration --test dynamic_help_examples_integration_tests --test hidden_flags_tests

Closes #132