### PR TITLE
ux: consolidate discovery command roles and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,29 @@ aperture config api add petstore https://petstore3.swagger.io/api/v3/openapi.jso
 # Configure authentication
 aperture config secret set petstore api_key --env PETSTORE_API_KEY
 
-# Discover available operations
-aperture api petstore --describe-json
+# Orient: understand the API surface
+aperture overview petstore
 
-# Execute a command
+# Find: search by intent
+aperture search "get pet by id" --api petstore
+
+# Inspect: read deep operation docs
+aperture docs petstore pet get-pet-by-id
+
+# Execute: run the operation
 aperture api petstore pet get-pet-by-id --petId 1
+
+# Machine introspection for agents
+aperture api petstore --describe-json
 ```
+
+### Discovery Commands (Canonical Roles)
+
+- `overview` → orient to an API at a high level
+- `search` → primary intent-first discovery (cross-API or scoped)
+- `commands` (`list-commands`) → terse structural tree
+- `docs` → deep operation reference before execution
+- `api --describe-json` → machine-readable capability manifest
 
 ## Agent Integration
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -251,7 +251,9 @@ aperture config reinit my-api
 
 ## Search Commands
 
-Find operations across all registered APIs. Search matches against operation names, descriptions, display names, and aliases from command mappings.
+**Canonical role:** primary intent-first discovery. Use search when you know what you want to do but not where the command is.
+
+Search matches operation names, descriptions, display names, and aliases from command mappings.
 
 ```bash
 # Search by keyword
@@ -284,9 +286,16 @@ aperture run users list
 
 ## API Exploration
 
+Use this human workflow for discovery:
+
+1. **Orient** with `overview`
+2. **Find** with `search`
+3. **Inspect** with `docs`
+4. **Execute** with `api`
+
 ### Overview
 
-Get a quick summary of an API with statistics and example commands:
+**Canonical role:** orientation. Get a high-level API summary with statistics and starter paths.
 
 ```bash
 # Overview of a specific API
@@ -296,15 +305,27 @@ aperture overview my-api
 aperture overview --all
 ```
 
+### Commands Tree
+
+**Canonical role:** structural lookup. Get a terse tree of available command paths.
+
+```bash
+# Canonical command name
+aperture commands my-api
+
+# Legacy alias
+aperture list-commands my-api
+```
+
 ### Interactive Documentation
 
-Browse detailed documentation for APIs and operations:
+**Canonical role:** deep reference. Inspect exact operation usage, parameters, request bodies, and responses.
 
 ```bash
 # Interactive help menu
 aperture docs
 
-# API overview
+# API reference index
 aperture docs my-api
 
 # Detailed command help with parameters and examples

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -25,12 +25,14 @@ pub fn list_commands(context: &str, output: &Output) -> Result<(), Error> {
     // ast-grep-ignore: no-println
     println!("{formatted_output}");
     output.tip(format!(
-        "Use 'aperture docs {context}' for detailed API documentation"
+        "Next: 'aperture overview {context}' for high-level API orientation"
     ));
     output.tip(format!(
-        "Use 'aperture search <term> --api {context}' to find specific operations"
+        "Next: 'aperture search <term> --api {context}' to find operations by intent"
     ));
-    output.tip("Use shortcuts: 'aperture run <operation-id> --help'");
+    output.tip(format!(
+        "Next: 'aperture docs {context} <tag> <operation>' for deep operation docs"
+    ));
     Ok(())
 }
 
@@ -44,8 +46,8 @@ pub fn execute_help_command(
     output: &Output,
 ) -> Result<(), Error> {
     match (api_name, tag, operation) {
-        (None, None, None) => render_interactive_menu(manager),
-        (Some(api), None, None) => render_api_reference_index(manager, api),
+        (None, None, None) => render_interactive_menu(manager, output),
+        (Some(api), None, None) => render_api_reference_index(manager, api, output),
         (Some(api), Some(tag), Some(op)) => {
             render_command_help(manager, api, tag, op, enhanced, output)
         }
@@ -58,23 +60,34 @@ pub fn execute_help_command(
     }
 }
 
-fn render_interactive_menu(manager: &ConfigManager<OsFileSystem>) -> Result<(), Error> {
+fn render_interactive_menu(
+    manager: &ConfigManager<OsFileSystem>,
+    output: &Output,
+) -> Result<(), Error> {
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
     // ast-grep-ignore: no-println
     println!("{}", doc_gen.generate_interactive_menu());
+    output.tip("Try 'aperture overview <api>' to orient to one API before drilling in");
     Ok(())
 }
 
 fn render_api_reference_index(
     manager: &ConfigManager<OsFileSystem>,
     api: &str,
+    output: &Output,
 ) -> Result<(), Error> {
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
     let reference = doc_gen.generate_api_reference_index(api)?;
     // ast-grep-ignore: no-println
     println!("{reference}");
+    output.tip(format!(
+        "Execute operations with 'aperture api {api} <tag> <operation> ...'"
+    ));
+    output.tip(format!(
+        "Machine workflow: 'aperture api {api} --describe-json'"
+    ));
     Ok(())
 }
 
@@ -97,6 +110,9 @@ fn render_command_help(
         println!("{}", help.lines().take(20).collect::<Vec<_>>().join("\n"));
         output.tip("Use --enhanced for full documentation with examples");
     }
+    output.tip(format!(
+        "Execute with 'aperture api {api} <tag> <operation> ...' after inspection"
+    ));
     Ok(())
 }
 
@@ -132,7 +148,7 @@ pub fn execute_overview_command(
         let Some(api) = api_name else {
             print_overview_usage();
         };
-        return render_single_api_overview(manager, api);
+        return render_single_api_overview(manager, api, output);
     }
 
     render_all_api_overviews(manager, output)
@@ -141,12 +157,22 @@ pub fn execute_overview_command(
 fn render_single_api_overview(
     manager: &ConfigManager<OsFileSystem>,
     api: &str,
+    output: &Output,
 ) -> Result<(), Error> {
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
     let overview = doc_gen.generate_api_overview(api)?;
     // ast-grep-ignore: no-println
     println!("{overview}");
+    output.tip(format!(
+        "Next: 'aperture search <term> --api {api}' to find specific operations"
+    ));
+    output.tip(format!(
+        "Next: 'aperture docs {api} <tag> <operation>' for deep operation reference"
+    ));
+    output.tip(format!(
+        "Machine workflow: 'aperture api {api} --describe-json'"
+    ));
     Ok(())
 }
 
@@ -183,7 +209,9 @@ fn render_all_api_overviews(
     }
     // ast-grep-ignore: no-println
     println!("\n{}", "=".repeat(60));
-    output.tip("Use 'aperture overview <api>' for detailed information about a specific API");
+    output.tip("Use 'aperture overview <api>' to orient to a specific API");
+    output.tip("Then use 'aperture search <term> --api <api>' to find operations by intent");
+    output.tip("Use 'aperture docs <api> <tag> <operation>' for deep operation reference");
     Ok(())
 }
 

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -45,7 +45,7 @@ pub fn execute_help_command(
 ) -> Result<(), Error> {
     match (api_name, tag, operation) {
         (None, None, None) => render_interactive_menu(manager),
-        (Some(api), None, None) => render_api_overview(manager, api),
+        (Some(api), None, None) => render_api_reference_index(manager, api),
         (Some(api), Some(tag), Some(op)) => {
             render_command_help(manager, api, tag, op, enhanced, output)
         }
@@ -66,12 +66,15 @@ fn render_interactive_menu(manager: &ConfigManager<OsFileSystem>) -> Result<(), 
     Ok(())
 }
 
-fn render_api_overview(manager: &ConfigManager<OsFileSystem>, api: &str) -> Result<(), Error> {
+fn render_api_reference_index(
+    manager: &ConfigManager<OsFileSystem>,
+    api: &str,
+) -> Result<(), Error> {
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
-    let overview = doc_gen.generate_api_overview(api)?;
+    let reference = doc_gen.generate_api_reference_index(api)?;
     // ast-grep-ignore: no-println
-    println!("{overview}");
+    println!("{reference}");
     Ok(())
 }
 
@@ -104,7 +107,7 @@ fn print_invalid_docs_usage() -> ! {
     // ast-grep-ignore: no-println
     eprintln!("  aperture docs                        # Interactive menu");
     // ast-grep-ignore: no-println
-    eprintln!("  aperture docs <api>                  # API overview");
+    eprintln!("  aperture docs <api>                  # API reference index");
     // ast-grep-ignore: no-println
     eprintln!("  aperture docs <api> <tag> <operation> # Command help");
     std::process::exit(1);

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -33,6 +33,9 @@ pub fn list_commands(context: &str, output: &Output) -> Result<(), Error> {
     output.tip(format!(
         "Next: 'aperture docs {context} <tag> <operation>' for deep operation docs"
     ));
+    output.tip(format!(
+        "Execute: 'aperture api {context} <tag> <operation> ...'"
+    ));
     Ok(())
 }
 
@@ -168,6 +171,9 @@ fn render_single_api_overview(
         "Next: 'aperture search <term> --api {api}' to find specific operations"
     ));
     output.tip(format!(
+        "Next: 'aperture commands {api}' for a terse command tree"
+    ));
+    output.tip(format!(
         "Next: 'aperture docs {api} <tag> <operation>' for deep operation reference"
     ));
     output.tip(format!(
@@ -211,6 +217,7 @@ fn render_all_api_overviews(
     println!("\n{}", "=".repeat(60));
     output.tip("Use 'aperture overview <api>' to orient to a specific API");
     output.tip("Then use 'aperture search <term> --api <api>' to find operations by intent");
+    output.tip("Use 'aperture commands <api>' for a terse command tree");
     output.tip("Use 'aperture docs <api> <tag> <operation>' for deep operation reference");
     Ok(())
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -237,10 +237,13 @@ pub enum Commands {
     #[command(
         name = "commands",
         visible_alias = "list-commands",
-        long_about = "Display a tree-like summary of all available commands for an API.\n\n\
-                      Shows operations organized by tags, making it easy to discover\n\
-                      what functionality is available in a registered API specification.\n\
-                      This provides an overview without having to use --help on each operation.\n\n\
+        long_about = "Show a terse structural tree of commands for one API.\n\n\
+                      Canonical role: quick structure lookup (what exists, grouped by category).\n\
+                      This stays intentionally compact and is not full documentation.\n\n\
+                      Next steps:\n\
+                      - Use `aperture overview <api>` to orient to the API at a high level.\n\
+                      - Use `aperture search <term> --api <api>` when you know intent, not path.\n\
+                      - Use `aperture docs <api> <tag> <operation>` for deep operation reference.\n\n\
                       Legacy alias: list-commands\n\n\
                       Example:\n  \
                       aperture commands myapi"
@@ -270,15 +273,20 @@ pub enum Commands {
         args: Vec<String>,
     },
     /// Search for API operations across all specifications
-    #[command(long_about = "Search for API operations by keyword or pattern.\n\n\
-                      Search through all registered API specifications to find\n\
-                      relevant operations. The search includes operation IDs,\n\
-                      descriptions, paths, and HTTP methods.\n\n\
+    #[command(
+        long_about = "Search for operations by intent (keyword, phrase, or regex).\n\n\
+                      Canonical role: primary human discovery entry point when you know\n\
+                      what you want to do but not where the command lives. Supports\n\
+                      both cross-API discovery and per-API filtering.\n\n\
+                      Next steps:\n\
+                      - Use `aperture docs <api> <tag> <operation>` to inspect details.\n\
+                      - Use `aperture api <api> <tag> <operation> ...` to execute.\n\n\
                       Examples:\n  \
-                      aperture search 'list users'     # Find user listing operations\n  \
-                      aperture search 'POST create'     # Find POST operations with 'create'\n  \
-                      aperture search issues --api sm   # Search only in 'sm' API\n  \
-                      aperture search 'get.*by.*id'     # Regex pattern search")]
+                      aperture search 'list users'      # Cross-API intent search\n  \
+                      aperture search 'POST create'     # Method + intent\n  \
+                      aperture search issues --api sm   # Limit to one API\n  \
+                      aperture search 'get.*by.*id'     # Regex pattern search"
+    )]
     Search {
         /// Search query (keywords, patterns, or regex)
         query: String,
@@ -322,14 +330,17 @@ pub enum Commands {
     },
     /// Get detailed documentation for APIs and commands
     #[command(
-        long_about = "Get comprehensive documentation for APIs and operations.\n\n\
-                      This provides detailed information including parameters, examples,\n\
-                      response schemas, and authentication requirements. Use it to learn\n\
-                      about available functionality without trial and error.\n\n\
+        long_about = "Show deep reference documentation for APIs and operations.\n\n\
+                      Canonical role: inspect exact operation details (parameters, request\n\
+                      body, responses, auth, and examples) before execution.\n\n\
+                      Next steps:\n\
+                      - Start with `aperture overview <api>` for orientation.\n\
+                      - Use `aperture search <term>` to find operation paths quickly.\n\
+                      - Execute with `aperture api <api> <tag> <operation> ...`.\n\n\
                       Examples:\n  \
-                      aperture docs                        # Interactive help menu\n  \
-                      aperture docs myapi                  # API overview\n  \
-                      aperture docs myapi users get-user  # Detailed command help"
+                      aperture docs                        # Interactive discovery menu\n  \
+                      aperture docs myapi                  # API reference index\n  \
+                      aperture docs myapi users get-user  # Detailed operation reference"
     )]
     Docs {
         /// API name (optional, shows interactive menu if omitted).
@@ -345,9 +356,13 @@ pub enum Commands {
     },
     /// Show API overview with statistics and quick start guide
     #[command(
-        long_about = "Display comprehensive API overview with statistics and examples.\n\n\
-                      Shows operation counts, method distribution, available categories,\n\
-                      and sample commands to help you get started quickly with any API.\n\n\
+        long_about = "Orient yourself to an API before diving into details.\n\n\
+                      Canonical role: high-level orientation (shape, scale, categories,\n\
+                      and starter paths) for one API or all configured APIs.\n\n\
+                      Next steps:\n\
+                      - Use `aperture search <term> --api <api>` to find intent-matching operations.\n\
+                      - Use `aperture commands <api>` for a terse structural tree.\n\
+                      - Use `aperture docs <api> <tag> <operation>` for deep inspection.\n\n\
                       Examples:\n  \
                       aperture overview myapi\n  \
                       aperture overview --all  # Overview of all registered APIs"

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -355,6 +355,38 @@ impl DocumentationGenerator {
         Ok(overview)
     }
 
+    /// Generate an API reference index for docs navigation.
+    ///
+    /// # Errors
+    /// Returns an error if the API is not found
+    pub fn generate_api_reference_index(&self, api_name: &str) -> Result<String, Error> {
+        let spec = self
+            .specs
+            .get(api_name)
+            .ok_or_else(|| Error::spec_not_found(api_name))?;
+
+        let visible_commands: Vec<&CachedCommand> = spec
+            .commands
+            .iter()
+            .filter(|command| !command.hidden)
+            .collect();
+
+        let mut category_counts = BTreeMap::new();
+        for command in &visible_commands {
+            *category_counts
+                .entry(Self::effective_group(command))
+                .or_insert(0usize) += 1;
+        }
+
+        let mut reference = String::new();
+        Self::write_api_reference_header(&mut reference, spec);
+        Self::write_api_reference_navigation(&mut reference, api_name);
+        Self::write_api_reference_categories(&mut reference, &category_counts);
+        Self::write_api_reference_examples(&mut reference, api_name, &visible_commands);
+
+        Ok(reference)
+    }
+
     fn write_api_overview_header(overview: &mut String, spec: &CachedSpec) {
         write!(overview, "# {} API\n\n", spec.name).ok();
         writeln!(overview, "**Version**: {}", spec.version).ok();
@@ -432,6 +464,81 @@ impl DocumentationGenerator {
             )
             .ok();
         }
+    }
+
+    fn write_api_reference_header(reference: &mut String, spec: &CachedSpec) {
+        write!(reference, "# {} API Reference\n\n", spec.name).ok();
+        writeln!(reference, "**Version**: {}", spec.version).ok();
+        if let Some(base_url) = spec.base_url.as_deref() {
+            writeln!(reference, "**Base URL**: {base_url}").ok();
+        }
+        reference.push('\n');
+        reference.push_str(
+            "Use this view to inspect operation-level documentation before executing commands.\n\n",
+        );
+    }
+
+    fn write_api_reference_navigation(reference: &mut String, api_name: &str) {
+        reference.push_str("## Reference Workflow\n\n");
+        write!(
+            reference,
+            "1. Find operations by intent:\n```bash\naperture search \"keyword\" --api {api_name}\n```\n\n"
+        )
+        .ok();
+        write!(
+            reference,
+            "2. Inspect command structure:\n```bash\naperture commands {api_name}\n```\n\n"
+        )
+        .ok();
+        write!(
+            reference,
+            "3. Open deep operation docs:\n```bash\naperture docs {api_name} <tag> <operation>\n```\n\n"
+        )
+        .ok();
+    }
+
+    fn write_api_reference_categories(
+        reference: &mut String,
+        category_counts: &BTreeMap<String, usize>,
+    ) {
+        reference.push_str("## Categories\n\n");
+
+        if category_counts.is_empty() {
+            reference.push_str("No visible operations found.\n\n");
+            return;
+        }
+
+        for (category, count) in category_counts {
+            writeln!(reference, "- `{category}` ({count} operations)").ok();
+        }
+        reference.push('\n');
+    }
+
+    fn write_api_reference_examples(
+        reference: &mut String,
+        api_name: &str,
+        visible_commands: &[&CachedCommand],
+    ) {
+        if visible_commands.is_empty() {
+            return;
+        }
+
+        reference.push_str("## Example Docs Paths\n\n");
+        for command in visible_commands.iter().take(3) {
+            let tag = Self::effective_group(command);
+            let operation = Self::effective_operation(command);
+            let summary = command
+                .summary
+                .as_deref()
+                .or(command.description.as_deref())
+                .unwrap_or("No description");
+            writeln!(
+                reference,
+                "- `aperture docs {api_name} {tag} {operation}` — {summary}"
+            )
+            .ok();
+        }
+        reference.push('\n');
     }
 
     /// Generate interactive help menu

--- a/src/search.rs
+++ b/src/search.rs
@@ -380,6 +380,10 @@ pub fn format_search_results(results: &[CommandSearchResult], verbose: bool) -> 
 
     if results.is_empty() {
         lines.push("No matching operations found.".to_string());
+        lines.push(
+            "Try broader terms or run `aperture commands <api>` to browse by structure."
+                .to_string(),
+        );
         return lines;
     }
 
@@ -406,6 +410,15 @@ pub fn format_search_results(results: &[CommandSearchResult], verbose: bool) -> 
         if let Some(ref summary) = result.command.summary {
             lines.push(format!("   {summary}"));
         }
+
+        lines.push(format!(
+            "   Inspect: aperture docs {} {}",
+            result.api_context, result.command_path
+        ));
+        lines.push(format!(
+            "   Execute: aperture api {} {} ...",
+            result.api_context, result.command_path
+        ));
 
         if !verbose {
             lines.push(String::new());

--- a/tests/cli_naming_integration_tests.rs
+++ b/tests/cli_naming_integration_tests.rs
@@ -46,3 +46,38 @@ fn exec_legacy_alias_still_renders_help() {
             "aperture run getUserById --id 123",
         ));
 }
+
+#[test]
+fn discovery_commands_help_describes_canonical_roles() {
+    aperture_cmd()
+        .args(["commands", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Canonical role: quick structure lookup",
+        ));
+
+    aperture_cmd()
+        .args(["search", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Canonical role: primary human discovery entry point",
+        ));
+
+    aperture_cmd()
+        .args(["docs", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Canonical role: inspect exact operation details",
+        ));
+
+    aperture_cmd()
+        .args(["overview", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Canonical role: high-level orientation",
+        ));
+}

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -191,6 +191,26 @@ fn test_generate_api_overview() {
 }
 
 #[test]
+fn test_generate_api_reference_index() {
+    let mut specs = BTreeMap::new();
+    specs.insert("testapi".to_string(), create_test_spec());
+
+    let doc_gen = DocumentationGenerator::new(specs);
+    let reference = doc_gen.generate_api_reference_index("testapi").unwrap();
+
+    assert!(reference.contains("# TestAPI API Reference"));
+    assert!(reference.contains("## Reference Workflow"));
+    assert!(reference.contains("aperture search \"keyword\" --api testapi"));
+    assert!(reference.contains("aperture docs testapi <tag> <operation>"));
+    assert!(reference.contains("## Categories"));
+    assert!(reference.contains("`users` (2 operations)"));
+    assert!(reference.contains("## Example Docs Paths"));
+    assert!(reference.contains("aperture docs testapi users get-user-by-id"));
+    assert!(!reference.contains("## Statistics"));
+    assert!(!reference.contains("## Sample Operations"));
+}
+
+#[test]
 fn test_generate_interactive_menu() {
     let mut specs = BTreeMap::new();
     specs.insert("testapi".to_string(), create_test_spec());

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -264,6 +264,12 @@ fn test_format_search_results() {
         .iter()
         .any(|line| line.contains("aperture api test-api")));
     assert!(output.iter().any(|line| line.contains("GET /users/{id}")));
+    assert!(output
+        .iter()
+        .any(|line| line.contains("Inspect: aperture docs test-api users get-user")));
+    assert!(output
+        .iter()
+        .any(|line| line.contains("Execute: aperture api test-api users get-user ...")));
 
     // Test verbose output
     let output = format_search_results(&results, true);
@@ -275,8 +281,8 @@ fn test_empty_search_results() {
     let results = vec![];
     let output = format_search_results(&results, false);
 
-    assert_eq!(output.len(), 1);
     assert_eq!(output[0], "No matching operations found.");
+    assert!(output[1].contains("aperture commands <api>"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- define canonical roles for `overview`, `commands`, `search`, and `docs` in CLI help text
- split `aperture docs <api>` into a reference index instead of reusing overview output
- add explicit next-step guidance across discovery command output and search results
- update README and guide docs to teach an orient -> find -> inspect -> execute flow
- add tests for docs reference index, search guidance formatting, and discovery help text

Closes #134

## Validation
- `cargo test`
- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo test --features integration --test quiet_mode_tests`
