### PR TITLE
feat: normalize CLI naming across the command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ cargo install aperture-cli --features "jq openapi31"
 | Document | Description |
 |----------|-------------|
 | [User Guide](docs/guide.md) | Day-to-day usage, commands, output formats |
+| [CLI Naming](docs/cli-naming.md) | Canonical command naming, aliases, migration guidance |
 | [Agent Integration](docs/agent-integration.md) | Capability manifests, batch ops, integration patterns |
 | [Security Model](docs/security.md) | Authentication, secrets, cache security |
 | [Configuration](docs/configuration.md) | URLs, environments, cache, command mapping |

--- a/docs/cli-naming.md
+++ b/docs/cli-naming.md
@@ -1,0 +1,45 @@
+# CLI Naming Conventions
+
+This document defines Aperture's canonical naming scheme for commands, subcommands, and examples.
+
+## Canonical naming rules
+
+### Top-level commands
+
+Use clear, full-word command names for the primary CLI surface:
+
+- `api`
+- `commands`
+- `run`
+- `search`
+- `docs`
+- `overview`
+- `config`
+
+### `config` subcommands
+
+Use `verb-resource` form for management operations:
+
+- `add`, `list`, `remove`, `edit`
+- `set-url`, `get-url`, `list-urls`
+- `set-secret`, `list-secrets`, `remove-secret`, `clear-secrets`
+- `set-mapping`, `list-mappings`, `remove-mapping`
+
+Singular resource names are used for single-target actions (`set-url`, `remove-secret`), while plural is used for collection-oriented operations (`list-urls`, `clear-secrets`, `list-mappings`).
+
+### Examples and help text
+
+All examples in help text and documentation should use canonical command names.
+
+## Compatibility aliases and migration
+
+To preserve backward compatibility with existing scripts, the CLI supports legacy aliases:
+
+- `list-commands` (legacy) → `commands` (canonical)
+- `exec` (legacy) → `run` (canonical)
+
+Migration guidance:
+
+1. Use canonical names in all new scripts and docs.
+2. Existing scripts using aliases remain functional.
+3. Prefer canonical names when updating existing automation.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,7 +282,7 @@ hidden = true
 During cache generation, Aperture validates that:
 - No two operations resolve to the same `(group, name)` pair
 - No alias collides with another operation's name or alias in the same group
-- Customized group names don't conflict with built-in commands (`config`, `search`, `exec`, `docs`, `overview`)
+- Customized group names don't conflict with built-in commands (`api`, `commands`, `run`, `config`, `search`, `docs`, `overview`; legacy aliases `list-commands` and `exec` are also reserved)
 
 Collisions produce hard errors that prevent cache generation.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -21,7 +21,7 @@ aperture config add my-api https://api.example.com/openapi.yaml
 aperture config list
 
 # List commands for an API
-aperture list-commands my-api
+aperture commands my-api
 
 # Get detailed command information
 aperture api my-api --describe-json
@@ -35,6 +35,23 @@ aperture api my-api users list
 aperture api my-api users get-user-by-id --id 123
 aperture api my-api users create --name "John Doe" --email "john@example.com"
 ```
+
+## CLI Naming Conventions
+
+Aperture follows these naming rules across commands, subcommands, and examples:
+
+- **Top-level commands:** prefer clear, full words (`commands`, `run`, `search`, `docs`, `overview`).
+- **Config subcommands:** use `verb-resource` (`set-url`, `get-url`, `list-secrets`).
+- **Examples and docs:** always use canonical command names.
+
+### Compatibility aliases
+
+To avoid breaking existing scripts, Aperture supports these legacy aliases:
+
+- `aperture list-commands` → `aperture commands`
+- `aperture exec` → `aperture run`
+
+These aliases remain available for compatibility, but new usage should prefer canonical names.
 
 ## Command Syntax
 
@@ -256,13 +273,13 @@ Execute operations using shorthand:
 
 ```bash
 # By operation ID
-aperture exec getUserById --id 123
+aperture run getUserById --id 123
 
 # By HTTP method and path
-aperture exec GET /users/123
+aperture run GET /users/123
 
 # By tag and operation
-aperture exec users list
+aperture run users list
 ```
 
 ## API Exploration

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -1,4 +1,4 @@
-//! Handlers for `aperture api`, `aperture exec`, and batch operations.
+//! Handlers for `aperture api`, `aperture run`, and batch operations.
 
 use crate::batch::{BatchConfig, BatchProcessor};
 use crate::cache::models::CachedSpec;
@@ -550,7 +550,7 @@ async fn handle_shortcut_resolution(
                 args[0]
             );
             // ast-grep-ignore: no-println
-            eprintln!("  aperture list-commands <api>  # List available commands for an API");
+            eprintln!("  aperture commands <api>       # List available commands for an API");
             // ast-grep-ignore: no-println
             eprintln!("  aperture api <api> --help     # Show help for an API");
             std::process::exit(1);
@@ -563,17 +563,17 @@ fn print_shortcut_usage() -> ! {
     // ast-grep-ignore: no-println
     eprintln!("Error: No command specified");
     // ast-grep-ignore: no-println
-    eprintln!("Usage: aperture exec <shortcut> [args...]");
+    eprintln!("Usage: aperture run <shortcut> [args...]");
     // ast-grep-ignore: no-println
     eprintln!("Examples:");
     // ast-grep-ignore: no-println
-    eprintln!("  aperture exec getUserById --id 123");
+    eprintln!("  aperture run getUserById --id 123");
     // ast-grep-ignore: no-println
-    eprintln!("  aperture exec --api billing getUserById --id 123");
+    eprintln!("  aperture run --api billing getUserById --id 123");
     // ast-grep-ignore: no-println
-    eprintln!("  aperture exec GET /users/123");
+    eprintln!("  aperture run GET /users/123");
     // ast-grep-ignore: no-println
-    eprintln!("  aperture exec users list");
+    eprintln!("  aperture run users list");
     std::process::exit(1);
 }
 

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -1,4 +1,4 @@
-//! Handlers for `aperture docs`, `aperture overview`, and `aperture list-commands`.
+//! Handlers for `aperture docs`, `aperture overview`, and `aperture commands`.
 
 use crate::cache::models::CachedSpec;
 use crate::config::manager::{get_config_dir, ConfigManager};
@@ -30,7 +30,7 @@ pub fn list_commands(context: &str, output: &Output) -> Result<(), Error> {
     output.tip(format!(
         "Use 'aperture search <term> --api {context}' to find specific operations"
     ));
-    output.tip("Use shortcuts: 'aperture exec <operation-id> --help'");
+    output.tip("Use shortcuts: 'aperture run <operation-id> --help'");
     Ok(())
 }
 
@@ -176,7 +176,7 @@ fn render_all_api_overviews(
         // ast-grep-ignore: no-println
         println!("   Methods: {}", method_summary.join(", "));
         // ast-grep-ignore: no-println
-        println!("   Quick start: aperture list-commands {api_name}");
+        println!("   Quick start: aperture commands {api_name}");
     }
     // ast-grep-ignore: no-println
     println!("\n{}", "=".repeat(60));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -227,12 +227,15 @@ pub enum Commands {
     },
     /// List available commands for an API specification
     #[command(
+        name = "commands",
+        visible_alias = "list-commands",
         long_about = "Display a tree-like summary of all available commands for an API.\n\n\
                       Shows operations organized by tags, making it easy to discover\n\
                       what functionality is available in a registered API specification.\n\
                       This provides an overview without having to use --help on each operation.\n\n\
+                      Legacy alias: list-commands\n\n\
                       Example:\n  \
-                      aperture list-commands myapi"
+                      aperture commands myapi"
     )]
     ListCommands {
         /// Name of the API specification context.
@@ -281,18 +284,20 @@ pub enum Commands {
     },
     /// Execute API operations using shortcuts or direct operation IDs
     #[command(
-        name = "exec",
+        name = "run",
+        visible_alias = "exec",
         long_about = "Execute API operations using shortcuts instead of full paths.\n\n\
                       This command attempts to resolve shortcuts to their full command paths:\n\
                       - Direct operation IDs: getUserById --id 123\n\
                       - HTTP method + path: GET /users/123\n\
                       - Tag-based shortcuts: users list\n\n\
                       When multiple matches are found, you'll get suggestions to choose from.\n\n\
+                      Legacy alias: exec\n\n\
                       Examples:\n  \
-                      aperture exec getUserById --id 123\n  \
-                      aperture exec --api billing getUserById --id 123\n  \
-                      aperture exec GET /users/123\n  \
-                      aperture exec users list"
+                      aperture run getUserById --id 123\n  \
+                      aperture run --api billing getUserById --id 123\n  \
+                      aperture run GET /users/123\n  \
+                      aperture run users list"
     )]
     Exec {
         /// Limit shortcut resolution to a specific API context.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -707,3 +707,53 @@ pub enum ConfigCommands {
         operation: Option<String>,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Cli, Commands};
+    use clap::Parser;
+
+    #[test]
+    fn commands_canonical_name_parses() {
+        let cli = Cli::try_parse_from(["aperture", "commands", "my-api"]).unwrap();
+        match cli.command {
+            Commands::ListCommands { context } => assert_eq!(context, "my-api"),
+            other => panic!("expected Commands::ListCommands, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_commands_alias_parses() {
+        let cli = Cli::try_parse_from(["aperture", "list-commands", "my-api"]).unwrap();
+        match cli.command {
+            Commands::ListCommands { context } => assert_eq!(context, "my-api"),
+            other => panic!("expected Commands::ListCommands, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_canonical_name_parses() {
+        let cli =
+            Cli::try_parse_from(["aperture", "run", "get-user-by-id", "--id", "123"]).unwrap();
+        match cli.command {
+            Commands::Exec { api, args } => {
+                assert!(api.is_none());
+                assert_eq!(args, vec!["get-user-by-id", "--id", "123"]);
+            }
+            other => panic!("expected Commands::Exec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn exec_alias_parses() {
+        let cli =
+            Cli::try_parse_from(["aperture", "exec", "get-user-by-id", "--id", "123"]).unwrap();
+        match cli.command {
+            Commands::Exec { api, args } => {
+                assert!(api.is_none());
+                assert_eq!(args, vec!["get-user-by-id", "--id", "123"]);
+            }
+            other => panic!("expected Commands::Exec, got {other:?}"),
+        }
+    }
+}

--- a/src/config/mapping.rs
+++ b/src/config/mapping.rs
@@ -10,7 +10,17 @@ use crate::utils::to_kebab_case;
 use std::collections::{HashMap, HashSet};
 
 /// Names reserved for built-in Aperture commands that cannot be used as group names.
-const RESERVED_GROUP_NAMES: &[&str] = &["config", "search", "exec", "docs", "overview"];
+const RESERVED_GROUP_NAMES: &[&str] = &[
+    "api",
+    "commands",
+    "list-commands",
+    "config",
+    "search",
+    "run",
+    "exec",
+    "docs",
+    "overview",
+];
 
 /// Result of applying command mappings, including any warnings.
 #[derive(Debug)]

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -398,7 +398,7 @@ impl DocumentationGenerator {
         overview.push_str("## Quick Start\n\n");
         write!(
             overview,
-            "List all available commands:\n```bash\naperture list-commands {api_name}\n```\n\n"
+            "List all available commands:\n```bash\naperture commands {api_name}\n```\n\n"
         )
         .ok();
 
@@ -465,8 +465,8 @@ impl DocumentationGenerator {
         menu.push_str("## Common Commands\n\n");
         menu.push_str("- `aperture config list` - List all configured APIs\n");
         menu.push_str("- `aperture search <term>` - Search across all APIs\n");
-        menu.push_str("- `aperture list-commands <api>` - Show available commands for an API\n");
-        menu.push_str("- `aperture exec <shortcut>` - Execute using shortcuts\n");
+        menu.push_str("- `aperture commands <api>` - Show available commands for an API\n");
+        menu.push_str("- `aperture run <shortcut>` - Execute using shortcuts\n");
         menu.push_str("- `aperture api <api> --help` - Get help for an API\n\n");
 
         // Tips

--- a/tests/cli_naming_integration_tests.rs
+++ b/tests/cli_naming_integration_tests.rs
@@ -1,0 +1,48 @@
+mod common;
+
+use common::aperture_cmd;
+use predicates::prelude::*;
+
+#[test]
+fn commands_canonical_name_renders_help() {
+    aperture_cmd()
+        .args(["commands", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Legacy alias: list-commands"))
+        .stdout(predicate::str::contains("aperture commands myapi"));
+}
+
+#[test]
+fn commands_legacy_alias_still_renders_help() {
+    aperture_cmd()
+        .args(["list-commands", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Legacy alias: list-commands"))
+        .stdout(predicate::str::contains("aperture commands myapi"));
+}
+
+#[test]
+fn run_canonical_name_renders_help() {
+    aperture_cmd()
+        .args(["run", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Legacy alias: exec"))
+        .stdout(predicate::str::contains(
+            "aperture run getUserById --id 123",
+        ));
+}
+
+#[test]
+fn exec_legacy_alias_still_renders_help() {
+    aperture_cmd()
+        .args(["exec", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Legacy alias: exec"))
+        .stdout(predicate::str::contains(
+            "aperture run getUserById --id 123",
+        ));
+}

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -186,7 +186,7 @@ fn test_generate_api_overview() {
     assert!(overview.contains("POST: 1"));
     assert!(overview.contains("users: 2"));
     assert!(overview.contains("## Quick Start"));
-    assert!(overview.contains("aperture list-commands testapi"));
+    assert!(overview.contains("aperture commands testapi"));
     assert!(overview.contains("## Sample Operations"));
 }
 
@@ -204,7 +204,7 @@ fn test_generate_interactive_menu() {
     assert!(menu.contains("## Common Commands"));
     assert!(menu.contains("aperture config list"));
     assert!(menu.contains("aperture search"));
-    assert!(menu.contains("aperture exec"));
+    assert!(menu.contains("aperture run"));
     assert!(menu.contains("## Tips"));
     assert!(menu.contains("--describe-json"));
     assert!(menu.contains("--dry-run"));


### PR DESCRIPTION
## Summary
- introduce canonical top-level command names: `commands` and `run`
- keep `list-commands` and `exec` as compatibility aliases, and reserve both canonical and legacy names in command-mapping collision checks
- update help text, generated docs output, and user documentation to use canonical names consistently
- add parser/integration tests that validate both canonical names and legacy aliases

## Testing
- cargo test --test docs_tests
- cargo test --test cli_naming_integration_tests
- cargo test

Closes #142
