### PR TITLE
fix: replace stale recovery hints with canonical command guidance

### DIFF
--- a/src/command_guidance.rs
+++ b/src/command_guidance.rs
@@ -1,0 +1,48 @@
+//! Canonical command guidance used in user-facing hints and remediation text.
+
+pub const CMD_CONFIG_SET_SECRET: &str = "aperture config set-secret";
+pub const CMD_CONFIG_LIST_SECRETS: &str = "aperture config list-secrets";
+pub const CMD_CONFIG_REMOVE_SECRET: &str = "aperture config remove-secret";
+pub const CMD_CONFIG_CLEAR_SECRETS: &str = "aperture config clear-secrets";
+pub const CMD_CONFIG_REINIT: &str = "aperture config reinit";
+pub const CMD_CONFIG_ADD: &str = "aperture config add";
+pub const CMD_CONFIG_SETTINGS: &str = "aperture config settings";
+pub const CMD_HELP_WITH_DESCRIBE_JSON: &str =
+    "Check available operations with --help or --describe-json";
+pub const CMD_HELP_WITH_DESCRIBE_JSON_COMMANDS: &str =
+    "Check available commands with --help or --describe-json";
+
+#[must_use]
+pub fn secret_management_commands_hint() -> String {
+    format!(
+        "Use '{CMD_CONFIG_SET_SECRET} <api> <scheme> --env <VAR>', '{CMD_CONFIG_LIST_SECRETS} <api>', '{CMD_CONFIG_REMOVE_SECRET} <api> <scheme>', or '{CMD_CONFIG_CLEAR_SECRETS} <api> --force'."
+    )
+}
+
+#[must_use]
+pub fn auth_secret_management_hint(scheme_name: &str) -> String {
+    format!(
+        "Configure authentication for '{scheme_name}'. {}",
+        secret_management_commands_hint()
+    )
+}
+
+#[must_use]
+pub fn auth_secret_missing_env_hint(env_var: &str) -> String {
+    format!(
+        "Set the {env_var} environment variable or run '{CMD_CONFIG_SET_SECRET} <api> <scheme> --env {env_var}' to configure the secret mapping."
+    )
+}
+
+#[must_use]
+pub fn cache_reinit_hint(spec_name: Option<&str>) -> String {
+    spec_name.map_or_else(
+        || format!("Run '{CMD_CONFIG_REINIT}' to regenerate the cache."),
+        |name| format!("Run '{CMD_CONFIG_REINIT} {name}' to regenerate the cache."),
+    )
+}
+
+#[must_use]
+pub fn cached_spec_not_found_hint(spec_name: &str) -> String {
+    format!("Run '{CMD_CONFIG_ADD} {spec_name} <spec-file>' first")
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@
 //! 3. **Builder Pattern**: `ErrorContext` provides fluent builder methods for error construction
 //! 4. **JSON Support**: All errors can be serialized to JSON for programmatic consumption
 
+use crate::command_guidance;
 use crate::constants;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -389,9 +390,7 @@ impl Error {
             )),
             context: Some(ErrorContext::new(
                 Some(json!({ "spec_name": name })),
-                Some(Cow::Owned(format!(
-                    "Run 'aperture config reinit {name}' to regenerate the cache."
-                ))),
+                Some(Cow::Owned(command_guidance::cache_reinit_hint(Some(&name)))),
             )),
         }
     }
@@ -402,7 +401,8 @@ impl Error {
         Self::Internal {
             kind: ErrorKind::Specification,
             message: Cow::Owned(format!(
-                "No cached spec found for '{name}'. Run 'aperture config add {name}' first"
+                "No cached spec found for '{name}'. {}",
+                command_guidance::cached_spec_not_found_hint(&name)
             )),
             context: Some(ErrorContext::with_detail("spec_name", &name)),
         }
@@ -438,9 +438,7 @@ impl Error {
                 Some(
                     json!({ "spec_name": name, "found_version": found, "expected_version": expected }),
                 ),
-                Some(Cow::Borrowed(
-                    "Run 'aperture config reinit' to regenerate the cache.",
-                )),
+                Some(Cow::Owned(command_guidance::cache_reinit_hint(None))),
             )),
         }
     }
@@ -840,9 +838,7 @@ impl Error {
             message: Cow::Owned(format!("Operation '{operation}' not found")),
             context: Some(ErrorContext::new(
                 Some(json!({ "operation": operation })),
-                Some(Cow::Borrowed(
-                    "Check available operations with --help or --describe-json",
-                )),
+                Some(Cow::Borrowed(command_guidance::CMD_HELP_WITH_DESCRIBE_JSON)),
             )),
         }
     }
@@ -854,7 +850,7 @@ impl Error {
     ) -> Self {
         let operation = operation.into();
         let suggestion_text = if suggestions.is_empty() {
-            "Check available operations with --help or --describe-json".to_string()
+            command_guidance::CMD_HELP_WITH_DESCRIBE_JSON.to_string()
         } else {
             format!("Did you mean one of these?\n{}", suggestions.join("\n"))
         };
@@ -920,7 +916,7 @@ impl Error {
             message: Cow::Owned(format!("Invalid command for '{context}': {reason}")),
             context: Some(
                 ErrorContext::with_name_reason("context", &context, &reason)
-                    .and_suggestion("Check available commands with --help or --describe-json"),
+                    .and_suggestion(command_guidance::CMD_HELP_WITH_DESCRIBE_JSON_COMMANDS),
             ),
         }
     }
@@ -1166,9 +1162,10 @@ impl Error {
             message: Cow::Owned(format!("Unknown setting key: '{key}'")),
             context: Some(ErrorContext::new(
                 Some(json!({ "key": key })),
-                Some(Cow::Borrowed(
-                    "Run 'aperture config settings' to see available settings.",
-                )),
+                Some(Cow::Owned(format!(
+                    "Run '{}' to see available settings.",
+                    command_guidance::CMD_CONFIG_SETTINGS
+                ))),
             )),
         }
     }
@@ -1353,7 +1350,10 @@ mod tests {
         let j = err.to_json();
         assert_eq!(j.error_type, "Specification");
         assert!(j.message.contains("stale-api"));
-        assert!(j.context.is_some());
+        let context = j
+            .context
+            .expect("cache_stale should include remediation hint");
+        assert!(context.contains("aperture config reinit stale-api"));
     }
 
     #[test]
@@ -1362,7 +1362,11 @@ mod tests {
         let j = err.to_json();
         assert_eq!(j.error_type, "Authentication");
         assert!(j.message.contains("MY_API_KEY"));
-        assert!(j.context.is_some(), "secret_not_set carries a suggestion");
+        let context = j
+            .context
+            .expect("secret_not_set should include remediation hint");
+        assert!(context.contains("aperture config set-secret"));
+        assert!(!context.contains("aperture config secrets"));
         assert!(j.details.is_some());
     }
 
@@ -1484,7 +1488,10 @@ mod tests {
         let j = err.to_json();
         assert_eq!(j.error_type, "Runtime");
         assert!(j.message.contains("unknown-op"));
-        assert!(j.context.is_some());
+        assert_eq!(
+            j.context.as_deref(),
+            Some(crate::command_guidance::CMD_HELP_WITH_DESCRIBE_JSON)
+        );
     }
 
     // ---- External error variants via to_json() ----

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod atomic;
 pub mod batch;
 pub mod cache;
 pub mod cli;
+pub mod command_guidance;
 pub mod config;
 pub mod constants;
 pub mod docs;

--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -1,6 +1,7 @@
 //! Smart suggestions for error messages and command discovery
 
 use crate::cache::models::CachedSpec;
+use crate::command_guidance;
 use crate::search::CommandSearcher;
 use std::collections::BTreeMap;
 
@@ -69,8 +70,8 @@ pub fn suggest_valid_values(param_name: &str, valid_values: &[String]) -> String
 #[must_use]
 pub fn suggest_auth_fix(scheme_name: &str, env_var: Option<&str>) -> String {
     env_var.map_or_else(
-        || format!("Configure authentication for '{scheme_name}' using 'aperture config secrets'"),
-        |var| format!("Set the {var} environment variable or run 'aperture config secrets' to configure authentication")
+        || command_guidance::auth_secret_management_hint(scheme_name),
+        command_guidance::auth_secret_missing_env_hint,
     )
 }
 

--- a/tests/error_suggestions_tests.rs
+++ b/tests/error_suggestions_tests.rs
@@ -149,9 +149,14 @@ fn test_suggest_valid_values() {
 fn test_suggest_auth_fix() {
     let suggestion = suggest_auth_fix("api-key", Some("API_KEY"));
     assert!(suggestion.contains("API_KEY"));
-    assert!(suggestion.contains("aperture config secrets"));
+    assert!(suggestion.contains("aperture config set-secret"));
+    assert!(!suggestion.contains("aperture config secrets"));
 
     let suggestion = suggest_auth_fix("oauth", None);
     assert!(suggestion.contains("oauth"));
-    assert!(suggestion.contains("aperture config secrets"));
+    assert!(suggestion.contains("aperture config set-secret"));
+    assert!(suggestion.contains("aperture config list-secrets"));
+    assert!(suggestion.contains("aperture config remove-secret"));
+    assert!(suggestion.contains("aperture config clear-secrets"));
+    assert!(!suggestion.contains("aperture config secrets"));
 }


### PR DESCRIPTION
## Summary
- add a centralized command-guidance module for canonical remediation commands
- replace stale auth recovery hints that referenced 'aperture config secrets' with current secret commands
- route command-lookup and config-remediation error hints through shared guidance helpers
- add regression assertions for auth, cache reinit, and operation lookup hint text

Closes #136