### PR TITLE
ux: reorganize config into nested domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ https://github.com/user-attachments/assets/5fe746e4-3a44-4f3b-801d-249df4901bd0
 cargo install aperture-cli
 
 # Register an API
-aperture config add petstore https://petstore3.swagger.io/api/v3/openapi.json
+aperture config api add petstore https://petstore3.swagger.io/api/v3/openapi.json
 
 # Configure authentication
-aperture config set-secret petstore api_key --env PETSTORE_API_KEY
+aperture config secret set petstore api_key --env PETSTORE_API_KEY
 
 # Discover available operations
 aperture api petstore --describe-json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,19 @@
 
 Aperture stores configuration in `~/.config/aperture/`. This document covers all configuration options and commands.
 
+## Config Command Taxonomy
+
+`aperture config` is organized into nested administrative domains:
+
+- `aperture config api ...` — specification lifecycle
+- `aperture config url ...` — base URL overrides
+- `aperture config secret ...` — auth secret mappings
+- `aperture config cache ...` — response cache operations
+- `aperture config setting ...` — global settings
+- `aperture config mapping ...` — command tree customization
+
+Legacy flat commands (for example `config set-url` and `config settings`) remain supported for compatibility, but new documentation uses nested domain commands.
+
 ## Directory Structure
 
 ```
@@ -25,25 +38,25 @@ Aperture stores configuration in `~/.config/aperture/`. This document covers all
 
 ```bash
 # From local file
-aperture config add my-api ./openapi.yaml
+aperture config api add my-api ./openapi.yaml
 
 # From URL
-aperture config add my-api https://api.example.com/openapi.yaml
+aperture config api add my-api https://api.example.com/openapi.yaml
 
 # With strict validation (reject unsupported features)
-aperture config add --strict my-api ./openapi.yaml
+aperture config api add --strict my-api ./openapi.yaml
 ```
 
 ### List Specifications
 
 ```bash
-aperture config list
+aperture config api list
 ```
 
 ### Remove a Specification
 
 ```bash
-aperture config remove my-api
+aperture config api remove my-api
 ```
 
 ### Reinitialize Cache
@@ -51,7 +64,7 @@ aperture config remove my-api
 Rebuild all cached specifications:
 
 ```bash
-aperture config reinit --all
+aperture config api reinit --all
 ```
 
 ## Base URL Management
@@ -62,28 +75,28 @@ Override the base URL defined in OpenAPI specs.
 
 ```bash
 # Permanent override
-aperture config set-url my-api https://api.example.com
+aperture config url set my-api https://api.example.com
 
 # Environment-specific
-aperture config set-url my-api --env staging https://staging.api.example.com
-aperture config set-url my-api --env prod https://api.example.com
+aperture config url set my-api --env staging https://staging.api.example.com
+aperture config url set my-api --env prod https://api.example.com
 ```
 
 ### View URL Configuration
 
 ```bash
 # Single API
-aperture config get-url my-api
+aperture config url get my-api
 
 # All APIs
-aperture config list-urls
+aperture config url list
 ```
 
 ### URL Resolution Priority
 
 1. **CLI argument** (for testing)
 2. **Environment-specific config** (when `APERTURE_ENV` is set)
-3. **Per-API override** (set via `config set-url`)
+3. **Per-API override** (set via `config url set`)
 4. **`APERTURE_BASE_URL`** environment variable
 5. **OpenAPI spec** server URL
 6. **Fallback** `https://api.example.com`
@@ -92,9 +105,9 @@ aperture config list-urls
 
 ```bash
 # Configure environments
-aperture config set-url my-api --env dev https://dev.api.example.com
-aperture config set-url my-api --env staging https://staging.api.example.com
-aperture config set-url my-api --env prod https://api.example.com
+aperture config url set my-api --env dev https://dev.api.example.com
+aperture config url set my-api --env staging https://staging.api.example.com
+aperture config url set my-api --env prod https://api.example.com
 
 # Select environment at runtime
 APERTURE_ENV=staging aperture api my-api users list
@@ -137,13 +150,13 @@ See [Security Model](security.md) for complete documentation.
 
 ```bash
 # Configure secret mapping
-aperture config set-secret my-api bearerAuth --env API_TOKEN
+aperture config secret set my-api bearerAuth --env API_TOKEN
 
 # Interactive setup
-aperture config set-secret my-api --interactive
+aperture config secret set my-api --interactive
 
 # List configured secrets
-aperture config list-secrets my-api
+aperture config secret list my-api
 ```
 
 ## Cache Management
@@ -152,24 +165,24 @@ aperture config list-secrets my-api
 
 ```bash
 # View cache statistics
-aperture config cache-stats my-api
+aperture config cache stats my-api
 
 # Clear response cache
-aperture config clear-cache my-api
+aperture config cache clear my-api
 ```
 
 ### Specification Cache
 
 ```bash
 # Rebuild all spec caches
-aperture config reinit --all
+aperture config api reinit --all
 
 # Rebuild specific spec cache
-aperture config reinit my-api
+aperture config api reinit my-api
 
 # Remove and re-add specific spec
-aperture config remove my-api
-aperture config add my-api ./openapi.yaml
+aperture config api remove my-api
+aperture config api add my-api ./openapi.yaml
 ```
 
 ## Command Mapping
@@ -178,7 +191,7 @@ Customize the CLI command tree for any API specification without modifying the o
 
 ### How It Works
 
-Command mappings are stored in `config.toml` under `api_configs.<name>.command_mapping` and applied during cache generation (`config add` or `config reinit`). Agents see the effective names in `--describe-json`.
+Command mappings are stored in `config.toml` under `api_configs.<name>.command_mapping` and applied during cache generation (`config api add` or `config api reinit`). Agents see the effective names in `--describe-json`.
 
 ### Group Renames
 
@@ -186,10 +199,10 @@ Rename the tag-derived command groups:
 
 ```bash
 # "User Management" tag becomes "users" group
-aperture config set-mapping my-api --group "User Management" users
+aperture config mapping set my-api --group "User Management" users
 
 # "Organization Settings" becomes "orgs"
-aperture config set-mapping my-api --group "Organization Settings" orgs
+aperture config mapping set my-api --group "Organization Settings" orgs
 ```
 
 ### Operation Mappings
@@ -198,28 +211,28 @@ Customize individual operations by their `operationId`:
 
 ```bash
 # Rename the subcommand
-aperture config set-mapping my-api --operation getUserById --name fetch
+aperture config mapping set my-api --operation getUserById --name fetch
 
 # Move to a different group
-aperture config set-mapping my-api --operation getUserById --op-group accounts
+aperture config mapping set my-api --operation getUserById --op-group accounts
 
 # Add an alias
-aperture config set-mapping my-api --operation getUserById --alias get
+aperture config mapping set my-api --operation getUserById --alias get
 
 # Remove an alias
-aperture config set-mapping my-api --operation getUserById --remove-alias get
+aperture config mapping set my-api --operation getUserById --remove-alias get
 
 # Hide from help output
-aperture config set-mapping my-api --operation deleteUser --hidden
+aperture config mapping set my-api --operation deleteUser --hidden
 
 # Unhide
-aperture config set-mapping my-api --operation deleteUser --visible
+aperture config mapping set my-api --operation deleteUser --visible
 ```
 
 ### Viewing Mappings
 
 ```bash
-aperture config list-mappings my-api
+aperture config mapping list my-api
 ```
 
 **Output:**
@@ -243,10 +256,10 @@ Command mappings for API 'my-api':
 
 ```bash
 # Remove a group mapping
-aperture config remove-mapping my-api --group "User Management"
+aperture config mapping remove my-api --group "User Management"
 
 # Remove an operation mapping
-aperture config remove-mapping my-api --operation getUserById
+aperture config mapping remove my-api --operation getUserById
 ```
 
 ### Applying Changes
@@ -254,7 +267,7 @@ aperture config remove-mapping my-api --operation getUserById
 Mappings take effect after rebuilding the cache:
 
 ```bash
-aperture config reinit my-api
+aperture config api reinit my-api
 ```
 
 ### Config File Format
@@ -291,7 +304,7 @@ Collisions produce hard errors that prevent cache generation.
 When a spec is updated and operations change:
 - Mappings referencing non-existent tags or operation IDs produce **warnings**, not errors
 - The spec is still processed with stale mappings ignored
-- Clean up stale mappings with `config remove-mapping`
+- Clean up stale mappings with `config mapping remove`
 
 ## Global Settings Management
 
@@ -300,7 +313,7 @@ Aperture provides commands to view and modify global settings without manually e
 ### List All Settings
 
 ```bash
-aperture config settings
+aperture config setting list
 ```
 
 **Output:**
@@ -331,10 +344,10 @@ Available configuration settings:
 ### Get a Setting
 
 ```bash
-aperture config get default_timeout_secs
+aperture config setting get default_timeout_secs
 # Output: 30
 
-aperture config get retry_defaults.max_attempts
+aperture config setting get retry_defaults.max_attempts
 # Output: 0
 ```
 
@@ -342,16 +355,16 @@ aperture config get retry_defaults.max_attempts
 
 ```bash
 # Set request timeout to 60 seconds
-aperture config set default_timeout_secs 60
+aperture config setting set default_timeout_secs 60
 
 # Enable JSON errors by default
-aperture config set agent_defaults.json_errors true
+aperture config setting set agent_defaults.json_errors true
 
 # Enable automatic retries (3 attempts)
-aperture config set retry_defaults.max_attempts 3
+aperture config setting set retry_defaults.max_attempts 3
 
 # Set initial retry delay to 1 second
-aperture config set retry_defaults.initial_delay_ms 1000
+aperture config setting set retry_defaults.initial_delay_ms 1000
 ```
 
 Settings are validated against their expected types. Comments and formatting in `config.toml` are preserved.
@@ -444,61 +457,76 @@ Without the feature, 3.1 specs produce an error with instructions to enable it.
 
 ## Command Reference
 
-### Spec Management
+### Spec Management (`config api`)
 
 | Command | Description |
 |---------|-------------|
-| `config add <name> <path>` | Add specification |
-| `config add --strict <name> <path>` | Add with strict validation |
-| `config list` | List registered specs |
-| `config remove <name>` | Remove specification |
-| `config reinit --all` | Rebuild all caches |
-| `config reinit <name>` | Rebuild specific cache |
+| `config api add <name> <path>` | Add specification |
+| `config api add --strict <name> <path>` | Add with strict validation |
+| `config api list` | List registered specs |
+| `config api remove <name>` | Remove specification |
+| `config api reinit --all` | Rebuild all caches |
+| `config api reinit <name>` | Rebuild specific cache |
 
-### URL Management
-
-| Command | Description |
-|---------|-------------|
-| `config set-url <name> <url>` | Set base URL |
-| `config set-url <name> --env <env> <url>` | Set environment URL |
-| `config get-url <name>` | Show URL config |
-| `config list-urls` | Show all URL configs |
-
-### Secret Management
+### URL Management (`config url`)
 
 | Command | Description |
 |---------|-------------|
-| `config set-secret <name> <scheme> --env <var>` | Map secret |
-| `config set-secret <name> --interactive` | Interactive setup |
-| `config list-secrets <name>` | List secret mappings |
+| `config url set <name> <url>` | Set base URL |
+| `config url set <name> --env <env> <url>` | Set environment URL |
+| `config url get <name>` | Show URL config |
+| `config url list` | Show all URL configs |
 
-### Cache Management
-
-| Command | Description |
-|---------|-------------|
-| `config cache-stats <name>` | Show cache stats |
-| `config clear-cache <name>` | Clear response cache |
-
-### Command Mapping
+### Secret Management (`config secret`)
 
 | Command | Description |
 |---------|-------------|
-| `config set-mapping <name> --group <original> <new>` | Rename a tag group |
-| `config set-mapping <name> --operation <id> --name <n>` | Rename an operation |
-| `config set-mapping <name> --operation <id> --op-group <g>` | Move operation to group |
-| `config set-mapping <name> --operation <id> --alias <a>` | Add an alias |
-| `config set-mapping <name> --operation <id> --remove-alias <a>` | Remove an alias |
-| `config set-mapping <name> --operation <id> --hidden` | Hide from help |
-| `config set-mapping <name> --operation <id> --visible` | Unhide |
-| `config list-mappings <name>` | List all mappings |
-| `config remove-mapping <name> --group <original>` | Remove group mapping |
-| `config remove-mapping <name> --operation <id>` | Remove operation mapping |
+| `config secret set <name> <scheme> --env <var>` | Map secret |
+| `config secret set <name> --interactive` | Interactive setup |
+| `config secret list <name>` | List secret mappings |
+| `config secret remove <name> <scheme>` | Remove one secret mapping |
+| `config secret clear <name> [--force]` | Clear all secret mappings |
 
-### Settings Management
+### Cache Management (`config cache`)
 
 | Command | Description |
 |---------|-------------|
-| `config settings` | List all settings with values |
-| `config settings --json` | List settings as JSON |
-| `config get <key>` | Get a setting value |
-| `config set <key> <value>` | Set a setting value |
+| `config cache stats <name>` | Show cache stats |
+| `config cache clear <name>` | Clear response cache |
+
+### Command Mapping (`config mapping`)
+
+| Command | Description |
+|---------|-------------|
+| `config mapping set <name> --group <original> <new>` | Rename a tag group |
+| `config mapping set <name> --operation <id> --name <n>` | Rename an operation |
+| `config mapping set <name> --operation <id> --op-group <g>` | Move operation to group |
+| `config mapping set <name> --operation <id> --alias <a>` | Add an alias |
+| `config mapping set <name> --operation <id> --remove-alias <a>` | Remove an alias |
+| `config mapping set <name> --operation <id> --hidden` | Hide from help |
+| `config mapping set <name> --operation <id> --visible` | Unhide |
+| `config mapping list <name>` | List all mappings |
+| `config mapping remove <name> --group <original>` | Remove group mapping |
+| `config mapping remove <name> --operation <id>` | Remove operation mapping |
+
+### Settings Management (`config setting`)
+
+| Command | Description |
+|---------|-------------|
+| `config setting list` | List all settings with values |
+| `config setting list --json` | List settings as JSON |
+| `config setting get <key>` | Get a setting value |
+| `config setting set <key> <value>` | Set a setting value |
+
+### Compatibility Aliases
+
+Legacy flat commands remain available during migration. Examples:
+
+| Legacy | Nested replacement |
+|--------|--------------------|
+| `config set-url ...` | `config url set ...` |
+| `config get-url ...` | `config url get ...` |
+| `config list-urls` | `config url list` |
+| `config set-secret ...` | `config secret set ...` |
+| `config clear-cache ...` | `config cache clear ...` |
+| `config settings` | `config setting list` |

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -465,7 +465,7 @@ pub async fn execute_shortcut_command(
 
     let specs = manager.list_specs()?;
     if specs.is_empty() {
-        output.info("No API specifications found. Use 'aperture config add' to register APIs.");
+        output.info("No API specifications found. Use 'aperture config api add' to register APIs.");
         return Ok(());
     }
 

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -1110,7 +1110,7 @@ pub fn handle_set_mapping(
         output.success(format!(
             "Set group mapping for '{api_name}': '{original}' → '{new_name}'"
         ));
-        output.info("Run 'aperture config reinit' to apply changes.");
+        output.info("Run 'aperture config api reinit' to apply changes.");
         return Ok(());
     }
 
@@ -1131,7 +1131,7 @@ pub fn handle_set_mapping(
         "Set operation mapping for '{api_name}': '{op_id}' → {}",
         describe_mapping_changes(name, op_group, alias, remove_alias, hidden, visible)
     ));
-    output.info("Run 'aperture config reinit' to apply changes.");
+    output.info("Run 'aperture config api reinit' to apply changes.");
     Ok(())
 }
 
@@ -1210,7 +1210,7 @@ pub fn handle_remove_mapping(
             ));
         }
     }
-    output.info("Run 'aperture config reinit' to apply changes.");
+    output.info("Run 'aperture config api reinit' to apply changes.");
     Ok(())
 }
 

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -386,9 +386,167 @@ enum ConfigCommandFamily {
     Mappings,
 }
 
+fn normalize_api_config_command(
+    command: crate::cli::ConfigApiCommands,
+) -> crate::cli::ConfigCommands {
+    match command {
+        crate::cli::ConfigApiCommands::Add {
+            name,
+            file_or_url,
+            force,
+            strict,
+        } => crate::cli::ConfigCommands::Add {
+            name,
+            file_or_url,
+            force,
+            strict,
+        },
+        crate::cli::ConfigApiCommands::List { verbose } => {
+            crate::cli::ConfigCommands::List { verbose }
+        }
+        crate::cli::ConfigApiCommands::Remove { name } => {
+            crate::cli::ConfigCommands::Remove { name }
+        }
+        crate::cli::ConfigApiCommands::Edit { name } => crate::cli::ConfigCommands::Edit { name },
+        crate::cli::ConfigApiCommands::Reinit { context, all } => {
+            crate::cli::ConfigCommands::Reinit { context, all }
+        }
+    }
+}
+
+fn normalize_url_config_command(
+    command: crate::cli::ConfigUrlCommands,
+) -> crate::cli::ConfigCommands {
+    match command {
+        crate::cli::ConfigUrlCommands::Set { name, url, env } => {
+            crate::cli::ConfigCommands::SetUrl { name, url, env }
+        }
+        crate::cli::ConfigUrlCommands::Get { name } => crate::cli::ConfigCommands::GetUrl { name },
+        crate::cli::ConfigUrlCommands::List => crate::cli::ConfigCommands::ListUrls {},
+    }
+}
+
+fn normalize_secret_config_command(
+    command: crate::cli::ConfigSecretCommands,
+) -> crate::cli::ConfigCommands {
+    match command {
+        crate::cli::ConfigSecretCommands::Set {
+            api_name,
+            scheme_name,
+            env,
+            interactive,
+        } => crate::cli::ConfigCommands::SetSecret {
+            api_name,
+            scheme_name,
+            env,
+            interactive,
+        },
+        crate::cli::ConfigSecretCommands::List { api_name } => {
+            crate::cli::ConfigCommands::ListSecrets { api_name }
+        }
+        crate::cli::ConfigSecretCommands::Remove {
+            api_name,
+            scheme_name,
+        } => crate::cli::ConfigCommands::RemoveSecret {
+            api_name,
+            scheme_name,
+        },
+        crate::cli::ConfigSecretCommands::Clear { api_name, force } => {
+            crate::cli::ConfigCommands::ClearSecrets { api_name, force }
+        }
+    }
+}
+
+fn normalize_cache_config_command(
+    command: crate::cli::ConfigCacheCommands,
+) -> crate::cli::ConfigCommands {
+    match command {
+        crate::cli::ConfigCacheCommands::Clear { api_name, all } => {
+            crate::cli::ConfigCommands::ClearCache { api_name, all }
+        }
+        crate::cli::ConfigCacheCommands::Stats { api_name } => {
+            crate::cli::ConfigCommands::CacheStats { api_name }
+        }
+    }
+}
+
+fn normalize_setting_config_command(
+    command: crate::cli::ConfigSettingCommands,
+) -> crate::cli::ConfigCommands {
+    match command {
+        crate::cli::ConfigSettingCommands::Set { key, value } => {
+            crate::cli::ConfigCommands::Set { key, value }
+        }
+        crate::cli::ConfigSettingCommands::Get { key, json } => {
+            crate::cli::ConfigCommands::Get { key, json }
+        }
+        crate::cli::ConfigSettingCommands::List { json } => {
+            crate::cli::ConfigCommands::Settings { json }
+        }
+    }
+}
+
+fn normalize_mapping_config_command(
+    command: crate::cli::ConfigMappingCommands,
+) -> crate::cli::ConfigCommands {
+    match command {
+        crate::cli::ConfigMappingCommands::Set {
+            api_name,
+            group,
+            operation,
+            name,
+            op_group,
+            alias,
+            remove_alias,
+            hidden,
+            visible,
+        } => crate::cli::ConfigCommands::SetMapping {
+            api_name,
+            group,
+            operation,
+            name,
+            op_group,
+            alias,
+            remove_alias,
+            hidden,
+            visible,
+        },
+        crate::cli::ConfigMappingCommands::List { api_name } => {
+            crate::cli::ConfigCommands::ListMappings { api_name }
+        }
+        crate::cli::ConfigMappingCommands::Remove {
+            api_name,
+            group,
+            operation,
+        } => crate::cli::ConfigCommands::RemoveMapping {
+            api_name,
+            group,
+            operation,
+        },
+    }
+}
+
+fn normalize_config_command(command: crate::cli::ConfigCommands) -> crate::cli::ConfigCommands {
+    match command {
+        crate::cli::ConfigCommands::Api { command } => normalize_api_config_command(command),
+        crate::cli::ConfigCommands::Url { command } => normalize_url_config_command(command),
+        crate::cli::ConfigCommands::Secret { command } => normalize_secret_config_command(command),
+        crate::cli::ConfigCommands::Cache { command } => normalize_cache_config_command(command),
+        crate::cli::ConfigCommands::Setting { command } => {
+            normalize_setting_config_command(command)
+        }
+        crate::cli::ConfigCommands::Mapping { command } => {
+            normalize_mapping_config_command(command)
+        }
+        legacy => legacy,
+    }
+}
+
 const fn config_command_family(command: &crate::cli::ConfigCommands) -> ConfigCommandFamily {
     match command {
-        crate::cli::ConfigCommands::Add { .. }
+        crate::cli::ConfigCommands::Api { .. }
+        | crate::cli::ConfigCommands::Url { .. }
+        | crate::cli::ConfigCommands::Add { .. }
         | crate::cli::ConfigCommands::List { .. }
         | crate::cli::ConfigCommands::Remove { .. }
         | crate::cli::ConfigCommands::Edit { .. }
@@ -396,16 +554,20 @@ const fn config_command_family(command: &crate::cli::ConfigCommands) -> ConfigCo
         | crate::cli::ConfigCommands::GetUrl { .. }
         | crate::cli::ConfigCommands::ListUrls {}
         | crate::cli::ConfigCommands::Reinit { .. } => ConfigCommandFamily::Specs,
-        crate::cli::ConfigCommands::ClearCache { .. }
+        crate::cli::ConfigCommands::Cache { .. }
+        | crate::cli::ConfigCommands::ClearCache { .. }
         | crate::cli::ConfigCommands::CacheStats { .. } => ConfigCommandFamily::Cache,
-        crate::cli::ConfigCommands::SetSecret { .. }
+        crate::cli::ConfigCommands::Secret { .. }
+        | crate::cli::ConfigCommands::SetSecret { .. }
         | crate::cli::ConfigCommands::ListSecrets { .. }
         | crate::cli::ConfigCommands::RemoveSecret { .. }
         | crate::cli::ConfigCommands::ClearSecrets { .. } => ConfigCommandFamily::Secrets,
-        crate::cli::ConfigCommands::Set { .. }
+        crate::cli::ConfigCommands::Setting { .. }
+        | crate::cli::ConfigCommands::Set { .. }
         | crate::cli::ConfigCommands::Get { .. }
         | crate::cli::ConfigCommands::Settings { .. } => ConfigCommandFamily::Settings,
-        crate::cli::ConfigCommands::SetMapping { .. }
+        crate::cli::ConfigCommands::Mapping { .. }
+        | crate::cli::ConfigCommands::SetMapping { .. }
         | crate::cli::ConfigCommands::ListMappings { .. }
         | crate::cli::ConfigCommands::RemoveMapping { .. } => ConfigCommandFamily::Mappings,
     }
@@ -580,6 +742,7 @@ pub async fn execute_config_command(
     command: crate::cli::ConfigCommands,
     output: &Output,
 ) -> Result<(), Error> {
+    let command = normalize_config_command(command);
     match config_command_family(&command) {
         ConfigCommandFamily::Specs => execute_specs_config_command(manager, command, output).await,
         ConfigCommandFamily::Cache => execute_cache_config_command(manager, command, output).await,

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -154,7 +154,7 @@ fn render_all_api_overviews(
     let specs = load_all_specs(manager)?;
     if specs.is_empty() {
         output.info("No API specifications configured.");
-        output.info("Use 'aperture config add <name> <spec-file>' to get started.");
+        output.info("Use 'aperture config api add <name> <spec-file>' to get started.");
         return Ok(());
     }
 

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -17,7 +17,7 @@ pub fn execute_search_command(
 ) -> Result<(), Error> {
     let specs = manager.list_specs()?;
     if specs.is_empty() {
-        output.info("No API specifications found. Use 'aperture config add' to register APIs.");
+        output.info("No API specifications found. Use 'aperture config api add' to register APIs.");
         return Ok(());
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,9 +28,9 @@ pub enum OutputFormat {
                   OpenAPI specs and creating a rich command-line interface with built-in\n\
                   security, caching, and agent-friendly features.\n\n\
                   Examples:\n  \
-                  aperture config add myapi api-spec.yaml\n  \
+                  aperture config api add myapi api-spec.yaml\n  \
                   aperture api myapi users get-user --id 123\n  \
-                  aperture config list\n\n\
+                  aperture config api list\n\n\
                   Agent-friendly features:\n  \
                   aperture api myapi --describe-json    # Get capability manifest\n  \
                   aperture --json-errors api myapi ...  # Structured error output\n  \

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1093,4 +1093,49 @@ mod tests {
         assert!(!help.contains("set-url"));
         assert!(!help.contains("list-urls"));
     }
+
+    #[test]
+    fn config_rejects_unknown_domain() {
+        let err = Cli::try_parse_from(["aperture", "config", "unknown-domain"]).unwrap_err();
+        let err = err.to_string();
+
+        assert!(err.contains("unrecognized subcommand 'unknown-domain'"));
+    }
+
+    #[test]
+    fn config_nested_url_set_rejects_extra_argument() {
+        let err = Cli::try_parse_from([
+            "aperture",
+            "config",
+            "url",
+            "set",
+            "my-api",
+            "https://api.example.com",
+            "extra",
+        ])
+        .unwrap_err();
+        let err = err.to_string();
+
+        assert!(err.contains("unexpected argument 'extra'"));
+    }
+
+    #[test]
+    fn config_nested_url_set_rejects_duplicate_env_flags() {
+        let err = Cli::try_parse_from([
+            "aperture",
+            "config",
+            "url",
+            "set",
+            "my-api",
+            "--env",
+            "dev",
+            "--env",
+            "prod",
+            "https://api.example.com",
+        ])
+        .unwrap_err();
+        let err = err.to_string();
+
+        assert!(err.contains("cannot be used multiple times"));
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -226,8 +226,8 @@ pub enum Commands {
                       - cache: response cache operations\n\
                       - setting: global CLI settings\n\
                       - mapping: command tree customization\n\n\
-                      Legacy flat commands (for example `config set-url`) are still\n\
-                      accepted for compatibility during migration."
+                      Legacy flat commands are still accepted for compatibility\n\
+                      during migration."
     )]
     Config {
         #[command(subcommand)]
@@ -974,8 +974,8 @@ pub enum ConfigCommands {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands};
-    use clap::Parser;
+    use super::{Cli, Commands, ConfigCommands, ConfigUrlCommands};
+    use clap::{CommandFactory, Parser};
 
     #[test]
     fn commands_canonical_name_parses() {
@@ -1019,5 +1019,78 @@ mod tests {
             }
             other => panic!("expected Commands::Exec, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn config_nested_url_set_parses() {
+        let cli = Cli::try_parse_from([
+            "aperture",
+            "config",
+            "url",
+            "set",
+            "my-api",
+            "https://api.example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Config {
+                command:
+                    ConfigCommands::Url {
+                        command: ConfigUrlCommands::Set { name, url, env },
+                    },
+            } => {
+                assert_eq!(name, "my-api");
+                assert_eq!(url, "https://api.example.com");
+                assert!(env.is_none());
+            }
+            other => panic!("expected nested url set command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_legacy_set_url_parses_for_compatibility() {
+        let cli = Cli::try_parse_from([
+            "aperture",
+            "config",
+            "set-url",
+            "my-api",
+            "https://api.example.com",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Config {
+                command: ConfigCommands::SetUrl { name, url, env },
+            } => {
+                assert_eq!(name, "my-api");
+                assert_eq!(url, "https://api.example.com");
+                assert!(env.is_none());
+            }
+            other => panic!("expected legacy set-url command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_help_lists_domain_commands() {
+        let mut command = Cli::command();
+        let config_command = command
+            .find_subcommand_mut("config")
+            .expect("config command should exist");
+        let mut help = Vec::new();
+        config_command
+            .write_long_help(&mut help)
+            .expect("config help should render");
+        let help = String::from_utf8(help).expect("help should be valid UTF-8");
+
+        for domain in ["api", "url", "secret", "cache", "setting", "mapping"] {
+            assert!(
+                help.contains(domain),
+                "config help should include domain '{domain}', got:\n{help}"
+            );
+        }
+
+        assert!(!help.contains("set-url"));
+        assert!(!help.contains("list-urls"));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -216,11 +216,19 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Manage API specifications (add, list, remove, edit)
-    #[command(long_about = "Manage your collection of OpenAPI specifications.\n\n\
-                      Add specifications to make their operations available as commands,\n\
-                      list currently registered specs, remove unused ones, or edit\n\
-                      existing specifications in your default editor.")]
+    /// Manage configuration in domain-specific groups
+    #[command(
+        long_about = "Manage Aperture configuration using domain-oriented subcommands.\n\n\
+                      Domains are organized by administrative area:\n\
+                      - api: specification lifecycle (add/list/remove/edit/reinit)\n\
+                      - url: base URL overrides and environment URL sets\n\
+                      - secret: authentication secret mappings\n\
+                      - cache: response cache operations\n\
+                      - setting: global CLI settings\n\
+                      - mapping: command tree customization\n\n\
+                      Legacy flat commands (for example `config set-url`) are still\n\
+                      accepted for compatibility during migration."
+    )]
     Config {
         #[command(subcommand)]
         command: ConfigCommands,
@@ -355,7 +363,244 @@ pub enum Commands {
 }
 
 #[derive(Subcommand, Debug, Clone)]
+pub enum ConfigApiCommands {
+    /// Add a new API specification from a file or URL
+    Add {
+        /// Name to identify this API specification (used as context in 'aperture api').
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        name: String,
+        /// Path to the `OpenAPI` 3.x specification file (YAML format) or URL
+        file_or_url: String,
+        /// Overwrite existing specification if it already exists
+        #[arg(long, help = "Replace the specification if it already exists")]
+        force: bool,
+        /// Reject specs with unsupported features instead of skipping endpoints
+        #[arg(
+            long,
+            help = "Reject entire spec if any endpoints have unsupported content types (e.g., multipart/form-data, XML). Default behavior skips unsupported endpoints with warnings."
+        )]
+        strict: bool,
+    },
+    /// List all registered API specifications
+    List {
+        /// Show detailed information including skipped endpoints
+        #[arg(long, help = "Show detailed information about each API")]
+        verbose: bool,
+    },
+    /// Remove an API specification from configuration
+    Remove {
+        /// Name of the API specification to remove.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        name: String,
+    },
+    /// Edit an API specification in your default editor
+    Edit {
+        /// Name of the API specification to edit.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        name: String,
+    },
+    /// Re-initialize cached specifications
+    Reinit {
+        /// Name of the API specification to reinitialize (omit for --all).
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        context: Option<String>,
+        /// Reinitialize all cached specifications
+        #[arg(long, conflicts_with = "context", help = "Reinitialize all specs")]
+        all: bool,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ConfigUrlCommands {
+    /// Set base URL for an API specification
+    Set {
+        /// Name of the API specification.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        name: String,
+        /// The base URL to set
+        url: String,
+        /// Set URL for a specific environment (e.g., dev, staging, prod)
+        #[arg(long, value_name = "ENV", help = "Set URL for specific environment")]
+        env: Option<String>,
+    },
+    /// Get base URL configuration for an API specification
+    Get {
+        /// Name of the API specification.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        name: String,
+    },
+    /// List all configured base URLs
+    List,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ConfigSecretCommands {
+    /// Set secret configuration for an API specification security scheme
+    Set {
+        /// Name of the API specification.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        api_name: String,
+        /// Name of the security scheme (omit for interactive mode)
+        scheme_name: Option<String>,
+        /// Environment variable name containing the secret
+        #[arg(long, value_name = "VAR", help = "Environment variable name")]
+        env: Option<String>,
+        /// Interactive mode to configure all undefined secrets
+        #[arg(long, conflicts_with_all = ["scheme_name", "env"], help = "Configure secrets interactively")]
+        interactive: bool,
+    },
+    /// List configured secrets for an API specification
+    List {
+        /// Name of the API specification.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        api_name: String,
+    },
+    /// Remove a specific configured secret for an API specification
+    Remove {
+        /// Name of the API specification.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        api_name: String,
+        /// Name of the security scheme to remove
+        scheme_name: String,
+    },
+    /// Clear all configured secrets for an API specification
+    Clear {
+        /// Name of the API specification.
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        api_name: String,
+        /// Skip confirmation prompt
+        #[arg(long, help = "Skip confirmation prompt")]
+        force: bool,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ConfigCacheCommands {
+    /// Clear response cache
+    Clear {
+        /// Name of the API specification to clear cache for (omit for --all).
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        api_name: Option<String>,
+        /// Clear all cached responses
+        #[arg(long, conflicts_with = "api_name", help = "Clear all response cache")]
+        all: bool,
+    },
+    /// Show response cache statistics
+    Stats {
+        /// Name of the API specification to show stats for (omit for all APIs).
+        /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
+        api_name: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ConfigSettingCommands {
+    /// Set a global configuration setting
+    Set {
+        /// Setting key (use `config setting list` to see all available keys)
+        key: String,
+        /// Value to set (validated against expected type)
+        value: String,
+    },
+    /// Get a global configuration setting value
+    Get {
+        /// Setting key to retrieve (use `config setting list` to see all available keys)
+        key: String,
+        /// Output as JSON
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+    /// List all available configuration settings
+    List {
+        /// Output as JSON
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ConfigMappingCommands {
+    /// Set a command mapping for an API specification
+    Set {
+        /// Name of the API specification.
+        api_name: String,
+        /// Rename a tag group: `--group <original> <new_name>`
+        #[arg(long, num_args = 2, value_names = ["ORIGINAL", "NEW_NAME"], conflicts_with = "operation")]
+        group: Option<Vec<String>>,
+        /// Target an operation by its operationId
+        #[arg(long, value_name = "OPERATION_ID")]
+        operation: Option<String>,
+        /// Set the subcommand name for an operation
+        #[arg(long, requires = "operation", value_name = "NAME")]
+        name: Option<String>,
+        /// Set the group for an operation (overrides tag)
+        #[arg(long = "op-group", requires = "operation", value_name = "GROUP")]
+        op_group: Option<String>,
+        /// Add an alias for an operation
+        #[arg(long, requires = "operation", value_name = "ALIAS")]
+        alias: Option<String>,
+        /// Remove an alias from an operation
+        #[arg(long, requires = "operation", value_name = "ALIAS")]
+        remove_alias: Option<String>,
+        /// Mark an operation as hidden from help output
+        #[arg(long, requires = "operation")]
+        hidden: bool,
+        /// Mark an operation as visible (unhide)
+        #[arg(long, requires = "operation", conflicts_with = "hidden")]
+        visible: bool,
+    },
+    /// List command mappings for an API specification
+    List {
+        /// Name of the API specification.
+        api_name: String,
+    },
+    /// Remove a command mapping for an API specification
+    Remove {
+        /// Name of the API specification.
+        api_name: String,
+        /// Remove a group mapping by original tag name
+        #[arg(long, value_name = "ORIGINAL", conflicts_with = "operation")]
+        group: Option<String>,
+        /// Remove an operation mapping by operationId
+        #[arg(long, value_name = "OPERATION_ID")]
+        operation: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
 pub enum ConfigCommands {
+    /// API specification administration
+    Api {
+        #[command(subcommand)]
+        command: ConfigApiCommands,
+    },
+    /// Base URL override administration
+    Url {
+        #[command(subcommand)]
+        command: ConfigUrlCommands,
+    },
+    /// Secret mapping administration
+    Secret {
+        #[command(subcommand)]
+        command: ConfigSecretCommands,
+    },
+    /// Response cache administration
+    Cache {
+        #[command(subcommand)]
+        command: ConfigCacheCommands,
+    },
+    /// Global setting administration
+    Setting {
+        #[command(subcommand)]
+        command: ConfigSettingCommands,
+    },
+    /// Command mapping administration
+    Mapping {
+        #[command(subcommand)]
+        command: ConfigMappingCommands,
+    },
+
+    #[command(hide = true)]
     /// Add a new API specification from a file
     #[command(
         long_about = "Add an OpenAPI 3.x specification to your configuration.\n\n\
@@ -384,6 +629,7 @@ pub enum ConfigCommands {
         )]
         strict: bool,
     },
+    #[command(hide = true)]
     /// List all registered API specifications
     #[command(
         long_about = "Display all currently registered API specifications.\n\n\
@@ -395,6 +641,7 @@ pub enum ConfigCommands {
         #[arg(long, help = "Show detailed information about each API")]
         verbose: bool,
     },
+    #[command(hide = true)]
     /// Remove an API specification from configuration
     #[command(
         long_about = "Remove a registered API specification and its cached data.\n\n\
@@ -407,6 +654,7 @@ pub enum ConfigCommands {
         /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
         name: String,
     },
+    #[command(hide = true)]
     /// Edit an API specification in your default editor
     #[command(
         long_about = "Open an API specification in your default text editor.\n\n\
@@ -422,6 +670,7 @@ pub enum ConfigCommands {
         /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
         name: String,
     },
+    #[command(hide = true)]
     /// Set base URL for an API specification
     #[command(long_about = "Set the base URL for an API specification.\n\n\
                       This overrides the base URL from the OpenAPI spec and the\n\
@@ -441,6 +690,7 @@ pub enum ConfigCommands {
         #[arg(long, value_name = "ENV", help = "Set URL for specific environment")]
         env: Option<String>,
     },
+    #[command(hide = true)]
     /// Get base URL configuration for an API specification
     #[command(
         long_about = "Display the base URL configuration for an API specification.\n\n\
@@ -455,6 +705,7 @@ pub enum ConfigCommands {
         /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
         name: String,
     },
+    #[command(hide = true)]
     /// List all configured base URLs
     #[command(
         long_about = "Display all configured base URLs across all API specifications.\n\n\
@@ -463,6 +714,7 @@ pub enum ConfigCommands {
                       at a glance."
     )]
     ListUrls {},
+    #[command(hide = true)]
     /// Set secret configuration for an API specification security scheme
     #[command(
         long_about = "Configure authentication secrets for API specifications.\n\n\
@@ -487,6 +739,7 @@ pub enum ConfigCommands {
         #[arg(long, conflicts_with_all = ["scheme_name", "env"], help = "Configure secrets interactively")]
         interactive: bool,
     },
+    #[command(hide = true)]
     /// List configured secrets for an API specification
     #[command(
         long_about = "Display configured secret mappings for an API specification.\n\n\
@@ -501,6 +754,7 @@ pub enum ConfigCommands {
         /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
         api_name: String,
     },
+    #[command(hide = true)]
     /// Remove a specific configured secret for an API specification
     #[command(
         long_about = "Remove a configured secret mapping for a specific security scheme.\n\n\
@@ -518,6 +772,7 @@ pub enum ConfigCommands {
         /// Name of the security scheme to remove
         scheme_name: String,
     },
+    #[command(hide = true)]
     /// Clear all configured secrets for an API specification
     #[command(
         long_about = "Remove all configured secret mappings for an API specification.\n\n\
@@ -536,6 +791,7 @@ pub enum ConfigCommands {
         #[arg(long, help = "Skip confirmation prompt")]
         force: bool,
     },
+    #[command(hide = true)]
     /// Re-initialize cached specifications
     #[command(
         long_about = "Regenerate binary cache files for API specifications.\n\n\
@@ -554,6 +810,7 @@ pub enum ConfigCommands {
         #[arg(long, conflicts_with = "context", help = "Reinitialize all specs")]
         all: bool,
     },
+    #[command(hide = true)]
     /// Clear response cache
     #[command(long_about = "Clear cached API responses to free up disk space.\n\n\
                       You can clear cache for a specific API or all cached responses.\n\
@@ -570,6 +827,7 @@ pub enum ConfigCommands {
         #[arg(long, conflicts_with = "api_name", help = "Clear all response cache")]
         all: bool,
     },
+    #[command(hide = true)]
     /// Show response cache statistics
     #[command(long_about = "Display statistics about cached API responses.\n\n\
                       Shows cache size, number of entries, and hit/miss rates.\n\
@@ -582,6 +840,7 @@ pub enum ConfigCommands {
         /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
         api_name: Option<String>,
     },
+    #[command(hide = true)]
     /// Set a global configuration setting
     #[command(long_about = "Set a global configuration setting value.\n\n\
                       Supports dot-notation for nested settings and type-safe validation.\n\
@@ -602,6 +861,7 @@ pub enum ConfigCommands {
         /// Value to set (validated against expected type)
         value: String,
     },
+    #[command(hide = true)]
     /// Get a global configuration setting value
     #[command(
         long_about = "Get the current value of a global configuration setting.\n\n\
@@ -619,6 +879,7 @@ pub enum ConfigCommands {
         #[arg(long, help = "Output as JSON")]
         json: bool,
     },
+    #[command(hide = true)]
     /// List all available configuration settings
     #[command(
         long_about = "Display all available configuration settings and their current values.\n\n\
@@ -633,6 +894,7 @@ pub enum ConfigCommands {
         #[arg(long, help = "Output as JSON")]
         json: bool,
     },
+    #[command(hide = true)]
     /// Set a command mapping for an API specification
     #[command(
         name = "set-mapping",
@@ -674,6 +936,7 @@ pub enum ConfigCommands {
         #[arg(long, requires = "operation", conflicts_with = "hidden")]
         visible: bool,
     },
+    #[command(hide = true)]
     /// List command mappings for an API specification
     #[command(
         name = "list-mappings",
@@ -686,6 +949,7 @@ pub enum ConfigCommands {
         /// Name of the API specification.
         api_name: String,
     },
+    #[command(hide = true)]
     /// Remove a command mapping for an API specification
     #[command(
         name = "remove-mapping",

--- a/src/command_guidance.rs
+++ b/src/command_guidance.rs
@@ -1,12 +1,12 @@
 //! Canonical command guidance used in user-facing hints and remediation text.
 
-pub const CMD_CONFIG_SET_SECRET: &str = "aperture config set-secret";
-pub const CMD_CONFIG_LIST_SECRETS: &str = "aperture config list-secrets";
-pub const CMD_CONFIG_REMOVE_SECRET: &str = "aperture config remove-secret";
-pub const CMD_CONFIG_CLEAR_SECRETS: &str = "aperture config clear-secrets";
-pub const CMD_CONFIG_REINIT: &str = "aperture config reinit";
-pub const CMD_CONFIG_ADD: &str = "aperture config add";
-pub const CMD_CONFIG_SETTINGS: &str = "aperture config settings";
+pub const CMD_CONFIG_SET_SECRET: &str = "aperture config secret set";
+pub const CMD_CONFIG_LIST_SECRETS: &str = "aperture config secret list";
+pub const CMD_CONFIG_REMOVE_SECRET: &str = "aperture config secret remove";
+pub const CMD_CONFIG_CLEAR_SECRETS: &str = "aperture config secret clear";
+pub const CMD_CONFIG_REINIT: &str = "aperture config api reinit";
+pub const CMD_CONFIG_ADD: &str = "aperture config api add";
+pub const CMD_CONFIG_SETTINGS: &str = "aperture config setting list";
 pub const CMD_HELP_WITH_DESCRIBE_JSON: &str =
     "Check available operations with --help or --describe-json";
 pub const CMD_HELP_WITH_DESCRIBE_JSON_COMMANDS: &str =

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -120,7 +120,8 @@ pub const ERR_OPENAPI_FORMAT: &str =
 
 // CLI Messages
 pub const MSG_USE_HELP: &str = "Use --help to see available commands.";
-pub const MSG_USE_CONFIG_LIST: &str = "Use 'aperture config list' to see available specifications.";
+pub const MSG_USE_CONFIG_LIST: &str =
+    "Use 'aperture config api list' to see available specifications.";
 pub const MSG_WARNING_PREFIX: &str = "Warning:";
 
 // Default Values

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -446,7 +446,7 @@ impl DocumentationGenerator {
         if self.specs.is_empty() {
             menu.push_str("## No APIs Configured\n\n");
             menu.push_str("Get started by adding an API specification:\n");
-            menu.push_str("```bash\naperture config add myapi ./openapi.yaml\n```\n\n");
+            menu.push_str("```bash\naperture config api add myapi ./openapi.yaml\n```\n\n");
         } else {
             menu.push_str("## Your APIs\n\n");
             for (api_name, spec) in &self.specs {
@@ -463,7 +463,7 @@ impl DocumentationGenerator {
 
         // Common commands
         menu.push_str("## Common Commands\n\n");
-        menu.push_str("- `aperture config list` - List all configured APIs\n");
+        menu.push_str("- `aperture config api list` - List all configured APIs\n");
         menu.push_str("- `aperture search <term>` - Search across all APIs\n");
         menu.push_str("- `aperture commands <api>` - Show available commands for an API\n");
         menu.push_str("- `aperture run <shortcut>` - Execute using shortcuts\n");

--- a/src/error.rs
+++ b/src/error.rs
@@ -1353,7 +1353,7 @@ mod tests {
         let context = j
             .context
             .expect("cache_stale should include remediation hint");
-        assert!(context.contains("aperture config reinit stale-api"));
+        assert!(context.contains("aperture config api reinit stale-api"));
     }
 
     #[test]
@@ -1365,8 +1365,8 @@ mod tests {
         let context = j
             .context
             .expect("secret_not_set should include remediation hint");
-        assert!(context.contains("aperture config set-secret"));
-        assert!(!context.contains("aperture config secrets"));
+        assert!(context.contains("aperture config secret set"));
+        assert!(!context.contains("aperture config set-secret"));
         assert!(j.details.is_some());
     }
 

--- a/tests/base_url_integration_tests.rs
+++ b/tests/base_url_integration_tests.rs
@@ -639,36 +639,42 @@ fn test_multiple_apis_url_management() {
 
 #[test]
 fn test_help_includes_new_commands() {
-    // Test that help shows the new URL management commands
+    // Top-level config help should expose nested domains.
     aperture_cmd()
         .args(["config", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("set-url"))
-        .stdout(predicate::str::contains("get-url"))
-        .stdout(predicate::str::contains("list-urls"));
+        .stdout(predicate::str::contains("url"))
+        .stdout(predicate::str::contains("secret"))
+        .stdout(predicate::str::contains("cache"))
+        .stdout(predicate::str::contains("setting"))
+        .stdout(predicate::str::contains("mapping"));
 
-    // Test individual command help
+    // Domain help should expose grouped URL verbs.
+    aperture_cmd()
+        .args(["config", "url", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("set"))
+        .stdout(predicate::str::contains("get"))
+        .stdout(predicate::str::contains("list"));
+
+    // Nested command help should work for the new taxonomy.
+    aperture_cmd()
+        .args(["config", "url", "set", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Set base URL for an API specification",
+        ))
+        .stdout(predicate::str::contains("--env"));
+
+    // Legacy flat command path remains available for compatibility.
     aperture_cmd()
         .args(["config", "set-url", "--help"])
         .assert()
         .success()
         .stdout(predicate::str::contains(
             "Set the base URL for an API specification",
-        ))
-        .stdout(predicate::str::contains("--env"));
-
-    aperture_cmd()
-        .args(["config", "get-url", "--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "Display the base URL configuration",
         ));
-
-    aperture_cmd()
-        .args(["config", "list-urls", "--help"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("Display all configured base URLs"));
 }

--- a/tests/config_settings_integration_tests.rs
+++ b/tests/config_settings_integration_tests.rs
@@ -176,7 +176,7 @@ fn test_config_get_invalid_key_error() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("Unknown setting key"))
-        .stderr(predicate::str::contains("aperture config settings"));
+        .stderr(predicate::str::contains("aperture config setting list"));
 }
 
 /// Test `aperture config set` with invalid value type shows helpful error

--- a/tests/config_settings_integration_tests.rs
+++ b/tests/config_settings_integration_tests.rs
@@ -24,6 +24,40 @@ fn test_config_settings_lists_all() {
         .stdout(predicate::str::contains("Type: boolean"));
 }
 
+/// Test `aperture config setting list` nested command lists settings
+#[test]
+fn test_config_setting_list_nested_command() {
+    let temp_dir = TempDir::new().unwrap();
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "setting", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("default_timeout_secs"))
+        .stdout(predicate::str::contains("agent_defaults.json_errors"));
+}
+
+/// Test `aperture config setting set/get` nested commands roundtrip
+#[test]
+fn test_config_setting_nested_set_get_roundtrip() {
+    let temp_dir = TempDir::new().unwrap();
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "setting", "set", "default_timeout_secs", "90"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Set default_timeout_secs = 90"));
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "setting", "get", "default_timeout_secs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("90"));
+}
+
 /// Test `aperture config settings --json` outputs valid JSON
 #[test]
 fn test_config_settings_json_output() {

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -202,7 +202,7 @@ fn test_generate_interactive_menu() {
     assert!(menu.contains("## Your APIs"));
     assert!(menu.contains("**testapi** (2 operations)"));
     assert!(menu.contains("## Common Commands"));
-    assert!(menu.contains("aperture config list"));
+    assert!(menu.contains("aperture config api list"));
     assert!(menu.contains("aperture search"));
     assert!(menu.contains("aperture run"));
     assert!(menu.contains("## Tips"));
@@ -217,7 +217,7 @@ fn test_generate_interactive_menu_no_apis() {
     let menu = doc_gen.generate_interactive_menu();
 
     assert!(menu.contains("## No APIs Configured"));
-    assert!(menu.contains("aperture config add myapi ./openapi.yaml"));
+    assert!(menu.contains("aperture config api add myapi ./openapi.yaml"));
 }
 
 #[test]

--- a/tests/error_suggestions_tests.rs
+++ b/tests/error_suggestions_tests.rs
@@ -149,14 +149,14 @@ fn test_suggest_valid_values() {
 fn test_suggest_auth_fix() {
     let suggestion = suggest_auth_fix("api-key", Some("API_KEY"));
     assert!(suggestion.contains("API_KEY"));
-    assert!(suggestion.contains("aperture config set-secret"));
-    assert!(!suggestion.contains("aperture config secrets"));
+    assert!(suggestion.contains("aperture config secret set"));
+    assert!(!suggestion.contains("aperture config set-secret"));
 
     let suggestion = suggest_auth_fix("oauth", None);
     assert!(suggestion.contains("oauth"));
-    assert!(suggestion.contains("aperture config set-secret"));
-    assert!(suggestion.contains("aperture config list-secrets"));
-    assert!(suggestion.contains("aperture config remove-secret"));
-    assert!(suggestion.contains("aperture config clear-secrets"));
-    assert!(!suggestion.contains("aperture config secrets"));
+    assert!(suggestion.contains("aperture config secret set"));
+    assert!(suggestion.contains("aperture config secret list"));
+    assert!(suggestion.contains("aperture config secret remove"));
+    assert!(suggestion.contains("aperture config secret clear"));
+    assert!(!suggestion.contains("aperture config set-secret"));
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -347,6 +347,68 @@ fn test_help_output() {
         .stdout(predicate::str::contains("mapping"));
 }
 
+#[test]
+fn test_mapping_commands_recommend_nested_reinit_path() {
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().to_path_buf();
+    let spec_file = temp_dir.path().join("spec.yaml");
+
+    fs::write(
+        &spec_file,
+        "openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /users/{id}:
+    get:
+      tags:
+        - users
+      operationId: getUserById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+",
+    )
+    .unwrap();
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args([
+            "config",
+            "api",
+            "add",
+            "test-api",
+            spec_file.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", config_dir.to_str().unwrap())
+        .args([
+            "config",
+            "mapping",
+            "set",
+            "test-api",
+            "--operation",
+            "getUserById",
+            "--alias",
+            "get",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Run 'aperture config api reinit' to apply changes.",
+        ));
+}
+
 #[tokio::test]
 async fn test_query_and_header_parameters() {
     let temp_dir = TempDir::new().unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -337,12 +337,14 @@ fn test_help_output() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Manage your collection of OpenAPI specifications",
+            "Manage Aperture configuration using domain-oriented subcommands",
         ))
-        .stdout(predicate::str::contains("add"))
-        .stdout(predicate::str::contains("list"))
-        .stdout(predicate::str::contains("remove"))
-        .stdout(predicate::str::contains("edit"));
+        .stdout(predicate::str::contains("api"))
+        .stdout(predicate::str::contains("url"))
+        .stdout(predicate::str::contains("secret"))
+        .stdout(predicate::str::contains("cache"))
+        .stdout(predicate::str::contains("setting"))
+        .stdout(predicate::str::contains("mapping"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- reorganize `aperture config` into nested administrative domains: `api`, `url`, `secret`, `cache`, `setting`, and `mapping`
- keep existing flat commands (for example `config set-url`) working as compatibility paths while hiding them from top-level config help
- add parser/help/integration coverage for the new hierarchy and compatibility behavior
- update configuration documentation and README examples with the new taxonomy and migration guidance

Closes #137

## Validation
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings