### PR TITLE
feat: harden exec shortcut resolution and disambiguation

### DIFF
--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -454,6 +454,7 @@ fn render_batch_text_summary(result: &crate::batch::BatchResult, output: &Output
 pub async fn execute_shortcut_command(
     manager: &ConfigManager<OsFileSystem>,
     args: Vec<String>,
+    api_filter: Option<&str>,
     cli: &Cli,
 ) -> Result<(), Error> {
     let output = Output::new(cli.quiet, cli.json_errors);
@@ -468,7 +469,7 @@ pub async fn execute_shortcut_command(
         return Ok(());
     }
 
-    let all_specs = load_shortcut_specs(manager, &specs);
+    let all_specs = load_shortcut_specs(manager, &specs, api_filter)?;
     if all_specs.is_empty() {
         output.info("No valid API specifications found.");
         return Ok(());
@@ -482,10 +483,21 @@ pub async fn execute_shortcut_command(
 fn load_shortcut_specs(
     manager: &ConfigManager<OsFileSystem>,
     specs: &[String],
-) -> std::collections::BTreeMap<String, crate::cache::models::CachedSpec> {
+    api_filter: Option<&str>,
+) -> Result<std::collections::BTreeMap<String, crate::cache::models::CachedSpec>, Error> {
+    let selected_specs: Vec<&String> = match api_filter {
+        Some(api_name) => {
+            let Some(spec_name) = specs.iter().find(|spec| spec.as_str() == api_name) else {
+                return Err(Error::spec_not_found(api_name));
+            };
+            vec![spec_name]
+        }
+        None => specs.iter().collect(),
+    };
+
     let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
     let mut all_specs = std::collections::BTreeMap::new();
-    for spec_name in specs {
+    for spec_name in selected_specs {
         match loader::load_cached_spec(&cache_dir, spec_name) {
             Ok(spec) => {
                 all_specs.insert(spec_name.clone(), spec);
@@ -493,7 +505,7 @@ fn load_shortcut_specs(
             Err(e) => tracing::warn!(spec = spec_name, error = %e, "could not load spec"),
         }
     }
-    all_specs
+    Ok(all_specs)
 }
 
 async fn handle_shortcut_resolution(
@@ -556,6 +568,8 @@ fn print_shortcut_usage() -> ! {
     eprintln!("Examples:");
     // ast-grep-ignore: no-println
     eprintln!("  aperture exec getUserById --id 123");
+    // ast-grep-ignore: no-println
+    eprintln!("  aperture exec --api billing getUserById --id 123");
     // ast-grep-ignore: no-println
     eprintln!("  aperture exec GET /users/123");
     // ast-grep-ignore: no-println

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -521,11 +521,9 @@ async fn handle_shortcut_resolution(
         ResolutionResult::Ambiguous(matches) => {
             // Must appear regardless of APERTURE_LOG; tracing may suppress at low levels.
             // ast-grep-ignore: no-println
-            eprintln!("Ambiguous shortcut. Multiple commands match:");
-            // ast-grep-ignore: no-println
             eprintln!("{}", resolver.format_ambiguous_suggestions(&matches));
             // ast-grep-ignore: no-println
-            eprintln!("\nTip: Use 'aperture search <term>' to explore available commands");
+            eprintln!("\nTip: Also try 'aperture search <term>' to explore available commands");
             std::process::exit(1);
         }
         ResolutionResult::NotFound => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -290,10 +290,19 @@ pub enum Commands {
                       When multiple matches are found, you'll get suggestions to choose from.\n\n\
                       Examples:\n  \
                       aperture exec getUserById --id 123\n  \
+                      aperture exec --api billing getUserById --id 123\n  \
                       aperture exec GET /users/123\n  \
                       aperture exec users list"
     )]
     Exec {
+        /// Limit shortcut resolution to a specific API context.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        #[arg(
+            long,
+            value_name = "API",
+            help = "Resolve shortcuts only within specified API"
+        )]
+        api: Option<String>,
         /// Shortcut command arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,17 @@ fn run_search_command(
 async fn run_shortcut_command(
     manager: &ConfigManager<OsFileSystem>,
     args: &[String],
+    api: Option<&str>,
     cli: &Cli,
 ) -> Result<(), Error> {
-    aperture_cli::cli::commands::api::execute_shortcut_command(manager, args.to_vec(), cli).await
+    let validated_api = api.map(validate_api_name).transpose()?;
+    aperture_cli::cli::commands::api::execute_shortcut_command(
+        manager,
+        args.to_vec(),
+        validated_api.as_deref(),
+        cli,
+    )
+    .await
 }
 
 fn run_docs_command(
@@ -118,7 +126,9 @@ async fn run_non_config_command(
             api,
             verbose,
         } => run_search_command(manager, query, api.as_deref(), *verbose, output),
-        Commands::Exec { args } => run_shortcut_command(manager, args, cli).await,
+        Commands::Exec { api, args } => {
+            run_shortcut_command(manager, args, api.as_deref(), cli).await
+        }
         Commands::Docs {
             api,
             tag,

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -427,21 +427,27 @@ impl ShortcutResolver {
     /// Generate suggestions for ambiguous matches
     #[must_use]
     pub fn format_ambiguous_suggestions(&self, matches: &[ResolvedShortcut]) -> String {
-        let mut suggestions = Vec::new();
+        let mut candidates = Self::deduplicate_candidates(matches.to_vec());
+        Self::sort_candidates_by_confidence(&mut candidates);
 
-        for (i, shortcut) in matches.iter().take(5).enumerate() {
+        let mut suggestions = Vec::new();
+        for (i, shortcut) in candidates.iter().take(5).enumerate() {
             let cmd = shortcut.full_command.join(" ");
+            let api_name = shortcut
+                .full_command
+                .get(1)
+                .map_or("unknown", String::as_str);
             let desc = shortcut
                 .command
                 .description
                 .as_deref()
                 .unwrap_or("No description");
             let num = i + 1;
-            suggestions.push(format!("{num}. aperture {cmd} - {desc}"));
+            suggestions.push(format!("{num}. [api: {api_name}] aperture {cmd} - {desc}"));
         }
 
         format!(
-            "Multiple commands match. Did you mean:\n{}",
+            "Multiple commands match this shortcut. Narrow by API with `--api <name>` or run one of these full paths:\n{}",
             suggestions.join("\n")
         )
     }

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -235,6 +235,39 @@ impl ShortcutResolver {
         }
     }
 
+    fn deduplicate_candidates(candidates: Vec<ResolvedShortcut>) -> Vec<ResolvedShortcut> {
+        let mut deduped: Vec<ResolvedShortcut> = Vec::new();
+        let mut seen_indexes: HashMap<Vec<String>, usize> = HashMap::new();
+
+        for candidate in candidates {
+            match seen_indexes.get(&candidate.full_command).copied() {
+                Some(existing_index)
+                    if candidate.confidence > deduped[existing_index].confidence =>
+                {
+                    deduped[existing_index] = candidate;
+                }
+                Some(_) => {}
+                None => {
+                    seen_indexes.insert(candidate.full_command.clone(), deduped.len());
+                    deduped.push(candidate);
+                }
+            }
+        }
+
+        deduped
+    }
+
+    fn sort_candidates_by_confidence(candidates: &mut [ResolvedShortcut]) {
+        candidates.sort_by(|a, b| {
+            b.confidence
+                .cmp(&a.confidence)
+                .then_with(|| a.full_command.cmp(&b.full_command))
+                .then_with(|| a.command.operation_id.cmp(&b.command.operation_id))
+                .then_with(|| a.command.method.cmp(&b.command.method))
+                .then_with(|| a.command.path.cmp(&b.command.path))
+        });
+    }
+
     fn resolve_single_candidate(candidates: Vec<ResolvedShortcut>) -> ResolutionResult {
         candidates.into_iter().next().map_or_else(
             || {
@@ -248,7 +281,7 @@ impl ShortcutResolver {
     }
 
     fn resolve_best_candidate(mut candidates: Vec<ResolvedShortcut>) -> ResolutionResult {
-        candidates.sort_by(|a, b| b.confidence.cmp(&a.confidence));
+        Self::sort_candidates_by_confidence(&mut candidates);
 
         if !Self::has_high_confidence_candidate(&candidates) {
             return ResolutionResult::Ambiguous(candidates);
@@ -268,7 +301,8 @@ impl ShortcutResolver {
             return ResolutionResult::NotFound;
         }
 
-        Self::resolve_from_candidates(self.collect_resolution_candidates(args))
+        let candidates = Self::deduplicate_candidates(self.collect_resolution_candidates(args));
+        Self::resolve_from_candidates(candidates)
     }
 
     /// Try to resolve using direct operation ID matching

--- a/tests/cli_translate_tests.rs
+++ b/tests/cli_translate_tests.rs
@@ -151,7 +151,10 @@ fn base_cli() -> Cli {
         retry_delay: None,
         retry_max_delay: None,
         force_retry: false,
-        command: Commands::Exec { args: vec![] },
+        command: Commands::Exec {
+            api: None,
+            args: vec![],
+        },
     }
 }
 

--- a/tests/dynamic_help_examples_integration_tests.rs
+++ b/tests/dynamic_help_examples_integration_tests.rs
@@ -299,6 +299,83 @@ fn exec_show_examples_succeeds_without_required_runtime_arguments() {
 }
 
 #[test]
+fn exec_api_filter_rejects_invalid_api_name() {
+    let temp_dir = TempDir::new().unwrap();
+    let output = run_with_config_dir(
+        &temp_dir,
+        &["exec", "--api", "   ", "get-user-by-id", "--help"],
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected validation failure; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("Invalid API context name '   '"),
+        "expected invalid API name error; got {combined}"
+    );
+}
+
+#[test]
+fn exec_api_filter_rejects_unknown_context() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec_named(&temp_dir, "users-a", &spec_file);
+
+    let output = run_with_config_dir(
+        &temp_dir,
+        &["exec", "--api", "none", "get-user-by-id", "--help"],
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected unknown API failure; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("Specification: API specification 'none' not found"),
+        "expected missing API context error; got {combined}"
+    );
+}
+
+#[test]
+fn exec_api_filter_rejects_duplicate_flags() {
+    let temp_dir = TempDir::new().unwrap();
+    let output = run_with_config_dir(
+        &temp_dir,
+        &[
+            "exec",
+            "--api",
+            "users-a",
+            "--api",
+            "users-b",
+            "get-user-by-id",
+            "--help",
+        ],
+    );
+
+    assert!(
+        !output.status.success(),
+        "expected parse failure; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("cannot be used multiple times"),
+        "expected duplicate --api rejection; got {combined}"
+    );
+}
+
+#[test]
 fn exec_api_filter_disambiguates_multi_api_shortcuts() {
     let temp_dir = TempDir::new().unwrap();
     let spec_file = create_required_param_spec(&temp_dir);

--- a/tests/dynamic_help_examples_integration_tests.rs
+++ b/tests/dynamic_help_examples_integration_tests.rs
@@ -36,12 +36,16 @@ paths:
     spec_file
 }
 
-fn add_spec(temp_dir: &TempDir, spec_file: &std::path::Path) {
+fn add_spec_named(temp_dir: &TempDir, name: &str, spec_file: &std::path::Path) {
     aperture_cmd()
         .env("APERTURE_CONFIG_DIR", temp_dir.path())
-        .args(["config", "add", "test-api", spec_file.to_str().unwrap()])
+        .args(["config", "add", name, spec_file.to_str().unwrap()])
         .assert()
         .success();
+}
+
+fn add_spec(temp_dir: &TempDir, spec_file: &std::path::Path) {
+    add_spec_named(temp_dir, "test-api", spec_file);
 }
 
 fn run_with_config_dir(temp_dir: &TempDir, args: &[&str]) -> Output {
@@ -291,5 +295,56 @@ fn exec_show_examples_succeeds_without_required_runtime_arguments() {
     assert!(
         combined.contains("Resolved shortcut to:") && combined.contains("Command: get-user-by-id"),
         "expected resolved examples output; got {combined}"
+    );
+}
+
+#[test]
+fn exec_api_filter_disambiguates_multi_api_shortcuts() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec_named(&temp_dir, "users-a", &spec_file);
+    add_spec_named(&temp_dir, "users-b", &spec_file);
+
+    let output = run_with_config_dir(
+        &temp_dir,
+        &["exec", "--api", "users-a", "get-user-by-id", "--help"],
+    );
+
+    assert_success_without_validation_framing(&output);
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("Resolved shortcut to: aperture api users-a users get-user-by-id"),
+        "expected API-scoped resolution output; got {combined}"
+    );
+}
+
+#[test]
+fn exec_ambiguity_output_explains_api_disambiguation() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = create_required_param_spec(&temp_dir);
+    add_spec_named(&temp_dir, "users-a", &spec_file);
+    add_spec_named(&temp_dir, "users-b", &spec_file);
+
+    let output = run_with_config_dir(&temp_dir, &["exec", "get-user-by-id", "--help"]);
+
+    assert!(
+        !output.status.success(),
+        "expected ambiguity failure; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let combined = combined_output(&output);
+    assert!(
+        combined.contains("Multiple commands match this shortcut"),
+        "expected explicit ambiguity header; got {combined}"
+    );
+    assert!(
+        combined.contains("--api <name>"),
+        "expected API narrowing guidance; got {combined}"
+    );
+    assert!(
+        combined.contains("[api: users-a]") && combined.contains("[api: users-b]"),
+        "expected per-API suggestions; got {combined}"
     );
 }

--- a/tests/shortcuts_tests.rs
+++ b/tests/shortcuts_tests.rs
@@ -247,7 +247,7 @@ fn test_ambiguous_suggestions_format() {
     let mut resolver = ShortcutResolver::new();
     resolver.index_specs(&specs);
 
-    // Create some mock ambiguous matches for formatting test
+    // Create mock ambiguous matches with one duplicate entry
     let matches = vec![
         aperture_cli::shortcuts::ResolvedShortcut {
             full_command: vec![
@@ -265,6 +265,17 @@ fn test_ambiguous_suggestions_format() {
                 "api".to_string(),
                 "petstore".to_string(),
                 "pets".to_string(),
+                "get-pet-by-id".to_string(),
+            ],
+            spec: specs.get("petstore").unwrap().clone(),
+            command: specs.get("petstore").unwrap().commands[0].clone(),
+            confidence: 50,
+        },
+        aperture_cli::shortcuts::ResolvedShortcut {
+            full_command: vec![
+                "api".to_string(),
+                "petstore".to_string(),
+                "pets".to_string(),
                 "create-pet".to_string(),
             ],
             spec: specs.get("petstore").unwrap().clone(),
@@ -274,10 +285,13 @@ fn test_ambiguous_suggestions_format() {
     ];
 
     let suggestion_text = resolver.format_ambiguous_suggestions(&matches);
-    assert!(suggestion_text.contains("Multiple commands match"));
+    assert!(suggestion_text.contains("Multiple commands match this shortcut"));
+    assert!(suggestion_text.contains("--api <name>"));
+    assert!(suggestion_text.contains("[api: petstore]"));
     assert!(suggestion_text.contains("aperture api petstore"));
     assert!(suggestion_text.contains("Get pet by ID"));
     assert!(suggestion_text.contains("Create a new pet"));
+    assert_eq!(suggestion_text.matches("get-pet-by-id").count(), 1);
 }
 
 #[test]

--- a/tests/shortcuts_tests.rs
+++ b/tests/shortcuts_tests.rs
@@ -299,6 +299,58 @@ fn test_empty_args() {
 }
 
 #[test]
+fn test_duplicate_candidates_are_deduplicated_by_effective_command_path() {
+    let spec = CachedSpec {
+        cache_format_version: aperture_cli::cache::models::CACHE_FORMAT_VERSION,
+        name: "test-api".to_string(),
+        version: "1.0.0".to_string(),
+        commands: vec![CachedCommand {
+            name: "users".to_string(),
+            description: Some("List users".to_string()),
+            summary: None,
+            operation_id: "listUsers".to_string(),
+            method: "GET".to_string(),
+            path: "/users".to_string(),
+            parameters: vec![],
+            request_body: None,
+            responses: vec![],
+            security_requirements: vec![],
+            tags: vec!["users".to_string()],
+            deprecated: false,
+            external_docs_url: None,
+            examples: vec![],
+            display_group: Some("users".to_string()),
+            display_name: Some("list-users".to_string()),
+            aliases: vec![],
+            hidden: false,
+            pagination: PaginationInfo::default(),
+        }],
+        base_url: Some("https://api.example.com".to_string()),
+        servers: vec![],
+        security_schemes: HashMap::new(),
+        skipped_endpoints: vec![],
+        server_variables: HashMap::new(),
+    };
+
+    let mut specs = BTreeMap::new();
+    specs.insert("test-api".to_string(), spec);
+
+    let mut resolver = ShortcutResolver::new();
+    resolver.index_specs(&specs);
+
+    match resolver.resolve_shortcut(&["users".to_string()]) {
+        ResolutionResult::Resolved(shortcut) => {
+            assert_eq!(shortcut.command.operation_id, "listUsers");
+            assert_eq!(
+                shortcut.full_command,
+                vec!["api", "test-api", "users", "list-users"]
+            );
+        }
+        other => panic!("Expected a single deduplicated match, got: {other:?}"),
+    }
+}
+
+#[test]
 fn test_shortcut_uses_display_names_in_full_command() {
     let spec = CachedSpec {
         cache_format_version: aperture_cli::cache::models::CACHE_FORMAT_VERSION,


### PR DESCRIPTION
## Summary
- deduplicate `exec` shortcut candidates by effective command path and keep highest-confidence entries
- stabilize ranking/sorting for deterministic resolution and ambiguity output
- make ambiguity suggestions actionable with explicit API narrowing guidance (`--api <name>`)
- add `aperture exec --api <context>` to constrain resolution in multi-API environments
- add tests for deduplication, ambiguity guidance, typo recovery coverage, and filtered resolution/help flows

Closes #138
