### PR TITLE
feat: add a landing view for 'aperture api <context>'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ aperture config api add petstore https://petstore3.swagger.io/api/v3/openapi.jso
 # Configure authentication
 aperture config secret set petstore api_key --env PETSTORE_API_KEY
 
-# Orient: understand the API surface
-aperture overview petstore
+# Land in context: get a concise API overview + next steps
+aperture api petstore
 
 # Find: search by intent
 aperture search "get pet by id" --api petstore
+
+# Orient: high-level overview command
+aperture overview petstore
 
 # Inspect: read deep operation docs
 aperture docs petstore pet get-pet-by-id
@@ -59,6 +62,7 @@ aperture api petstore --describe-json
 
 ### Discovery Commands (Canonical Roles)
 
+- `api <context>` → landing page for that API (overview + next actions)
 - `overview` → orient to an API at a high level
 - `search` → primary intent-first discovery (cross-API or scoped)
 - `commands` (`list-commands`) → terse structural tree

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -20,10 +20,13 @@ aperture config add my-api https://api.example.com/openapi.yaml
 # List registered APIs
 aperture config list
 
+# Land in an API context (overview + next actions)
+aperture api my-api
+
 # List commands for an API
 aperture commands my-api
 
-# Get detailed command information
+# Get detailed command information (machine-oriented)
 aperture api my-api --describe-json
 ```
 
@@ -288,10 +291,10 @@ aperture run users list
 
 Use this human workflow for discovery:
 
-1. **Orient** with `overview`
+1. **Land** with `api <context>`
 2. **Find** with `search`
 3. **Inspect** with `docs`
-4. **Execute** with `api`
+4. **Execute** with `api <context> <tag> <operation>`
 
 ### Overview
 

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -11,6 +11,7 @@ use crate::error::Error;
 use crate::fs::OsFileSystem;
 use crate::output::Output;
 use crate::shortcuts::{ResolutionResult, ShortcutResolver};
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 /// Adds connection/timeout context to network errors.
@@ -152,6 +153,45 @@ fn handle_show_examples_command(
         .find(|cmd| cmd.operation_id == operation_id)
         .ok_or_else(|| Error::spec_not_found(context))?;
     crate::cli::render::render_examples(operation);
+    Ok(())
+}
+
+fn render_api_context_landing(context: &str, spec: &CachedSpec) -> Result<(), Error> {
+    let mut specs = std::collections::BTreeMap::new();
+    specs.insert(context.to_string(), spec.clone());
+
+    let doc_gen = crate::docs::DocumentationGenerator::new(specs);
+    let mut overview = doc_gen.generate_api_overview(context)?;
+
+    overview.push_str("## Next Steps\n\n");
+    writeln!(
+        overview,
+        "- Discover by intent: `aperture search \"<keyword>\" --api {context}`"
+    )
+    .ok();
+    writeln!(
+        overview,
+        "- Inspect command paths: `aperture commands {context}`"
+    )
+    .ok();
+    writeln!(
+        overview,
+        "- Read operation docs: `aperture docs {context} <tag> <operation>`"
+    )
+    .ok();
+    writeln!(
+        overview,
+        "- Execute an operation: `aperture api {context} <tag> <operation> ...`"
+    )
+    .ok();
+    writeln!(
+        overview,
+        "- Machine manifest: `aperture api {context} --describe-json`"
+    )
+    .ok();
+
+    // ast-grep-ignore: no-println
+    println!("{overview}");
     Ok(())
 }
 
@@ -318,6 +358,10 @@ pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) ->
 
     if let Some(batch_file_path) = &cli.batch_file {
         return handle_batch_file_command(context, batch_file_path, &command_context, cli).await;
+    }
+
+    if args.is_empty() {
+        return render_api_context_landing(context, &command_context.spec);
     }
 
     let Some(matches) = parse_matches_with_examples_fallback(

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -195,6 +195,46 @@ fn render_api_context_landing(context: &str, spec: &CachedSpec) -> Result<(), Er
     Ok(())
 }
 
+const LANDING_INCOMPATIBLE_GLOBAL_FLAGS: &[&str] = &[
+    "--json-errors",
+    "--dry-run",
+    "--idempotency-key",
+    "--format",
+    "--jq",
+    "--batch-file",
+    "--batch-concurrency",
+    "--batch-rate-limit",
+    "--cache",
+    "--no-cache",
+    "--cache-ttl",
+    "--positional-args",
+    "--auto-paginate",
+    "--retry",
+    "--retry-delay",
+    "--retry-max-delay",
+    "--force-retry",
+];
+
+fn has_explicit_flag(argv: &[String], flag: &str) -> bool {
+    argv.iter()
+        .any(|arg| arg == flag || arg.starts_with(&format!("{flag}=")))
+}
+
+fn has_explicit_landing_incompatible_global_flags(argv: &[String]) -> bool {
+    LANDING_INCOMPATIBLE_GLOBAL_FLAGS
+        .iter()
+        .any(|flag| has_explicit_flag(argv, flag))
+}
+
+fn should_render_api_context_landing(args: &[String]) -> bool {
+    if !args.is_empty() {
+        return false;
+    }
+
+    let raw_argv: Vec<String> = std::env::args().collect();
+    !has_explicit_landing_incompatible_global_flags(&raw_argv)
+}
+
 async fn execute_api_runtime(
     spec: &CachedSpec,
     matches: &clap::ArgMatches,
@@ -360,7 +400,7 @@ pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) ->
         return handle_batch_file_command(context, batch_file_path, &command_context, cli).await;
     }
 
-    if args.is_empty() {
+    if should_render_api_context_landing(&args) {
         return render_api_context_landing(context, &command_context.spec);
     }
 
@@ -632,7 +672,10 @@ fn count_shortcut_args(args: &[String]) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_output_format;
+    use super::{
+        has_explicit_landing_incompatible_global_flags, resolve_output_format,
+        should_render_api_context_landing, LANDING_INCOMPATIBLE_GLOBAL_FLAGS,
+    };
     use crate::cli::OutputFormat;
     use clap::{Arg, Command};
 
@@ -661,5 +704,39 @@ mod tests {
         let resolved = resolve_output_format(&matches, &OutputFormat::Yaml);
 
         assert!(matches!(resolved, OutputFormat::Json));
+    }
+
+    #[test]
+    fn landing_incompatible_global_flags_are_detected() {
+        for flag in LANDING_INCOMPATIBLE_GLOBAL_FLAGS {
+            let argv = vec![
+                "aperture".to_string(),
+                "api".to_string(),
+                "test-api".to_string(),
+                (*flag).to_string(),
+            ];
+
+            assert!(
+                has_explicit_landing_incompatible_global_flags(&argv),
+                "expected {flag} to block landing output"
+            );
+        }
+    }
+
+    #[test]
+    fn landing_incompatible_global_flags_support_equals_syntax() {
+        let argv = vec![
+            "aperture".to_string(),
+            "--format=yaml".to_string(),
+            "api".to_string(),
+            "test-api".to_string(),
+        ];
+
+        assert!(has_explicit_landing_incompatible_global_flags(&argv));
+    }
+
+    #[test]
+    fn landing_only_renders_without_operation_args() {
+        assert!(!should_render_api_context_landing(&["users".to_string()]));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -259,10 +259,13 @@ pub enum Commands {
                       The context refers to the name you gave when adding the spec.\n\
                       Commands are dynamically generated based on the OpenAPI specification,\n\
                       organized by tags (e.g., 'users', 'posts', 'orders').\n\n\
+                      Running only `aperture api <context>` shows a human-oriented landing\n\
+                      overview with discovery and execution next steps.\n\n\
                       Examples:\n  \
+                      aperture api myapi                    # Landing overview\n  \
                       aperture api myapi users get-user --id 123\n  \
                       aperture api myapi posts create-post --body '{\"title\":\"Hello\"}'\n  \
-                      aperture api myapi --help  # See available operations"
+                      aperture api myapi --help             # See available operations"
     )]
     Api {
         /// Name of the API specification context.

--- a/tests/api_context_landing_integration_tests.rs
+++ b/tests/api_context_landing_integration_tests.rs
@@ -94,3 +94,90 @@ fn api_context_describe_json_remains_machine_oriented() {
     assert_eq!(manifest["api"]["name"].as_str(), Some("Landing Test API"));
     assert!(manifest["commands"]["users"].is_array());
 }
+
+#[test]
+fn api_context_with_json_errors_and_no_operation_preserves_error_semantics() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let spec_file = create_spec(&temp_dir);
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "--quiet",
+            "config",
+            "api",
+            "add",
+            "test-api",
+            spec_file.to_str().expect("spec path should be valid UTF-8"),
+        ])
+        .assert()
+        .success();
+
+    let output = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["--json-errors", "api", "test-api"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    let error_json: serde_json::Value =
+        serde_json::from_str(&stderr).expect("json-errors output should be valid JSON");
+    assert_eq!(error_json["error_type"].as_str(), Some("Validation"));
+    assert_eq!(error_json["details"]["operation"].as_str(), Some("unknown"));
+}
+
+#[test]
+fn api_context_with_dry_run_and_no_operation_preserves_error_semantics() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let spec_file = create_spec(&temp_dir);
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "--quiet",
+            "config",
+            "api",
+            "add",
+            "test-api",
+            spec_file.to_str().expect("spec path should be valid UTF-8"),
+        ])
+        .assert()
+        .success();
+
+    let output = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["api", "test-api", "--dry-run"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("Operation 'unknown' not found"));
+}
+
+#[test]
+fn api_context_with_explicit_format_and_no_operation_preserves_error_semantics() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let spec_file = create_spec(&temp_dir);
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "--quiet",
+            "config",
+            "api",
+            "add",
+            "test-api",
+            spec_file.to_str().expect("spec path should be valid UTF-8"),
+        ])
+        .assert()
+        .success();
+
+    let output = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["api", "test-api", "--format", "yaml"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("Operation 'unknown' not found"));
+}

--- a/tests/api_context_landing_integration_tests.rs
+++ b/tests/api_context_landing_integration_tests.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "integration")]
+
+mod common;
+
+use common::aperture_cmd;
+use std::fs;
+use tempfile::TempDir;
+
+fn create_spec(temp_dir: &TempDir) -> std::path::PathBuf {
+    let spec_content = r#"
+openapi: "3.0.0"
+info:
+  title: "Landing Test API"
+  version: "1.0.0"
+paths:
+  /users:
+    get:
+      operationId: listUsers
+      summary: List users
+      tags:
+        - users
+      responses:
+        "200":
+          description: Success
+"#;
+
+    let spec_file = temp_dir.path().join("spec.yaml");
+    fs::write(&spec_file, spec_content).expect("spec file should be written");
+    spec_file
+}
+
+#[test]
+fn api_context_without_operation_shows_landing_overview() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let spec_file = create_spec(&temp_dir);
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "--quiet",
+            "config",
+            "api",
+            "add",
+            "test-api",
+            spec_file.to_str().expect("spec path should be valid UTF-8"),
+        ])
+        .assert()
+        .success();
+
+    let output = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["api", "test-api"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    assert!(stdout.contains("# test-api API"));
+    assert!(stdout.contains("## Statistics"));
+    assert!(stdout.contains("## Next Steps"));
+    assert!(stdout.contains("aperture commands test-api"));
+    assert!(stdout.contains("aperture docs test-api <tag> <operation>"));
+    assert!(stdout.contains("aperture api test-api <tag> <operation> ..."));
+}
+
+#[test]
+fn api_context_describe_json_remains_machine_oriented() {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let spec_file = create_spec(&temp_dir);
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "--quiet",
+            "config",
+            "api",
+            "add",
+            "test-api",
+            spec_file.to_str().expect("spec path should be valid UTF-8"),
+        ])
+        .assert()
+        .success();
+
+    let output = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["api", "test-api", "--describe-json"])
+        .output()
+        .expect("describe-json command should execute");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&stdout).expect("describe-json output should be valid JSON");
+    assert_eq!(manifest["api"]["name"].as_str(), Some("Landing Test API"));
+    assert!(manifest["commands"]["users"].is_array());
+}


### PR DESCRIPTION
## Summary
- make `aperture api <context>` render a human-oriented landing view when no operation is provided
- preserve machine flow semantics by keeping `--describe-json` behavior unchanged
- document the landing behavior in CLI help and user docs
- add integration coverage for landing output and `--describe-json` preservation

Closes #141

## Testing
- `cargo test --features integration --test api_context_landing_integration_tests`
- `cargo test --features integration --test integration_tests test_describe_json_flag`
- `cargo test` (via pre-commit hook)
