### PR TITLE
Scope execution flags to commands that honor them

### DIFF
--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -206,10 +206,10 @@ The `--auto-paginate` flag loops through all pages of a paginated API endpoint a
 
 ```bash
 # Stream all users as NDJSON
-aperture --auto-paginate api myapi users list-users
+aperture api myapi --auto-paginate users list-users
 
 # Pipe to jq for processing
-aperture --auto-paginate api myapi issues list-issues | jq '.title'
+aperture api myapi --auto-paginate issues list-issues | jq '.title'
 ```
 
 **Strategy detection** is automatic — Aperture inspects the OpenAPI spec at cache time and selects the appropriate strategy:
@@ -241,7 +241,7 @@ aperture api myapi --describe-json | jq '.commands[][] | select(.pagination.supp
 
 **Mid-stream error handling:** when `--json-errors` is active and an error occurs after partial output has been emitted, a structured JSON error object is written as the final NDJSON line on stdout. Consumers can detect failure by checking the last line for an `error_type` key.
 
-**Flag interactions:** `--jq` and `--format` are ignored when `--auto-paginate` is active (a warning is emitted for `--jq`). Output is always NDJSON — apply jq externally via pipe: `aperture --auto-paginate api myapi users list | jq '.name'`.
+**Flag interactions:** `--jq` and `--format` are ignored when `--auto-paginate` is active (a warning is emitted for `--jq`). Output is always NDJSON — apply jq externally via pipe: `aperture api myapi --auto-paginate users list | jq '.name'`.
 
 **Batch interaction:** `--auto-paginate` is not applied inside batch operations. Each batch operation executes as a single request. To paginate within a batch workflow, use `capture` / `capture_append` with explicit cursor forwarding across dependent operations.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -86,6 +86,21 @@ echo '{"name": "John"}' | aperture api my-api users create --body-file -
 aperture api my-api orders search --status pending --created-after 2024-01-01
 ```
 
+### Flag Scoping Model
+
+Execution-oriented flags are scoped to execution commands (`api`, `run`) instead of being global.
+
+```bash
+# ✅ Scoped execution flags on execution commands
+aperture api my-api --dry-run users get-user-by-id --id 123
+aperture run --dry-run getUserById --id 123
+
+# ❌ Rejected on non-execution commands
+aperture docs --dry-run
+```
+
+Universal flags remain available everywhere: `--json-errors`, `--quiet`, and `-v`.
+
 ### Legacy Positional Syntax
 
 For backwards compatibility, positional arguments are available:

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -2,7 +2,7 @@
 
 use crate::batch::{BatchConfig, BatchProcessor};
 use crate::cache::models::CachedSpec;
-use crate::cli::Cli;
+use crate::cli::{Cli, ExecutionFlags};
 use crate::config::manager::{get_config_dir, ConfigManager};
 use crate::config::models::GlobalConfig;
 use crate::constants;
@@ -37,6 +37,15 @@ fn emit_pagination_error_ndjson(cli: &Cli, writer: &mut impl std::io::Write, err
         return;
     };
     let _ = writeln!(writer, "{json}");
+}
+
+fn require_execution_flags(cli: &Cli) -> Result<&ExecutionFlags, Error> {
+    cli.execution_flags().ok_or_else(|| {
+        Error::invalid_command(
+            "cli",
+            "execution flags are only available for the 'api' and 'run' commands",
+        )
+    })
 }
 
 /// Resolves the output format from dynamic matches vs CLI global flag.
@@ -97,7 +106,7 @@ fn load_api_command_context(context: &str) -> Result<ApiCommandContext, Error> {
 fn handle_describe_json_command(
     context: &str,
     command_context: &ApiCommandContext,
-    cli: &Cli,
+    execution: &ExecutionFlags,
 ) -> Result<(), Error> {
     let specs_dir = command_context.config_dir.join(constants::DIR_SPECS);
     let spec_path = specs_dir.join(format!("{context}.yaml"));
@@ -114,7 +123,7 @@ fn handle_describe_json_command(
         &command_context.spec,
         command_context.global_config.as_ref(),
     )?;
-    let output = match &cli.jq {
+    let output = match &execution.jq {
         Some(jq_filter) => executor::apply_jq_filter(&manifest, jq_filter)?,
         None => manifest,
     };
@@ -128,6 +137,7 @@ async fn handle_batch_file_command(
     batch_file_path: &str,
     command_context: &ApiCommandContext,
     cli: &Cli,
+    execution: &ExecutionFlags,
 ) -> Result<(), Error> {
     execute_batch_operations(
         context,
@@ -135,6 +145,7 @@ async fn handle_batch_file_command(
         &command_context.spec,
         command_context.global_config.as_ref(),
         cli,
+        execution,
     )
     .await
 }
@@ -239,15 +250,16 @@ async fn execute_api_runtime(
     spec: &CachedSpec,
     matches: &clap::ArgMatches,
     cli: &Cli,
+    execution: &ExecutionFlags,
     global_config: Option<GlobalConfig>,
 ) -> Result<(), Error> {
     let jq_filter = matches
         .get_one::<String>("jq")
         .map(String::as_str)
-        .or(cli.jq.as_deref());
-    let output_format = resolve_output_format(matches, &cli.format);
+        .or(execution.jq.as_deref());
+    let output_format = resolve_output_format(matches, &execution.format);
     let call = crate::cli::translate::matches_to_operation_call(spec, matches)?;
-    let mut ctx = crate::cli::translate::cli_to_execution_context(cli, global_config)?;
+    let mut ctx = crate::cli::translate::cli_to_execution_context(execution, global_config)?;
     ctx.server_var_args = crate::cli::translate::extract_server_var_args(matches);
 
     if ctx.auto_paginate {
@@ -391,13 +403,21 @@ fn handle_parse_error_with_examples_fallback(
 
 pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) -> Result<(), Error> {
     let command_context = load_api_command_context(context)?;
+    let execution = require_execution_flags(cli)?;
 
-    if cli.describe_json {
-        return handle_describe_json_command(context, &command_context, cli);
+    if execution.describe_json {
+        return handle_describe_json_command(context, &command_context, execution);
     }
 
-    if let Some(batch_file_path) = &cli.batch_file {
-        return handle_batch_file_command(context, batch_file_path, &command_context, cli).await;
+    if let Some(batch_file_path) = &execution.batch_file {
+        return handle_batch_file_command(
+            context,
+            batch_file_path,
+            &command_context,
+            cli,
+            execution,
+        )
+        .await;
     }
 
     if should_render_api_context_landing(&args) {
@@ -408,7 +428,7 @@ pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) ->
         context,
         &command_context.spec,
         &args,
-        cli.positional_args,
+        execution.positional_args,
     )?
     else {
         return Ok(());
@@ -423,6 +443,7 @@ pub async fn execute_api_command(context: &str, args: Vec<String>, cli: &Cli) ->
         &command_context.spec,
         &matches,
         cli,
+        execution,
         command_context.global_config.clone(),
     )
     .await
@@ -436,12 +457,13 @@ pub async fn execute_batch_operations(
     spec: &CachedSpec,
     global_config: Option<&GlobalConfig>,
     cli: &Cli,
+    execution: &ExecutionFlags,
 ) -> Result<(), Error> {
     let batch_file =
         BatchProcessor::parse_batch_file(std::path::Path::new(batch_file_path)).await?;
     let batch_config = BatchConfig {
-        max_concurrency: cli.batch_concurrency,
-        rate_limit: cli.batch_rate_limit,
+        max_concurrency: execution.batch_concurrency,
+        rate_limit: execution.batch_rate_limit,
         continue_on_error: true,
         show_progress: !cli.quiet && !cli.json_errors,
         suppress_output: cli.json_errors,
@@ -453,15 +475,15 @@ pub async fn execute_batch_operations(
             batch_file,
             global_config,
             None,
-            cli.dry_run,
-            &cli.format,
+            execution.dry_run,
+            &execution.format,
             None,
         )
         .await?;
 
     let output = Output::new(cli.quiet, cli.json_errors);
     if cli.json_errors {
-        render_batch_json_summary(&result, cli)?;
+        render_batch_json_summary(&result, execution)?;
         return Ok(());
     }
 
@@ -469,7 +491,10 @@ pub async fn execute_batch_operations(
     Ok(())
 }
 
-fn render_batch_json_summary(result: &crate::batch::BatchResult, cli: &Cli) -> Result<(), Error> {
+fn render_batch_json_summary(
+    result: &crate::batch::BatchResult,
+    execution: &ExecutionFlags,
+) -> Result<(), Error> {
     let summary = serde_json::json!({
         "batch_execution_summary": {
             "total_operations": result.results.len(),
@@ -485,7 +510,7 @@ fn render_batch_json_summary(result: &crate::batch::BatchResult, cli: &Cli) -> R
             })).collect::<Vec<_>>()
         }
     });
-    let json_output = match &cli.jq {
+    let json_output = match &execution.jq {
         Some(jq_filter) => {
             let summary_json = serde_json::to_string(&summary)
                 .expect("JSON serialization of valid structure cannot fail");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,7 +5,7 @@ pub mod render;
 pub mod tracing_init;
 pub mod translate;
 
-use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 #[derive(ValueEnum, Clone, Debug)]
 pub enum OutputFormat {
@@ -17,8 +17,137 @@ pub enum OutputFormat {
     Table,
 }
 
-#[derive(Parser, Debug)]
+/// Flags that are only meaningful for execution-oriented commands (`api`, `run`).
+#[derive(Args, Debug, Clone)]
 #[allow(clippy::struct_excessive_bools)]
+pub struct ExecutionFlags {
+    /// Output a JSON manifest of all available commands and parameters
+    #[arg(
+        long,
+        help = "Output capability manifest as JSON (can be filtered with --jq)"
+    )]
+    pub describe_json: bool,
+
+    /// Show the HTTP request that would be made without executing it
+    #[arg(long, help = "Show request details without executing")]
+    pub dry_run: bool,
+
+    /// Set the Idempotency-Key header for safe retries
+    #[arg(long, value_name = "KEY", help = "Set idempotency key header")]
+    pub idempotency_key: Option<String>,
+
+    /// Output format for response data
+    #[arg(
+        long,
+        value_enum,
+        default_value = "json",
+        help = "Output format for response data"
+    )]
+    pub format: OutputFormat,
+
+    /// Apply JQ filter to response data, describe-json output, or batch results (with --json-errors)
+    #[arg(
+        long,
+        value_name = "FILTER",
+        help = "Apply JQ filter to JSON output (e.g., '.name', '.[] | select(.active)', '.batch_execution_summary.operations[] | select(.success == false)')"
+    )]
+    pub jq: Option<String>,
+
+    /// Execute operations from a batch file
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Path to batch file (JSON or YAML) containing multiple operations"
+    )]
+    pub batch_file: Option<String>,
+
+    /// Maximum concurrent requests for batch operations
+    #[arg(
+        long,
+        value_name = "N",
+        default_value = "5",
+        help = "Maximum number of concurrent requests for batch operations"
+    )]
+    pub batch_concurrency: usize,
+
+    /// Rate limit for batch operations (requests per second)
+    #[arg(
+        long,
+        value_name = "N",
+        help = "Rate limit for batch operations (requests per second)"
+    )]
+    pub batch_rate_limit: Option<u32>,
+
+    /// Enable response caching
+    #[arg(
+        long,
+        help = "Enable response caching (can speed up repeated requests)"
+    )]
+    pub cache: bool,
+
+    /// Disable response caching
+    #[arg(long, conflicts_with = "cache", help = "Disable response caching")]
+    pub no_cache: bool,
+
+    /// TTL for cached responses in seconds
+    #[arg(
+        long,
+        value_name = "SECONDS",
+        help = "Cache TTL in seconds (default: 300)"
+    )]
+    pub cache_ttl: Option<u64>,
+
+    /// Use positional arguments for path parameters (legacy syntax)
+    #[arg(
+        long,
+        help = "Use positional arguments for path parameters (legacy syntax)"
+    )]
+    pub positional_args: bool,
+
+    /// Automatically paginate through all pages, streaming results as NDJSON
+    ///
+    /// Detects the pagination strategy from the `OpenAPI` spec (cursor, offset,
+    /// or Link header) and loops until the last page, printing each page's
+    /// array items as newline-delimited JSON objects.
+    #[arg(
+        long,
+        help = "Stream all pages as NDJSON (auto-detects pagination strategy)"
+    )]
+    pub auto_paginate: bool,
+
+    /// Maximum number of retry attempts for failed requests
+    #[arg(
+        long,
+        value_name = "N",
+        help = "Maximum retry attempts (0 = disabled, overrides config)"
+    )]
+    pub retry: Option<u32>,
+
+    /// Initial delay between retries (e.g., "500ms", "1s")
+    #[arg(
+        long,
+        value_name = "DURATION",
+        help = "Initial retry delay (e.g., '500ms', '1s', '2s')"
+    )]
+    pub retry_delay: Option<String>,
+
+    /// Maximum delay cap between retries (e.g., "30s", "1m")
+    #[arg(
+        long,
+        value_name = "DURATION",
+        help = "Maximum retry delay cap (e.g., '30s', '1m')"
+    )]
+    pub retry_max_delay: Option<String>,
+
+    /// Force retry on non-idempotent requests without an idempotency key
+    #[arg(
+        long,
+        help = "Allow retrying non-idempotent requests without idempotency key"
+    )]
+    pub force_retry: bool,
+}
+
+#[derive(Parser, Debug)]
 #[command(
     author,
     version,
@@ -37,14 +166,6 @@ pub enum OutputFormat {
                   aperture api myapi --dry-run ...      # Show request without executing"
 )]
 pub struct Cli {
-    /// Output a JSON manifest of all available commands and parameters
-    #[arg(
-        long,
-        global = true,
-        help = "Output capability manifest as JSON (can be filtered with --jq)"
-    )]
-    pub describe_json: bool,
-
     /// Output all errors as structured JSON to stderr
     /// When used with batch operations, outputs a clean JSON summary at the end
     #[arg(long, global = true, help = "Output errors in JSON format")]
@@ -69,149 +190,18 @@ pub struct Cli {
     )]
     pub verbosity: u8,
 
-    /// Show the HTTP request that would be made without executing it
-    #[arg(long, global = true, help = "Show request details without executing")]
-    pub dry_run: bool,
-
-    /// Set the Idempotency-Key header for safe retries
-    #[arg(
-        long,
-        global = true,
-        value_name = "KEY",
-        help = "Set idempotency key header"
-    )]
-    pub idempotency_key: Option<String>,
-
-    /// Output format for response data
-    #[arg(
-        long,
-        global = true,
-        value_enum,
-        default_value = "json",
-        help = "Output format for response data"
-    )]
-    pub format: OutputFormat,
-
-    /// Apply JQ filter to response data, describe-json output, or batch results (with --json-errors)
-    #[arg(
-        long,
-        global = true,
-        value_name = "FILTER",
-        help = "Apply JQ filter to JSON output (e.g., '.name', '.[] | select(.active)', '.batch_execution_summary.operations[] | select(.success == false)')"
-    )]
-    pub jq: Option<String>,
-
-    /// Execute operations from a batch file
-    #[arg(
-        long,
-        global = true,
-        value_name = "PATH",
-        help = "Path to batch file (JSON or YAML) containing multiple operations"
-    )]
-    pub batch_file: Option<String>,
-
-    /// Maximum concurrent requests for batch operations
-    #[arg(
-        long,
-        global = true,
-        value_name = "N",
-        default_value = "5",
-        help = "Maximum number of concurrent requests for batch operations"
-    )]
-    pub batch_concurrency: usize,
-
-    /// Rate limit for batch operations (requests per second)
-    #[arg(
-        long,
-        global = true,
-        value_name = "N",
-        help = "Rate limit for batch operations (requests per second)"
-    )]
-    pub batch_rate_limit: Option<u32>,
-
-    /// Enable response caching
-    #[arg(
-        long,
-        global = true,
-        help = "Enable response caching (can speed up repeated requests)"
-    )]
-    pub cache: bool,
-
-    /// Disable response caching
-    #[arg(
-        long,
-        global = true,
-        conflicts_with = "cache",
-        help = "Disable response caching"
-    )]
-    pub no_cache: bool,
-
-    /// TTL for cached responses in seconds
-    #[arg(
-        long,
-        global = true,
-        value_name = "SECONDS",
-        help = "Cache TTL in seconds (default: 300)"
-    )]
-    pub cache_ttl: Option<u64>,
-
-    /// Use positional arguments for path parameters (legacy syntax)
-    #[arg(
-        long,
-        global = true,
-        help = "Use positional arguments for path parameters (legacy syntax)"
-    )]
-    pub positional_args: bool,
-
-    /// Automatically paginate through all pages, streaming results as NDJSON
-    ///
-    /// Detects the pagination strategy from the `OpenAPI` spec (cursor, offset,
-    /// or Link header) and loops until the last page, printing each page's
-    /// array items as newline-delimited JSON objects.
-    #[arg(
-        long,
-        global = true,
-        help = "Stream all pages as NDJSON (auto-detects pagination strategy)"
-    )]
-    pub auto_paginate: bool,
-
-    /// Maximum number of retry attempts for failed requests
-    #[arg(
-        long,
-        global = true,
-        value_name = "N",
-        help = "Maximum retry attempts (0 = disabled, overrides config)"
-    )]
-    pub retry: Option<u32>,
-
-    /// Initial delay between retries (e.g., "500ms", "1s")
-    #[arg(
-        long,
-        global = true,
-        value_name = "DURATION",
-        help = "Initial retry delay (e.g., '500ms', '1s', '2s')"
-    )]
-    pub retry_delay: Option<String>,
-
-    /// Maximum delay cap between retries (e.g., "30s", "1m")
-    #[arg(
-        long,
-        global = true,
-        value_name = "DURATION",
-        help = "Maximum retry delay cap (e.g., '30s', '1m')"
-    )]
-    pub retry_max_delay: Option<String>,
-
-    /// Force retry on non-idempotent requests without an idempotency key
-    #[arg(
-        long,
-        global = true,
-        help = "Allow retrying non-idempotent requests without idempotency key"
-    )]
-    pub force_retry: bool,
-
     #[command(subcommand)]
     pub command: Commands,
+}
+
+impl Cli {
+    #[must_use]
+    pub const fn execution_flags(&self) -> Option<&ExecutionFlags> {
+        match &self.command {
+            Commands::Api { execution, .. } | Commands::Exec { execution, .. } => Some(execution),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -271,6 +261,9 @@ pub enum Commands {
         /// Name of the API specification context.
         /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
         context: String,
+        /// Flags honored by execution-oriented workflows for this command.
+        #[command(flatten)]
+        execution: ExecutionFlags,
         /// Remaining arguments will be parsed dynamically based on the `OpenAPI` spec
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -327,6 +320,9 @@ pub enum Commands {
             help = "Resolve shortcuts only within specified API"
         )]
         api: Option<String>,
+        /// Flags honored by execution-oriented workflows for this command.
+        #[command(flatten)]
+        execution: ExecutionFlags,
         /// Shortcut command arguments
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
@@ -1018,7 +1014,7 @@ mod tests {
         let cli =
             Cli::try_parse_from(["aperture", "run", "get-user-by-id", "--id", "123"]).unwrap();
         match cli.command {
-            Commands::Exec { api, args } => {
+            Commands::Exec { api, args, .. } => {
                 assert!(api.is_none());
                 assert_eq!(args, vec!["get-user-by-id", "--id", "123"]);
             }
@@ -1031,7 +1027,7 @@ mod tests {
         let cli =
             Cli::try_parse_from(["aperture", "exec", "get-user-by-id", "--id", "123"]).unwrap();
         match cli.command {
-            Commands::Exec { api, args } => {
+            Commands::Exec { api, args, .. } => {
                 assert!(api.is_none());
                 assert_eq!(args, vec!["get-user-by-id", "--id", "123"]);
             }
@@ -1110,6 +1106,35 @@ mod tests {
 
         assert!(!help.contains("set-url"));
         assert!(!help.contains("list-urls"));
+        assert!(!help.contains("--dry-run"));
+        assert!(!help.contains("--batch-file"));
+        assert!(!help.contains("--retry"));
+    }
+
+    #[test]
+    fn api_help_includes_execution_flags() {
+        let mut command = Cli::command();
+        let api_command = command
+            .find_subcommand_mut("api")
+            .expect("api command should exist");
+
+        let mut help = Vec::new();
+        api_command
+            .write_long_help(&mut help)
+            .expect("api help should render");
+        let help = String::from_utf8(help).expect("help should be valid UTF-8");
+
+        assert!(help.contains("--dry-run"));
+        assert!(help.contains("--batch-file"));
+        assert!(help.contains("--retry"));
+    }
+
+    #[test]
+    fn docs_rejects_execution_only_flag() {
+        let err = Cli::try_parse_from(["aperture", "docs", "--dry-run"]).unwrap_err();
+        let err = err.to_string();
+
+        assert!(err.contains("unexpected argument '--dry-run'"));
     }
 
     #[test]

--- a/src/cli/translate.rs
+++ b/src/cli/translate.rs
@@ -5,7 +5,7 @@
 //! by the execution engine.
 
 use crate::cache::models::{CachedCommand, CachedParameter, CachedSpec};
-use crate::cli::Cli;
+use crate::cli::ExecutionFlags;
 use crate::config::models::GlobalConfig;
 use crate::constants;
 use crate::duration::parse_duration;
@@ -309,7 +309,7 @@ pub fn has_show_examples_flag(matches: &ArgMatches) -> bool {
 /// Returns an error if duration parsing fails for retry delay values.
 #[allow(clippy::cast_possible_truncation)]
 pub fn cli_to_execution_context(
-    cli: &Cli,
+    execution: &ExecutionFlags,
     global_config: Option<GlobalConfig>,
 ) -> Result<ExecutionContext, Error> {
     let config_dir = if let Ok(dir) = std::env::var(crate::constants::ENV_APERTURE_CONFIG_DIR) {
@@ -319,32 +319,32 @@ pub fn cli_to_execution_context(
     };
 
     // Build cache config from CLI flags
-    let cache_config = if cli.no_cache {
+    let cache_config = if execution.no_cache {
         None
     } else {
         Some(CacheConfig {
             cache_dir: config_dir
                 .join(crate::constants::DIR_CACHE)
                 .join(crate::constants::DIR_RESPONSES),
-            default_ttl: Duration::from_secs(cli.cache_ttl.unwrap_or(300)),
+            default_ttl: Duration::from_secs(execution.cache_ttl.unwrap_or(300)),
             max_entries: 1000,
-            enabled: cli.cache || cli.cache_ttl.is_some(),
+            enabled: execution.cache || execution.cache_ttl.is_some(),
             allow_authenticated: false,
         })
     };
 
     // Build retry context
-    let retry_context = build_retry_context(cli, global_config.as_ref())?;
+    let retry_context = build_retry_context(execution, global_config.as_ref())?;
 
     Ok(ExecutionContext {
-        dry_run: cli.dry_run,
-        idempotency_key: cli.idempotency_key.clone(),
+        dry_run: execution.dry_run,
+        idempotency_key: execution.idempotency_key.clone(),
         cache_config,
         retry_context,
         base_url: None, // Resolved by BaseUrlResolver
         global_config,
         server_var_args: Vec::new(), // Populated from dynamic matches in the caller
-        auto_paginate: cli.auto_paginate,
+        auto_paginate: execution.auto_paginate,
     })
 }
 
@@ -353,22 +353,22 @@ pub fn cli_to_execution_context(
 /// CLI flags take precedence over global config defaults.
 #[allow(clippy::cast_possible_truncation)]
 fn build_retry_context(
-    cli: &Cli,
+    execution: &ExecutionFlags,
     global_config: Option<&GlobalConfig>,
 ) -> Result<Option<RetryContext>, Error> {
     let defaults = global_config.map(|c| &c.retry_defaults);
-    let max_attempts = resolve_retry_attempts(cli.retry, defaults.map(|d| d.max_attempts));
+    let max_attempts = resolve_retry_attempts(execution.retry, defaults.map(|d| d.max_attempts));
 
     if max_attempts == 0 {
         return Ok(None);
     }
 
     let initial_delay_ms = resolve_retry_delay_ms(
-        cli.retry_delay.as_deref(),
+        execution.retry_delay.as_deref(),
         defaults.map_or(500, |d| d.initial_delay_ms),
     )?;
     let max_delay_ms = resolve_retry_delay_ms(
-        cli.retry_max_delay.as_deref(),
+        execution.retry_max_delay.as_deref(),
         defaults.map_or(30_000, |d| d.max_delay_ms),
     )?;
 
@@ -376,9 +376,9 @@ fn build_retry_context(
         max_attempts,
         initial_delay_ms,
         max_delay_ms,
-        force_retry: cli.force_retry,
+        force_retry: execution.force_retry,
         method: None, // Determined by executor at execution time
-        has_idempotency_key: cli.idempotency_key.is_some(),
+        has_idempotency_key: execution.idempotency_key.is_some(),
     }))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,13 +120,13 @@ async fn run_non_config_command(
 ) -> Result<(), Error> {
     match &cli.command {
         Commands::ListCommands { context } => run_list_commands(context, output),
-        Commands::Api { context, args } => run_api_command(cli, context, args).await,
+        Commands::Api { context, args, .. } => run_api_command(cli, context, args).await,
         Commands::Search {
             query,
             api,
             verbose,
         } => run_search_command(manager, query, api.as_deref(), *verbose, output),
-        Commands::Exec { api, args } => {
+        Commands::Exec { api, args, .. } => {
             run_shortcut_command(manager, args, api.as_deref(), cli).await
         }
         Commands::Docs {

--- a/tests/cli_translate_tests.rs
+++ b/tests/cli_translate_tests.rs
@@ -5,7 +5,7 @@ use aperture_cli::cli::translate::{
     cli_to_execution_context, extract_server_var_args, has_show_examples_flag,
     matches_to_operation_call, matches_to_operation_id,
 };
-use aperture_cli::cli::{Cli, Commands, OutputFormat};
+use aperture_cli::cli::{ExecutionFlags, OutputFormat};
 use aperture_cli::config::models::GlobalConfig;
 use aperture_cli::engine::generator::generate_command_tree_with_flags;
 use clap::{Arg, ArgAction, Command};
@@ -129,12 +129,9 @@ fn build_matches(include_show_examples: bool) -> clap::ArgMatches {
 }
 
 #[allow(clippy::missing_const_for_fn)]
-fn base_cli() -> Cli {
-    Cli {
+fn base_execution_flags() -> ExecutionFlags {
+    ExecutionFlags {
         describe_json: false,
-        json_errors: false,
-        quiet: false,
-        verbosity: 0,
         dry_run: false,
         idempotency_key: None,
         format: OutputFormat::Json,
@@ -151,10 +148,6 @@ fn base_cli() -> Cli {
         retry_delay: None,
         retry_max_delay: None,
         force_retry: false,
-        command: Commands::Exec {
-            api: None,
-            args: vec![],
-        },
     }
 }
 
@@ -299,17 +292,17 @@ fn matches_to_operation_id_does_not_validate_body_json() {
 
 #[test]
 fn cli_to_execution_context_builds_retry_and_cache_settings() {
-    let mut cli = base_cli();
-    cli.dry_run = true;
-    cli.idempotency_key = Some("idem-1".to_string());
-    cli.cache = true;
-    cli.cache_ttl = Some(42);
-    cli.retry = Some(3);
-    cli.retry_delay = Some("750ms".to_string());
-    cli.retry_max_delay = Some("5s".to_string());
-    cli.force_retry = true;
+    let mut execution = base_execution_flags();
+    execution.dry_run = true;
+    execution.idempotency_key = Some("idem-1".to_string());
+    execution.cache = true;
+    execution.cache_ttl = Some(42);
+    execution.retry = Some(3);
+    execution.retry_delay = Some("750ms".to_string());
+    execution.retry_max_delay = Some("5s".to_string());
+    execution.force_retry = true;
 
-    let ctx = cli_to_execution_context(&cli, Some(GlobalConfig::default()))
+    let ctx = cli_to_execution_context(&execution, Some(GlobalConfig::default()))
         .expect("context construction should succeed");
 
     assert!(ctx.dry_run);
@@ -332,11 +325,12 @@ fn cli_to_execution_context_builds_retry_and_cache_settings() {
 
 #[test]
 fn cli_to_execution_context_disables_cache_when_no_cache_flag_is_set() {
-    let mut cli = base_cli();
-    cli.cache = true;
-    cli.no_cache = true;
+    let mut execution = base_execution_flags();
+    execution.cache = true;
+    execution.no_cache = true;
 
-    let ctx = cli_to_execution_context(&cli, None).expect("context construction should succeed");
+    let ctx =
+        cli_to_execution_context(&execution, None).expect("context construction should succeed");
     assert!(ctx.cache_config.is_none());
 }
 

--- a/tests/hidden_flags_tests.rs
+++ b/tests/hidden_flags_tests.rs
@@ -1,11 +1,7 @@
-//! Integration tests for hidden global flags functionality.
+//! Integration tests for hidden dynamic flags functionality.
 //!
-//! Tests that global flags (--jq, --format, --server-var) are hidden from
-//! dynamic subcommand help but remain functional.
-//!
-//! Note: The hiding only affects the DYNAMIC command tree generated from `OpenAPI` specs,
-//! not the main CLI help. The main `aperture api <spec> --help` shows static CLI help
-//! which includes all flags. The dynamic help is shown at deeper levels (e.g., `users`, `list-users`).
+//! Tests that dynamic-operation flags (--jq, --format, --server-var) remain hidden from
+//! generated operation help while staying functional where supported.
 
 #![cfg(feature = "integration")]
 
@@ -63,20 +59,23 @@ paths:
 }
 
 #[test]
-fn test_global_flags_visible_in_main_help() {
-    // Check main help - should show --jq, --format (these are in the main CLI)
+fn test_execution_only_flags_hidden_in_main_help() {
+    // Main help should stay focused on universal flags only.
     let output = aperture_cmd().args(["--help"]).assert().success();
 
     let stdout = String::from_utf8_lossy(&output.get_output().stdout);
 
-    // These flags should be visible in the main help
     assert!(
-        stdout.contains("--jq"),
-        "Expected --jq to be visible in main help"
+        !stdout.contains("--jq"),
+        "Expected --jq to be hidden from main help"
     );
     assert!(
-        stdout.contains("--format"),
-        "Expected --format to be visible in main help"
+        !stdout.contains("--format"),
+        "Expected --format to be hidden from main help"
+    );
+    assert!(
+        stdout.contains("--json-errors"),
+        "Expected universal flags to remain visible"
     );
 }
 

--- a/tests/server_template_integration_tests.rs
+++ b/tests/server_template_integration_tests.rs
@@ -121,7 +121,7 @@ paths:
     // Should work with default values using dry-run to avoid network calls
     aperture_cmd()
         .env("HOME", home_dir.path())
-        .args(["--dry-run", "api", "regional", "health", "get-status"])
+        .args(["api", "regional", "--dry-run", "health", "get-status"])
         .assert()
         .success()
         .stdout(predicate::str::contains(
@@ -132,9 +132,9 @@ paths:
     aperture_cmd()
         .env("HOME", home_dir.path())
         .args([
-            "--dry-run",
             "api",
             "regional",
+            "--dry-run",
             "health",
             "get-status",
             "--server-var",
@@ -161,7 +161,7 @@ paths:
     // Config override should take precedence (non-template URL)
     aperture_cmd()
         .env("HOME", home_dir.path())
-        .args(["--dry-run", "api", "regional", "health", "get-status"])
+        .args(["api", "regional", "--dry-run", "health", "get-status"])
         .assert()
         .success()
         .stdout(predicate::str::contains(
@@ -212,7 +212,7 @@ paths:
     // Should work with default values
     aperture_cmd()
         .env("HOME", home_dir.path())
-        .args(["--dry-run", "api", "multi", "health", "ping"])
+        .args(["api", "multi", "--dry-run", "health", "ping"])
         .assert()
         .success()
         .stdout(predicate::str::contains(
@@ -223,9 +223,9 @@ paths:
     aperture_cmd()
         .env("HOME", home_dir.path())
         .args([
-            "--dry-run",
             "api",
             "multi",
+            "--dry-run",
             "health",
             "ping",
             "--server-var",


### PR DESCRIPTION
## Summary
- scope execution-only flags to `api` and `run` via a dedicated `ExecutionFlags` parser struct
- keep only universal flags at the root CLI and update runtime wiring to read scoped execution flags
- add coverage proving non-execution help no longer advertises execution flags and that irrelevant flags are rejected
- update guide/agent docs to reflect command-scoped execution flags

Closes #133
