### PR TITLE
ux: guide next steps after config add

### DIFF
--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -29,8 +29,32 @@ async fn handle_add_spec_command(
         .add_spec_auto(&name, &file_or_url, force, strict)
         .await?;
     output.success(format!("Spec '{name}' added successfully."));
+    print_partial_add_acceptance_summary(manager, &name, output);
     print_config_add_next_steps(&name, output);
     Ok(())
+}
+
+fn print_partial_add_acceptance_summary(
+    manager: &ConfigManager<OsFileSystem>,
+    name: &ApiContextName,
+    output: &Output,
+) {
+    let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
+    let Ok(cached_spec) = crate::engine::loader::load_cached_spec(&cache_dir, name.as_str()) else {
+        return;
+    };
+
+    let skipped = cached_spec.skipped_endpoints.len();
+    if skipped == 0 {
+        return;
+    }
+
+    let available = cached_spec.commands.len();
+    let total = available + skipped;
+    output.info(format!(
+        "Partial spec acceptance: {available} of {total} endpoints available ({skipped} skipped)."
+    ));
+    output.tip("Review skipped endpoints with 'aperture config list --verbose'.");
 }
 
 fn print_config_add_next_steps(name: &ApiContextName, output: &Output) {

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -29,7 +29,18 @@ async fn handle_add_spec_command(
         .add_spec_auto(&name, &file_or_url, force, strict)
         .await?;
     output.success(format!("Spec '{name}' added successfully."));
+    print_config_add_next_steps(&name, output);
     Ok(())
+}
+
+fn print_config_add_next_steps(name: &ApiContextName, output: &Output) {
+    let context = name.as_str();
+    output.info("Next steps:");
+    output.tip(format!("  1. aperture overview {context}"));
+    output.tip(format!("  2. aperture search <term> --api {context}"));
+    output.tip(format!("  3. aperture list-commands {context}"));
+    output.tip(format!("  4. aperture docs {context} <tag> <operation>"));
+    output.tip(format!("  5. aperture api {context} --describe-json"));
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -43,11 +43,50 @@ fn test_config_add_new_spec() {
         .env("APERTURE_CONFIG_DIR", &config_dir)
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "Spec 'my-api' added successfully.",
-        ));
+        .stdout(
+            predicate::str::contains("Spec 'my-api' added successfully.")
+                .and(predicate::str::contains("Next steps:"))
+                .and(predicate::str::contains("aperture overview my-api"))
+                .and(predicate::str::contains(
+                    "aperture search <term> --api my-api",
+                ))
+                .and(predicate::str::contains("aperture list-commands my-api"))
+                .and(predicate::str::contains(
+                    "aperture docs my-api <tag> <operation>",
+                ))
+                .and(predicate::str::contains(
+                    "aperture api my-api --describe-json",
+                )),
+        );
 
     assert!(config_dir.join("specs").join("my-api.yaml").exists());
+}
+
+#[test]
+fn test_config_add_partial_spec_reports_skipped_endpoint_summary() {
+    let config_dir =
+        setup_temp_config_dir("test_config_add_partial_spec_reports_skipped_endpoint_summary");
+    let spec_file = PathBuf::from("tests/fixtures/openapi/spec-with-multipart.yaml")
+        .canonicalize()
+        .unwrap();
+
+    get_bin()
+        .arg("config")
+        .arg("add")
+        .arg("partial-api")
+        .arg(&spec_file)
+        .env("APERTURE_CONFIG_DIR", &config_dir)
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("Spec 'partial-api' added successfully.")
+                .and(predicate::str::contains(
+                    "Partial spec acceptance: 3 of 5 endpoints available (2 skipped).",
+                ))
+                .and(predicate::str::contains(
+                    "Review skipped endpoints with 'aperture config list --verbose'.",
+                )),
+        );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add post-`config add` onboarding guidance with discovery-first next commands (`overview`, `search`, `list-commands`, `docs`, and `api --describe-json`)
- add concise partial-acceptance summary when endpoints are skipped, including an actionable follow-up command
- extend integration coverage for normal and partial `config add` success paths

Closes #140
