### PR TITLE
feat: add structured output modes for discovery commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ aperture api petstore --describe-json
 - `docs` → deep operation reference before execution
 - `api --describe-json` → machine-readable capability manifest
 
+### Structured Discovery Output
+
+Primary discovery commands support machine-readable output:
+
+```bash
+aperture commands <api> --format json
+aperture overview <api> --format json
+aperture overview --all --format json
+aperture docs --format json
+aperture docs <api> --format json
+aperture docs <api> <tag> <operation> --format json
+aperture config api list --json
+```
+
+Stable top-level JSON shapes:
+
+- `commands --format json` → `{ api, groups[] }`
+- `overview <api> --format json` → `{ api, statistics, quick_start, sample_operations[] }`
+- `overview --all --format json` → `{ apis[] }`
+- `docs --format json` → `{ mode: "interactive", apis[] }`
+- `docs <api> --format json` → `{ mode: "api-reference", api, categories[], example_paths[] }`
+- `docs <api> <tag> <operation> --format json` → `{ mode: "operation", api, operation }`
+- `config api list --json` → `[{ name, ... }]` (verbose mode adds version/endpoint detail)
+
 ## Agent Integration
 
 Aperture provides features specifically for programmatic use:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -30,6 +30,28 @@ aperture commands my-api
 aperture api my-api --describe-json
 ```
 
+### Structured Discovery Output
+
+For script-friendly discovery data, use structured output modes:
+
+```bash
+aperture commands my-api --format json
+aperture overview my-api --format json
+aperture docs my-api --format json
+aperture docs my-api users get-user-by-id --format json
+aperture config api list --json
+```
+
+Top-level response shapes are stable for scripting:
+
+- `commands --format json` → `{ api, groups[] }`
+- `overview <api> --format json` → `{ api, statistics, quick_start, sample_operations[] }`
+- `overview --all --format json` → `{ apis[] }`
+- `docs --format json` → `{ mode: "interactive", apis[] }`
+- `docs <api> --format json` → `{ mode: "api-reference", api, categories[], example_paths[] }`
+- `docs <api> <tag> <operation> --format json` → `{ mode: "operation", api, operation }`
+- `config api list --json` → `[{ name, ... }]` (`--verbose` adds endpoint details)
+
 ### 3. Execute Commands
 
 ```bash

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -8,6 +8,7 @@ use crate::error::Error;
 use crate::fs::OsFileSystem;
 use crate::output::Output;
 use crate::response_cache::{CacheConfig, ResponseCache};
+use serde::Serialize;
 use std::path::PathBuf;
 
 /// Validates and returns the API context name, returning an error for invalid names.
@@ -199,11 +200,18 @@ fn handle_list_specs(
     output: &Output,
 ) -> Result<(), Error> {
     let specs = manager.list_specs()?;
+    if json {
+        let payload = collect_specs_with_details(manager, specs, verbose);
+        // ast-grep-ignore: no-println
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
     if specs.is_empty() {
         output.info("No API specifications found.");
     } else {
         output.info("Registered API specifications:");
-        list_specs_with_details(manager, specs, verbose, json, output);
+        list_specs_with_details(manager, specs, verbose, output);
     }
     Ok(())
 }
@@ -919,11 +927,92 @@ pub fn reinit_all_specs(
     Ok(())
 }
 
+#[derive(Debug, Serialize)]
+struct SpecEndpointStatsJson {
+    available: usize,
+    skipped: usize,
+    total: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct SkippedEndpointJson {
+    method: String,
+    path: String,
+    content_type: String,
+    reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SpecListItemJson {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    endpoints: Option<SpecEndpointStatsJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    skipped_endpoints: Vec<SkippedEndpointJson>,
+}
+
+fn collect_specs_with_details(
+    manager: &ConfigManager<OsFileSystem>,
+    specs: Vec<String>,
+    verbose: bool,
+) -> Vec<SpecListItemJson> {
+    let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
+    specs
+        .into_iter()
+        .map(|spec_name| {
+            if !verbose {
+                return SpecListItemJson {
+                    name: spec_name,
+                    version: None,
+                    endpoints: None,
+                    skipped_endpoints: vec![],
+                };
+            }
+
+            let Ok(cached_spec) = crate::engine::loader::load_cached_spec(&cache_dir, &spec_name)
+            else {
+                return SpecListItemJson {
+                    name: spec_name,
+                    version: None,
+                    endpoints: None,
+                    skipped_endpoints: vec![],
+                };
+            };
+
+            let available = cached_spec.commands.len();
+            let skipped = cached_spec.skipped_endpoints.len();
+            let total = available + skipped;
+            let skipped_endpoints = cached_spec
+                .skipped_endpoints
+                .iter()
+                .map(|endpoint| SkippedEndpointJson {
+                    method: endpoint.method.clone(),
+                    path: endpoint.path.clone(),
+                    content_type: endpoint.content_type.clone(),
+                    reason: endpoint.reason.clone(),
+                })
+                .collect::<Vec<_>>();
+
+            SpecListItemJson {
+                name: spec_name,
+                version: Some(cached_spec.version),
+                endpoints: Some(SpecEndpointStatsJson {
+                    available,
+                    skipped,
+                    total,
+                }),
+                skipped_endpoints,
+            }
+        })
+        .collect()
+}
+
 pub fn list_specs_with_details(
     manager: &ConfigManager<OsFileSystem>,
     specs: Vec<String>,
     verbose: bool,
-    _json: bool,
     output: &Output,
 ) {
     let cache_dir = manager.config_dir().join(constants::DIR_CACHE);

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -195,6 +195,7 @@ fn handle_remove_mapping_command(
 fn handle_list_specs(
     manager: &ConfigManager<OsFileSystem>,
     verbose: bool,
+    json: bool,
     output: &Output,
 ) -> Result<(), Error> {
     let specs = manager.list_specs()?;
@@ -202,7 +203,7 @@ fn handle_list_specs(
         output.info("No API specifications found.");
     } else {
         output.info("Registered API specifications:");
-        list_specs_with_details(manager, specs, verbose, output);
+        list_specs_with_details(manager, specs, verbose, json, output);
     }
     Ok(())
 }
@@ -436,8 +437,8 @@ fn normalize_api_config_command(
             force,
             strict,
         },
-        crate::cli::ConfigApiCommands::List { verbose } => {
-            crate::cli::ConfigCommands::List { verbose }
+        crate::cli::ConfigApiCommands::List { verbose, json } => {
+            crate::cli::ConfigCommands::List { verbose, json }
         }
         crate::cli::ConfigApiCommands::Remove { name } => {
             crate::cli::ConfigCommands::Remove { name }
@@ -644,7 +645,9 @@ async fn execute_specs_catalog_command(
             force,
             strict,
         } => handle_add_spec_command(manager, name, file_or_url, force, strict, output).await,
-        crate::cli::ConfigCommands::List { verbose } => handle_list_specs(manager, verbose, output),
+        crate::cli::ConfigCommands::List { verbose, json } => {
+            handle_list_specs(manager, verbose, json, output)
+        }
         crate::cli::ConfigCommands::Remove { name } => {
             handle_remove_spec_command(manager, name, output)
         }
@@ -920,6 +923,7 @@ pub fn list_specs_with_details(
     manager: &ConfigManager<OsFileSystem>,
     specs: Vec<String>,
     verbose: bool,
+    _json: bool,
     output: &Output,
 ) {
     let cache_dir = manager.config_dir().join(constants::DIR_CACHE);

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -1,6 +1,6 @@
 //! Handlers for `aperture docs`, `aperture overview`, and `aperture commands`.
 
-use crate::cache::models::CachedSpec;
+use crate::cache::models::{CachedCommand, CachedSpec};
 use crate::cli::DiscoveryFormat;
 use crate::config::manager::{get_config_dir, ConfigManager};
 use crate::constants;
@@ -9,11 +9,183 @@ use crate::engine::loader;
 use crate::error::Error;
 use crate::fs::OsFileSystem;
 use crate::output::Output;
+use crate::utils::to_kebab_case;
+use serde::Serialize;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
+
+#[derive(Debug, Serialize)]
+struct ApiInfoJson {
+    context: String,
+    name: String,
+    version: String,
+    base_url: Option<String>,
+    operation_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct MethodCountJson {
+    method: String,
+    count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct CategoryCountJson {
+    name: String,
+    count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct OperationSummaryJson {
+    group: String,
+    name: String,
+    method: String,
+    path: String,
+    summary: Option<String>,
+    description: Option<String>,
+    deprecated: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct CommandGroupJson {
+    name: String,
+    operations: Vec<OperationSummaryJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct CommandListJson {
+    api: ApiInfoJson,
+    groups: Vec<CommandGroupJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct DocsInteractiveJson {
+    mode: &'static str,
+    apis: Vec<ApiInfoJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct DocsPathExampleJson {
+    command: String,
+    summary: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DocsReferenceJson {
+    mode: &'static str,
+    api: ApiInfoJson,
+    categories: Vec<CategoryCountJson>,
+    example_paths: Vec<DocsPathExampleJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct ParameterJson {
+    name: String,
+    cli_name: String,
+    location: String,
+    required: bool,
+    description: Option<String>,
+    schema: Option<String>,
+    schema_type: Option<String>,
+    format: Option<String>,
+    default_value: Option<String>,
+    enum_values: Vec<String>,
+    example: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RequestBodyJson {
+    content_type: String,
+    schema: String,
+    required: bool,
+    description: Option<String>,
+    example: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ResponseJson {
+    status_code: String,
+    description: Option<String>,
+    content_type: Option<String>,
+    schema: Option<String>,
+    example: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CommandExampleJson {
+    description: String,
+    command_line: String,
+    explanation: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct OperationDetailsJson {
+    group: String,
+    name: String,
+    aliases: Vec<String>,
+    method: String,
+    path: String,
+    summary: Option<String>,
+    description: Option<String>,
+    deprecated: bool,
+    external_docs_url: Option<String>,
+    usage: String,
+    parameters: Vec<ParameterJson>,
+    request_body: Option<RequestBodyJson>,
+    responses: Vec<ResponseJson>,
+    security_requirements: Vec<String>,
+    examples: Vec<CommandExampleJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct DocsOperationJson {
+    mode: &'static str,
+    api: ApiInfoJson,
+    operation: OperationDetailsJson,
+}
+
+#[derive(Debug, Serialize)]
+struct OverviewStatisticsJson {
+    total_operations: usize,
+    methods: Vec<MethodCountJson>,
+    categories: Vec<CategoryCountJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct OverviewQuickStartJson {
+    commands: String,
+    search: String,
+    docs: String,
+    describe_json: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SingleOverviewJson {
+    api: ApiInfoJson,
+    statistics: OverviewStatisticsJson,
+    quick_start: OverviewQuickStartJson,
+    sample_operations: Vec<OperationSummaryJson>,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiOverviewJson {
+    context: String,
+    name: String,
+    version: String,
+    base_url: Option<String>,
+    operation_count: usize,
+    methods: Vec<MethodCountJson>,
+    quick_start: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AllOverviewJson {
+    apis: Vec<ApiOverviewJson>,
+}
 
 pub fn list_commands(
     context: &str,
-    _format: &DiscoveryFormat,
+    format: &DiscoveryFormat,
     output: &Output,
 ) -> Result<(), Error> {
     let config_dir = if let Ok(dir) = std::env::var(constants::ENV_APERTURE_CONFIG_DIR) {
@@ -26,22 +198,28 @@ pub fn list_commands(
         Error::Io(_) => Error::spec_not_found(context),
         _ => e,
     })?;
-    let formatted_output = HelpFormatter::format_command_list(&spec);
-    // ast-grep-ignore: no-println
-    println!("{formatted_output}");
-    output.tip(format!(
-        "Next: 'aperture overview {context}' for high-level API orientation"
-    ));
-    output.tip(format!(
-        "Next: 'aperture search <term> --api {context}' to find operations by intent"
-    ));
-    output.tip(format!(
-        "Next: 'aperture docs {context} <tag> <operation>' for deep operation docs"
-    ));
-    output.tip(format!(
-        "Execute: 'aperture api {context} <tag> <operation> ...'"
-    ));
-    Ok(())
+
+    match format {
+        DiscoveryFormat::Text => {
+            let formatted_output = HelpFormatter::format_command_list(&spec);
+            // ast-grep-ignore: no-println
+            println!("{formatted_output}");
+            output.tip(format!(
+                "Next: 'aperture overview {context}' for high-level API orientation"
+            ));
+            output.tip(format!(
+                "Next: 'aperture search <term> --api {context}' to find operations by intent"
+            ));
+            output.tip(format!(
+                "Next: 'aperture docs {context} <tag> <operation>' for deep operation docs"
+            ));
+            output.tip(format!(
+                "Execute: 'aperture api {context} <tag> <operation> ...'"
+            ));
+            Ok(())
+        }
+        DiscoveryFormat::Json => render_command_list_json(context, &spec),
+    }
 }
 
 /// Execute help command with enhanced documentation
@@ -51,7 +229,23 @@ pub fn execute_help_command(
     tag: Option<&str>,
     operation: Option<&str>,
     enhanced: bool,
-    _format: &DiscoveryFormat,
+    format: &DiscoveryFormat,
+    output: &Output,
+) -> Result<(), Error> {
+    match format {
+        DiscoveryFormat::Text => {
+            execute_help_command_text(manager, api_name, tag, operation, enhanced, output)
+        }
+        DiscoveryFormat::Json => execute_help_command_json(manager, api_name, tag, operation),
+    }
+}
+
+fn execute_help_command_text(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: Option<&str>,
+    tag: Option<&str>,
+    operation: Option<&str>,
+    enhanced: bool,
     output: &Output,
 ) -> Result<(), Error> {
     match (api_name, tag, operation) {
@@ -60,6 +254,25 @@ pub fn execute_help_command(
         (Some(api), Some(tag), Some(op)) => {
             render_command_help(manager, api, tag, op, enhanced, output)
         }
+        (Some(_), _, _) => {
+            print_invalid_docs_usage();
+        }
+        _ => {
+            print_invalid_help_arguments();
+        }
+    }
+}
+
+fn execute_help_command_json(
+    manager: &ConfigManager<OsFileSystem>,
+    api_name: Option<&str>,
+    tag: Option<&str>,
+    operation: Option<&str>,
+) -> Result<(), Error> {
+    match (api_name, tag, operation) {
+        (None, None, None) => render_interactive_menu_json(manager),
+        (Some(api), None, None) => render_api_reference_index_json(manager, api),
+        (Some(api), Some(tag), Some(op)) => render_command_help_json(manager, api, tag, op),
         (Some(_), _, _) => {
             print_invalid_docs_usage();
         }
@@ -81,6 +294,18 @@ fn render_interactive_menu(
     Ok(())
 }
 
+fn render_interactive_menu_json(manager: &ConfigManager<OsFileSystem>) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let apis = specs
+        .iter()
+        .map(|(context, spec)| api_info(context, spec, spec.commands.len()))
+        .collect::<Vec<_>>();
+    print_json(&DocsInteractiveJson {
+        mode: "interactive",
+        apis,
+    })
+}
+
 fn render_api_reference_index(
     manager: &ConfigManager<OsFileSystem>,
     api: &str,
@@ -98,6 +323,57 @@ fn render_api_reference_index(
         "Machine workflow: 'aperture api {api} --describe-json'"
     ));
     Ok(())
+}
+
+fn render_api_reference_index_json(
+    manager: &ConfigManager<OsFileSystem>,
+    api: &str,
+) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let spec = specs.get(api).ok_or_else(|| Error::spec_not_found(api))?;
+    let visible_commands = spec
+        .commands
+        .iter()
+        .filter(|command| !command.hidden)
+        .collect::<Vec<_>>();
+
+    let mut category_counts = BTreeMap::new();
+    for command in &visible_commands {
+        *category_counts
+            .entry(DocumentationGenerator::effective_group(command))
+            .or_insert(0usize) += 1;
+    }
+
+    let categories = category_counts
+        .into_iter()
+        .map(|(name, count)| CategoryCountJson { name, count })
+        .collect::<Vec<_>>();
+
+    let example_paths = visible_commands
+        .iter()
+        .take(3)
+        .map(|command| {
+            let group = DocumentationGenerator::effective_group(command);
+            let operation = DocumentationGenerator::effective_operation(command);
+            let summary = command
+                .summary
+                .as_deref()
+                .or(command.description.as_deref())
+                .unwrap_or("No description")
+                .to_string();
+            DocsPathExampleJson {
+                command: format!("aperture docs {api} {group} {operation}"),
+                summary,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    print_json(&DocsReferenceJson {
+        mode: "api-reference",
+        api: api_info(api, spec, visible_commands.len()),
+        categories,
+        example_paths,
+    })
 }
 
 fn render_command_help(
@@ -123,6 +399,129 @@ fn render_command_help(
         "Execute with 'aperture api {api} <tag> <operation> ...' after inspection"
     ));
     Ok(())
+}
+
+fn render_command_help_json(
+    manager: &ConfigManager<OsFileSystem>,
+    api: &str,
+    tag: &str,
+    operation: &str,
+) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let spec = specs.get(api).ok_or_else(|| Error::spec_not_found(api))?;
+    let command = find_docs_command(spec, api, tag, operation)?;
+
+    print_json(&DocsOperationJson {
+        mode: "operation",
+        api: api_info(api, spec, spec.commands.len()),
+        operation: build_operation_details_json(api, command),
+    })
+}
+
+fn find_docs_command<'a>(
+    spec: &'a CachedSpec,
+    api: &str,
+    tag: &str,
+    operation: &str,
+) -> Result<&'a CachedCommand, Error> {
+    spec.commands
+        .iter()
+        .find(|command| DocumentationGenerator::matches_command_reference(command, tag, operation))
+        .ok_or_else(|| {
+            Error::spec_not_found(format!(
+                "Operation '{tag} {operation}' not found in API '{api}'"
+            ))
+        })
+}
+
+fn build_operation_details_json(api: &str, command: &CachedCommand) -> OperationDetailsJson {
+    let group = DocumentationGenerator::effective_group(command);
+    let operation_name = DocumentationGenerator::effective_operation(command);
+    let usage = format!("aperture api {api} {group} {operation_name}");
+
+    OperationDetailsJson {
+        group,
+        name: operation_name,
+        aliases: command.aliases.clone(),
+        method: command.method.clone(),
+        path: command.path.clone(),
+        summary: command.summary.clone(),
+        description: command.description.clone(),
+        deprecated: command.deprecated,
+        external_docs_url: command.external_docs_url.clone(),
+        usage: usage.clone(),
+        parameters: serialize_parameters(command),
+        request_body: serialize_request_body(command),
+        responses: serialize_responses(command),
+        security_requirements: command.security_requirements.clone(),
+        examples: serialize_examples(command, &usage),
+    }
+}
+
+fn serialize_parameters(command: &CachedCommand) -> Vec<ParameterJson> {
+    command
+        .parameters
+        .iter()
+        .map(|param| ParameterJson {
+            name: param.name.clone(),
+            cli_name: to_kebab_case(&param.name),
+            location: param.location.clone(),
+            required: param.required,
+            description: param.description.clone(),
+            schema: param.schema.clone(),
+            schema_type: param.schema_type.clone(),
+            format: param.format.clone(),
+            default_value: param.default_value.clone(),
+            enum_values: param.enum_values.clone(),
+            example: param.example.clone(),
+        })
+        .collect()
+}
+
+fn serialize_request_body(command: &CachedCommand) -> Option<RequestBodyJson> {
+    command.request_body.as_ref().map(|body| RequestBodyJson {
+        content_type: body.content_type.clone(),
+        schema: body.schema.clone(),
+        required: body.required,
+        description: body.description.clone(),
+        example: body.example.clone(),
+    })
+}
+
+fn serialize_responses(command: &CachedCommand) -> Vec<ResponseJson> {
+    command
+        .responses
+        .iter()
+        .map(|response| ResponseJson {
+            status_code: response.status_code.clone(),
+            description: response.description.clone(),
+            content_type: response.content_type.clone(),
+            schema: response.schema.clone(),
+            example: response.example.clone(),
+        })
+        .collect()
+}
+
+fn serialize_examples(command: &CachedCommand, usage: &str) -> Vec<CommandExampleJson> {
+    let mut examples = command
+        .examples
+        .iter()
+        .map(|example| CommandExampleJson {
+            description: example.description.clone(),
+            command_line: example.command_line.clone(),
+            explanation: example.explanation.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    if examples.is_empty() {
+        examples.push(CommandExampleJson {
+            description: "Basic example".to_string(),
+            command_line: usage.to_string(),
+            explanation: None,
+        });
+    }
+
+    examples
 }
 
 fn print_invalid_docs_usage() -> ! {
@@ -151,17 +550,23 @@ pub fn execute_overview_command(
     manager: &ConfigManager<OsFileSystem>,
     api_name: Option<&str>,
     all: bool,
-    _format: &DiscoveryFormat,
+    format: &DiscoveryFormat,
     output: &Output,
 ) -> Result<(), Error> {
     if !all {
         let Some(api) = api_name else {
             print_overview_usage();
         };
-        return render_single_api_overview(manager, api, output);
+        return match format {
+            DiscoveryFormat::Text => render_single_api_overview(manager, api, output),
+            DiscoveryFormat::Json => render_single_api_overview_json(manager, api),
+        };
     }
 
-    render_all_api_overviews(manager, output)
+    match format {
+        DiscoveryFormat::Text => render_all_api_overviews(manager, output),
+        DiscoveryFormat::Json => render_all_api_overviews_json(manager),
+    }
 }
 
 fn render_single_api_overview(
@@ -187,6 +592,43 @@ fn render_single_api_overview(
         "Machine workflow: 'aperture api {api} --describe-json'"
     ));
     Ok(())
+}
+
+fn render_single_api_overview_json(
+    manager: &ConfigManager<OsFileSystem>,
+    api: &str,
+) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let spec = specs.get(api).ok_or_else(|| Error::spec_not_found(api))?;
+    let visible_commands = spec
+        .commands
+        .iter()
+        .filter(|command| !command.hidden)
+        .collect::<Vec<_>>();
+
+    let method_counts = collect_method_counts(visible_commands.iter().copied());
+    let category_counts = collect_category_counts(&visible_commands);
+    let sample_operations = visible_commands
+        .iter()
+        .take(3)
+        .map(|command| operation_summary(command))
+        .collect::<Vec<_>>();
+
+    print_json(&SingleOverviewJson {
+        api: api_info(api, spec, visible_commands.len()),
+        statistics: OverviewStatisticsJson {
+            total_operations: visible_commands.len(),
+            methods: method_counts,
+            categories: category_counts,
+        },
+        quick_start: OverviewQuickStartJson {
+            commands: format!("aperture commands {api}"),
+            search: format!("aperture search \"keyword\" --api {api}"),
+            docs: format!("aperture docs {api} <tag> <operation>"),
+            describe_json: format!("aperture api {api} --describe-json"),
+        },
+        sample_operations,
+    })
 }
 
 fn render_all_api_overviews(
@@ -229,14 +671,109 @@ fn render_all_api_overviews(
     Ok(())
 }
 
-fn summarize_methods(spec_commands: &[crate::cache::models::CachedCommand]) -> Vec<String> {
-    let mut method_counts = std::collections::BTreeMap::new();
-    for command in spec_commands {
+fn render_all_api_overviews_json(manager: &ConfigManager<OsFileSystem>) -> Result<(), Error> {
+    let specs = load_all_specs(manager)?;
+    let apis = specs
+        .iter()
+        .map(|(context, spec)| ApiOverviewJson {
+            context: context.clone(),
+            name: spec.name.clone(),
+            version: spec.version.clone(),
+            base_url: spec.base_url.clone(),
+            operation_count: spec.commands.len(),
+            methods: collect_method_counts(spec.commands.iter()),
+            quick_start: format!("aperture commands {context}"),
+        })
+        .collect::<Vec<_>>();
+
+    print_json(&AllOverviewJson { apis })
+}
+
+fn render_command_list_json(context: &str, spec: &CachedSpec) -> Result<(), Error> {
+    let visible_commands = spec
+        .commands
+        .iter()
+        .filter(|command| !command.hidden)
+        .collect::<Vec<_>>();
+
+    let mut groups = BTreeMap::<String, Vec<OperationSummaryJson>>::new();
+    for command in &visible_commands {
+        groups
+            .entry(DocumentationGenerator::effective_group(command))
+            .or_default()
+            .push(operation_summary(command));
+    }
+
+    let groups = groups
+        .into_iter()
+        .map(|(name, operations)| CommandGroupJson { name, operations })
+        .collect::<Vec<_>>();
+
+    print_json(&CommandListJson {
+        api: api_info(context, spec, visible_commands.len()),
+        groups,
+    })
+}
+
+fn collect_method_counts<'a, I>(commands: I) -> Vec<MethodCountJson>
+where
+    I: Iterator<Item = &'a CachedCommand>,
+{
+    let mut method_counts = BTreeMap::new();
+    for command in commands {
         *method_counts.entry(command.method.clone()).or_insert(0) += 1;
     }
     method_counts
-        .iter()
-        .map(|(method, count)| format!("{method}: {count}"))
+        .into_iter()
+        .map(|(method, count)| MethodCountJson { method, count })
+        .collect()
+}
+
+fn collect_category_counts(commands: &[&CachedCommand]) -> Vec<CategoryCountJson> {
+    let mut category_counts = BTreeMap::new();
+    for command in commands {
+        *category_counts
+            .entry(DocumentationGenerator::effective_group(command))
+            .or_insert(0usize) += 1;
+    }
+    category_counts
+        .into_iter()
+        .map(|(name, count)| CategoryCountJson { name, count })
+        .collect()
+}
+
+fn api_info(context: &str, spec: &CachedSpec, operation_count: usize) -> ApiInfoJson {
+    ApiInfoJson {
+        context: context.to_string(),
+        name: spec.name.clone(),
+        version: spec.version.clone(),
+        base_url: spec.base_url.clone(),
+        operation_count,
+    }
+}
+
+fn operation_summary(command: &CachedCommand) -> OperationSummaryJson {
+    OperationSummaryJson {
+        group: DocumentationGenerator::effective_group(command),
+        name: DocumentationGenerator::effective_operation(command),
+        method: command.method.clone(),
+        path: command.path.clone(),
+        summary: command.summary.clone(),
+        description: command.description.clone(),
+        deprecated: command.deprecated,
+    }
+}
+
+fn print_json<T: Serialize>(payload: &T) -> Result<(), Error> {
+    // ast-grep-ignore: no-println
+    println!("{}", serde_json::to_string_pretty(payload)?);
+    Ok(())
+}
+
+fn summarize_methods(spec_commands: &[crate::cache::models::CachedCommand]) -> Vec<String> {
+    collect_method_counts(spec_commands.iter())
+        .into_iter()
+        .map(|entry| format!("{}: {}", entry.method, entry.count))
         .collect()
 }
 

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -1,6 +1,7 @@
 //! Handlers for `aperture docs`, `aperture overview`, and `aperture commands`.
 
 use crate::cache::models::CachedSpec;
+use crate::cli::DiscoveryFormat;
 use crate::config::manager::{get_config_dir, ConfigManager};
 use crate::constants;
 use crate::docs::{DocumentationGenerator, HelpFormatter};
@@ -10,7 +11,11 @@ use crate::fs::OsFileSystem;
 use crate::output::Output;
 use std::path::PathBuf;
 
-pub fn list_commands(context: &str, output: &Output) -> Result<(), Error> {
+pub fn list_commands(
+    context: &str,
+    _format: &DiscoveryFormat,
+    output: &Output,
+) -> Result<(), Error> {
     let config_dir = if let Ok(dir) = std::env::var(constants::ENV_APERTURE_CONFIG_DIR) {
         PathBuf::from(dir)
     } else {
@@ -46,6 +51,7 @@ pub fn execute_help_command(
     tag: Option<&str>,
     operation: Option<&str>,
     enhanced: bool,
+    _format: &DiscoveryFormat,
     output: &Output,
 ) -> Result<(), Error> {
     match (api_name, tag, operation) {
@@ -145,6 +151,7 @@ pub fn execute_overview_command(
     manager: &ConfigManager<OsFileSystem>,
     api_name: Option<&str>,
     all: bool,
+    _format: &DiscoveryFormat,
     output: &Output,
 ) -> Result<(), Error> {
     if !all {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,6 +17,14 @@ pub enum OutputFormat {
     Table,
 }
 
+#[derive(ValueEnum, Clone, Debug)]
+pub enum DiscoveryFormat {
+    /// Human-readable output (default)
+    Text,
+    /// Structured JSON output
+    Json,
+}
+
 /// Flags that are only meaningful for execution-oriented commands (`api`, `run`).
 #[derive(Args, Debug, Clone)]
 #[allow(clippy::struct_excessive_bools)]
@@ -242,6 +250,14 @@ pub enum Commands {
         /// Name of the API specification context.
         /// Must start with a letter or digit; may contain letters, digits, dots, hyphens, or underscores (max 64 chars).
         context: String,
+        /// Output format for discovery data
+        #[arg(
+            long,
+            value_enum,
+            default_value = "text",
+            help = "Output format for discovery data"
+        )]
+        format: DiscoveryFormat,
     },
     /// Execute API operations for a specific context
     #[command(
@@ -349,9 +365,20 @@ pub enum Commands {
         tag: Option<String>,
         /// Operation name (optional)
         operation: Option<String>,
-        /// Show enhanced formatting with examples
-        #[arg(long, help = "Enhanced formatting with examples and tips")]
+        /// Show enhanced formatting with examples (text format only)
+        #[arg(
+            long,
+            help = "Enhanced formatting with examples and tips (text format only)"
+        )]
         enhanced: bool,
+        /// Output format for discovery data
+        #[arg(
+            long,
+            value_enum,
+            default_value = "text",
+            help = "Output format for discovery data"
+        )]
+        format: DiscoveryFormat,
     },
     /// Show API overview with statistics and quick start guide
     #[command(
@@ -373,6 +400,14 @@ pub enum Commands {
         /// Show overview for all registered APIs
         #[arg(long, conflicts_with = "api", help = "Show overview for all APIs")]
         all: bool,
+        /// Output format for discovery data
+        #[arg(
+            long,
+            value_enum,
+            default_value = "text",
+            help = "Output format for discovery data"
+        )]
+        format: DiscoveryFormat,
     },
 }
 
@@ -400,6 +435,9 @@ pub enum ConfigApiCommands {
         /// Show detailed information including skipped endpoints
         #[arg(long, help = "Show detailed information about each API")]
         verbose: bool,
+        /// Output as JSON
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
     /// Remove an API specification from configuration
     Remove {
@@ -654,6 +692,9 @@ pub enum ConfigCommands {
         /// Show detailed information including skipped endpoints
         #[arg(long, help = "Show detailed information about each API")]
         verbose: bool,
+        /// Output as JSON
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
     #[command(hide = true)]
     /// Remove an API specification from configuration
@@ -995,7 +1036,10 @@ mod tests {
     fn commands_canonical_name_parses() {
         let cli = Cli::try_parse_from(["aperture", "commands", "my-api"]).unwrap();
         match cli.command {
-            Commands::ListCommands { context } => assert_eq!(context, "my-api"),
+            Commands::ListCommands { context, format } => {
+                assert_eq!(context, "my-api");
+                assert!(matches!(format, super::DiscoveryFormat::Text));
+            }
             other => panic!("expected Commands::ListCommands, got {other:?}"),
         }
     }
@@ -1004,7 +1048,10 @@ mod tests {
     fn list_commands_alias_parses() {
         let cli = Cli::try_parse_from(["aperture", "list-commands", "my-api"]).unwrap();
         match cli.command {
-            Commands::ListCommands { context } => assert_eq!(context, "my-api"),
+            Commands::ListCommands { context, format } => {
+                assert_eq!(context, "my-api");
+                assert!(matches!(format, super::DiscoveryFormat::Text));
+            }
             other => panic!("expected Commands::ListCommands, got {other:?}"),
         }
     }

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -70,7 +70,7 @@ impl DocumentationGenerator {
     }
 
     /// Returns the effective command group shown in CLI paths.
-    fn effective_group(command: &CachedCommand) -> String {
+    pub(crate) fn effective_group(command: &CachedCommand) -> String {
         command.display_group.as_ref().map_or_else(
             || {
                 if command.name.is_empty() {
@@ -84,7 +84,7 @@ impl DocumentationGenerator {
     }
 
     /// Returns the effective command name shown in CLI paths.
-    fn effective_operation(command: &CachedCommand) -> String {
+    pub(crate) fn effective_operation(command: &CachedCommand) -> String {
         command.display_name.as_ref().map_or_else(
             || {
                 if command.operation_id.is_empty() {
@@ -100,7 +100,11 @@ impl DocumentationGenerator {
     /// Returns true when the provided docs path references this command.
     ///
     /// Supports both effective (mapped) names and original names for compatibility.
-    fn matches_command_reference(command: &CachedCommand, tag: &str, operation: &str) -> bool {
+    pub(crate) fn matches_command_reference(
+        command: &CachedCommand,
+        tag: &str,
+        operation: &str,
+    ) -> bool {
         let requested_tag = to_kebab_case(tag);
         let requested_operation = to_kebab_case(operation);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use aperture_cli::cli::commands::config::validate_api_name;
-use aperture_cli::cli::{Cli, Commands};
+use aperture_cli::cli::{Cli, Commands, DiscoveryFormat};
 use aperture_cli::config::manager::ConfigManager;
 use aperture_cli::constants;
 use aperture_cli::error::Error;
@@ -36,9 +36,13 @@ async fn main() {
     }
 }
 
-fn run_list_commands(context: &str, output: &Output) -> Result<(), Error> {
+fn run_list_commands(
+    context: &str,
+    format: &DiscoveryFormat,
+    output: &Output,
+) -> Result<(), Error> {
     let context = validate_api_name(context)?;
-    aperture_cli::cli::commands::docs::list_commands(&context, output)
+    aperture_cli::cli::commands::docs::list_commands(&context, format, output)
 }
 
 async fn run_api_command(cli: &Cli, context: &str, args: &[String]) -> Result<(), Error> {
@@ -85,6 +89,7 @@ fn run_docs_command(
     tag: Option<&str>,
     operation: Option<&str>,
     enhanced: bool,
+    format: &DiscoveryFormat,
     output: &Output,
 ) -> Result<(), Error> {
     let validated_api = api.map(validate_api_name).transpose()?;
@@ -94,6 +99,7 @@ fn run_docs_command(
         tag,
         operation,
         enhanced,
+        format,
         output,
     )
 }
@@ -102,6 +108,7 @@ fn run_overview_command(
     manager: &ConfigManager<OsFileSystem>,
     api: Option<&str>,
     all: bool,
+    format: &DiscoveryFormat,
     output: &Output,
 ) -> Result<(), Error> {
     let validated_api = api.map(validate_api_name).transpose()?;
@@ -109,6 +116,7 @@ fn run_overview_command(
         manager,
         validated_api.as_deref(),
         all,
+        format,
         output,
     )
 }
@@ -119,7 +127,7 @@ async fn run_non_config_command(
     output: &Output,
 ) -> Result<(), Error> {
     match &cli.command {
-        Commands::ListCommands { context } => run_list_commands(context, output),
+        Commands::ListCommands { context, format } => run_list_commands(context, format, output),
         Commands::Api { context, args, .. } => run_api_command(cli, context, args).await,
         Commands::Search {
             query,
@@ -134,16 +142,18 @@ async fn run_non_config_command(
             tag,
             operation,
             enhanced,
+            format,
         } => run_docs_command(
             manager,
             api.as_deref(),
             tag.as_deref(),
             operation.as_deref(),
             *enhanced,
+            format,
             output,
         ),
-        Commands::Overview { api, all } => {
-            run_overview_command(manager, api.as_deref(), *all, output)
+        Commands::Overview { api, all, format } => {
+            run_overview_command(manager, api.as_deref(), *all, format, output)
         }
         Commands::Config { .. } => unreachable!("config commands are handled separately"),
     }

--- a/tests/discovery_structured_output_integration_tests.rs
+++ b/tests/discovery_structured_output_integration_tests.rs
@@ -1,0 +1,273 @@
+mod common;
+
+use common::aperture_cmd;
+use std::fs;
+use tempfile::TempDir;
+
+fn write_primary_spec(temp_dir: &TempDir) -> std::path::PathBuf {
+    let spec_file = temp_dir.path().join("spec.yaml");
+    fs::write(
+        &spec_file,
+        r"openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com
+paths:
+  /users:
+    get:
+      tags:
+        - users
+      operationId: listUsers
+      summary: List users
+      responses:
+        '200':
+          description: Success
+  /users/{id}:
+    get:
+      tags:
+        - users
+      operationId: getUserById
+      summary: Get user by id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Success
+  /health:
+    get:
+      operationId: healthCheck
+      summary: Health check
+      responses:
+        '200':
+          description: Success
+",
+    )
+    .unwrap();
+    spec_file
+}
+
+fn write_secondary_spec(temp_dir: &TempDir) -> std::path::PathBuf {
+    let spec_file = temp_dir.path().join("spec-2.yaml");
+    fs::write(
+        &spec_file,
+        r"openapi: 3.0.0
+info:
+  title: Billing API
+  version: 2.1.0
+paths:
+  /invoices:
+    get:
+      tags:
+        - billing
+      operationId: listInvoices
+      responses:
+        '200':
+          description: Success
+",
+    )
+    .unwrap();
+    spec_file
+}
+
+fn add_spec(config_dir: &std::path::Path, name: &str, spec_file: &std::path::Path) {
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", config_dir)
+        .args(["config", "api", "add", name, spec_file.to_str().unwrap()])
+        .assert()
+        .success();
+}
+
+#[test]
+fn commands_support_json_format() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = write_primary_spec(&temp_dir);
+    add_spec(temp_dir.path(), "test-api", &spec_file);
+
+    let output = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["commands", "test-api", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    assert_eq!(parsed["api"]["context"], "test-api");
+    assert_eq!(parsed["api"]["operation_count"], 3);
+    assert!(parsed["groups"].is_array());
+    assert!(parsed["groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|group| group["name"] == "users"));
+}
+
+#[test]
+fn overview_supports_json_for_single_and_all() {
+    let temp_dir = TempDir::new().unwrap();
+    let primary = write_primary_spec(&temp_dir);
+    let secondary = write_secondary_spec(&temp_dir);
+    add_spec(temp_dir.path(), "test-api", &primary);
+    add_spec(temp_dir.path(), "billing", &secondary);
+
+    let single = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["overview", "test-api", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(single.status.success());
+    let single_json: serde_json::Value =
+        serde_json::from_slice(&single.stdout).expect("single overview should be valid JSON");
+    assert_eq!(single_json["api"]["context"], "test-api");
+    assert_eq!(single_json["statistics"]["total_operations"], 3);
+    assert!(single_json["statistics"]["methods"].is_array());
+
+    let all = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["overview", "--all", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert!(all.status.success());
+    let all_json: serde_json::Value =
+        serde_json::from_slice(&all.stdout).expect("all overview should be valid JSON");
+    let apis = all_json["apis"].as_array().unwrap();
+    assert_eq!(apis.len(), 2);
+    assert!(apis.iter().any(|api| api["context"] == "test-api"));
+    assert!(apis.iter().any(|api| api["context"] == "billing"));
+}
+
+#[test]
+fn docs_support_json_for_all_modes() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = write_primary_spec(&temp_dir);
+    add_spec(temp_dir.path(), "test-api", &spec_file);
+
+    let interactive = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["docs", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(interactive.status.success());
+    let interactive_json: serde_json::Value = serde_json::from_slice(&interactive.stdout).unwrap();
+    assert_eq!(interactive_json["mode"], "interactive");
+    assert!(interactive_json["apis"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|api| api["context"] == "test-api"));
+
+    let index = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["docs", "test-api", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(index.status.success());
+    let index_json: serde_json::Value = serde_json::from_slice(&index.stdout).unwrap();
+    assert_eq!(index_json["mode"], "api-reference");
+    assert_eq!(index_json["api"]["context"], "test-api");
+    assert!(index_json["categories"].is_array());
+
+    let operation = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "docs",
+            "test-api",
+            "users",
+            "get-user-by-id",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(operation.status.success());
+    let op_json: serde_json::Value = serde_json::from_slice(&operation.stdout).unwrap();
+    assert_eq!(op_json["mode"], "operation");
+    assert_eq!(op_json["operation"]["name"], "get-user-by-id");
+    assert_eq!(
+        op_json["operation"]["usage"],
+        "aperture api test-api users get-user-by-id"
+    );
+    assert!(op_json["operation"]["parameters"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|param| param["cli_name"] == "id"));
+}
+
+#[test]
+fn config_api_list_supports_json_output() {
+    let temp_dir = TempDir::new().unwrap();
+    let spec_file = write_primary_spec(&temp_dir);
+    add_spec(temp_dir.path(), "test-api", &spec_file);
+
+    let list = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "api", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(list.status.success());
+    let list_json: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert!(list_json.is_array());
+    assert_eq!(list_json[0]["name"], "test-api");
+
+    let verbose = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "api", "list", "--verbose", "--json"])
+        .output()
+        .unwrap();
+    assert!(verbose.status.success());
+    let verbose_json: serde_json::Value = serde_json::from_slice(&verbose.stdout).unwrap();
+    assert_eq!(verbose_json[0]["name"], "test-api");
+    assert_eq!(verbose_json[0]["version"], "1.0.0");
+    assert_eq!(verbose_json[0]["endpoints"]["available"], 3);
+
+    let legacy = aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(legacy.status.success());
+    let legacy_json: serde_json::Value = serde_json::from_slice(&legacy.stdout).unwrap();
+    assert_eq!(legacy_json[0]["name"], "test-api");
+}
+
+#[test]
+fn help_advertises_structured_output_only_on_supported_commands() {
+    let commands_help = aperture_cmd()
+        .args(["commands", "--help"])
+        .output()
+        .unwrap();
+    let commands_help = String::from_utf8_lossy(&commands_help.stdout);
+    assert!(commands_help.contains("Output format for discovery data"));
+
+    let overview_help = aperture_cmd()
+        .args(["overview", "--help"])
+        .output()
+        .unwrap();
+    let overview_help = String::from_utf8_lossy(&overview_help.stdout);
+    assert!(overview_help.contains("Output format for discovery data"));
+
+    let docs_help = aperture_cmd().args(["docs", "--help"]).output().unwrap();
+    let docs_help = String::from_utf8_lossy(&docs_help.stdout);
+    assert!(docs_help.contains("Output format for discovery data"));
+
+    let config_list_help = aperture_cmd()
+        .args(["config", "api", "list", "--help"])
+        .output()
+        .unwrap();
+    let config_list_help = String::from_utf8_lossy(&config_list_help.stdout);
+    assert!(config_list_help.contains("--json"));
+
+    let search_help = aperture_cmd().args(["search", "--help"]).output().unwrap();
+    let search_help = String::from_utf8_lossy(&search_help.stdout);
+    assert!(!search_help.contains("Output format for discovery data"));
+}


### PR DESCRIPTION
## Summary
- add structured output modes for discovery commands via `--format json` on `commands`, `overview`, and `docs`
- add `--json` support for `config api list` (and legacy `config list`) with stable verbose/non-verbose schemas
- add integration coverage for structured discovery output and help flag visibility
- document stable top-level response schemas in README and guide docs

Closes #143
