### PR TITLE
fix: generate canonical examples and usage from effective CLI model

### DIFF
--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -163,7 +163,7 @@ fn handle_show_examples_command(
         .iter()
         .find(|cmd| cmd.operation_id == operation_id)
         .ok_or_else(|| Error::spec_not_found(context))?;
-    crate::cli::render::render_examples(operation);
+    crate::cli::render::render_examples(context, operation);
     Ok(())
 }
 
@@ -318,21 +318,24 @@ async fn execute_standard_api_runtime(
 }
 
 fn parse_dynamic_matches(
+    context: &str,
     spec: &CachedSpec,
     args: &[String],
     use_positional_args: bool,
 ) -> Result<clap::ArgMatches, clap::Error> {
-    generator::generate_command_tree_with_flags(spec, use_positional_args).try_get_matches_from(
-        std::iter::once(constants::CLI_ROOT_COMMAND.to_string()).chain(args.iter().cloned()),
-    )
+    generator::generate_command_tree_for_api_with_flags(spec, context, use_positional_args)
+        .try_get_matches_from(
+            std::iter::once(constants::CLI_ROOT_COMMAND.to_string()).chain(args.iter().cloned()),
+        )
 }
 
 fn parse_dynamic_matches_relaxed(
+    context: &str,
     spec: &CachedSpec,
     args: &[String],
     use_positional_args: bool,
 ) -> Result<clap::ArgMatches, clap::Error> {
-    generator::generate_command_tree_with_flags(spec, use_positional_args)
+    generator::generate_command_tree_for_api_with_flags(spec, context, use_positional_args)
         .ignore_errors(true)
         .try_get_matches_from(
             std::iter::once(constants::CLI_ROOT_COMMAND.to_string()).chain(args.iter().cloned()),
@@ -363,7 +366,7 @@ fn parse_matches_with_examples_fallback(
     args: &[String],
     use_positional_args: bool,
 ) -> Result<Option<clap::ArgMatches>, Error> {
-    match parse_dynamic_matches(spec, args, use_positional_args) {
+    match parse_dynamic_matches(context, spec, args, use_positional_args) {
         Ok(matches) => Ok(Some(matches)),
         Err(parse_error) => handle_parse_error_with_examples_fallback(
             context,
@@ -391,7 +394,7 @@ fn handle_parse_error_with_examples_fallback(
         return Err(Error::invalid_command(context, parse_error.to_string()));
     }
 
-    let relaxed_matches = parse_dynamic_matches_relaxed(spec, args, use_positional_args)
+    let relaxed_matches = parse_dynamic_matches_relaxed(context, spec, args, use_positional_args)
         .map_err(|e| Error::invalid_command(context, e.to_string()))?;
 
     if crate::cli::translate::has_show_examples_flag(&relaxed_matches) {

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -437,7 +437,7 @@ fn find_docs_command<'a>(
 fn build_operation_details_json(api: &str, command: &CachedCommand) -> OperationDetailsJson {
     let group = DocumentationGenerator::effective_group(command);
     let operation_name = DocumentationGenerator::effective_operation(command);
-    let usage = format!("aperture api {api} {group} {operation_name}");
+    let usage = DocumentationGenerator::canonical_usage(api, command);
 
     OperationDetailsJson {
         group,
@@ -449,12 +449,12 @@ fn build_operation_details_json(api: &str, command: &CachedCommand) -> Operation
         description: command.description.clone(),
         deprecated: command.deprecated,
         external_docs_url: command.external_docs_url.clone(),
-        usage: usage.clone(),
+        usage,
         parameters: serialize_parameters(command),
         request_body: serialize_request_body(command),
         responses: serialize_responses(command),
         security_requirements: command.security_requirements.clone(),
-        examples: serialize_examples(command, &usage),
+        examples: serialize_examples(api, command),
     }
 }
 
@@ -502,26 +502,15 @@ fn serialize_responses(command: &CachedCommand) -> Vec<ResponseJson> {
         .collect()
 }
 
-fn serialize_examples(command: &CachedCommand, usage: &str) -> Vec<CommandExampleJson> {
-    let mut examples = command
-        .examples
-        .iter()
+fn serialize_examples(api: &str, command: &CachedCommand) -> Vec<CommandExampleJson> {
+    DocumentationGenerator::canonical_examples(api, command)
+        .into_iter()
         .map(|example| CommandExampleJson {
-            description: example.description.clone(),
-            command_line: example.command_line.clone(),
-            explanation: example.explanation.clone(),
+            description: example.description,
+            command_line: example.command_line,
+            explanation: example.explanation,
         })
-        .collect::<Vec<_>>();
-
-    if examples.is_empty() {
-        examples.push(CommandExampleJson {
-            description: "Basic example".to_string(),
-            command_line: usage.to_string(),
-            explanation: None,
-        });
-    }
-
-    examples
+        .collect()
 }
 
 fn print_invalid_docs_usage() -> ! {

--- a/src/cli/legacy_execute.rs
+++ b/src/cli/legacy_execute.rs
@@ -85,6 +85,6 @@ fn maybe_render_examples(spec: &CachedSpec, matches: &ArgMatches) -> Result<bool
         .iter()
         .find(|cmd| cmd.operation_id == operation_id)
         .ok_or_else(|| Error::spec_not_found(&spec.name))?;
-    crate::cli::render::render_examples(operation);
+    crate::cli::render::render_examples("<api>", operation);
     Ok(true)
 }

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -95,9 +95,12 @@ pub fn render_result_to_string(
 }
 
 /// Renders extended examples for a command to stdout.
-pub fn render_examples(operation: &CachedCommand) {
+pub fn render_examples(api_name: &str, operation: &CachedCommand) {
+    let operation_name = crate::docs::DocumentationGenerator::effective_operation(operation);
+    let examples = crate::docs::DocumentationGenerator::canonical_examples(api_name, operation);
+
     // ast-grep-ignore: no-println
-    println!("Command: {}\n", to_kebab_case(&operation.operation_id));
+    println!("Command: {operation_name}\n");
 
     if let Some(ref summary) = operation.summary {
         // ast-grep-ignore: no-println
@@ -107,15 +110,9 @@ pub fn render_examples(operation: &CachedCommand) {
     // ast-grep-ignore: no-println
     println!("Method: {} {}\n", operation.method, operation.path);
 
-    if operation.examples.is_empty() {
-        // ast-grep-ignore: no-println
-        println!("No examples available for this command.");
-        return;
-    }
-
     // ast-grep-ignore: no-println
     println!("Examples:\n");
-    for (i, example) in operation.examples.iter().enumerate() {
+    for (i, example) in examples.iter().enumerate() {
         // ast-grep-ignore: no-println
         println!("{}. {}", i + 1, example.description);
         // ast-grep-ignore: no-println
@@ -139,7 +136,12 @@ pub fn render_examples(operation: &CachedCommand) {
         let required = if param.required { " (required)" } else { "" };
         let param_type = param.schema_type.as_deref().unwrap_or("string");
         // ast-grep-ignore: no-println
-        println!("  --{}{} [{}]", param.name, required, param_type);
+        println!(
+            "  --{}{} [{}]",
+            to_kebab_case(&param.name),
+            required,
+            param_type
+        );
 
         let Some(ref desc) = param.description else {
             continue;

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -300,7 +300,7 @@ impl DocumentationGenerator {
 
         let mut command_line = base_cmd.to_string();
         for param in required_params {
-            Self::append_example_parameter(&mut command_line, param, "<value>");
+            Self::append_example_parameter(&mut command_line, param, "example");
         }
         examples.push(CommandExample {
             description: "Basic usage with required parameters".to_string(),
@@ -398,8 +398,20 @@ impl DocumentationGenerator {
             return;
         }
 
-        let value = param.example.as_deref().unwrap_or(fallback);
+        let value = param
+            .example
+            .as_deref()
+            .unwrap_or_else(|| Self::default_example_value(param.schema_type.as_deref(), fallback));
         write!(command_line, " {value}").ok();
+    }
+
+    fn default_example_value<'a>(schema_type: Option<&'a str>, fallback: &'a str) -> &'a str {
+        match schema_type {
+            Some("integer" | "number") => "123",
+            Some("array") => "[item1,item2]",
+            Some("object") => "{\"key\":\"value\"}",
+            _ => fallback,
+        }
     }
 
     fn is_boolean_parameter(param: &CachedParameter) -> bool {

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -320,12 +320,8 @@ impl DocumentationGenerator {
         }
 
         let mut command_line = base_cmd.to_string();
-        for param in required_params
-            .iter()
-            .copied()
-            .filter(|p| p.location == "path" || p.location == "query")
-        {
-            Self::append_example_parameter(&mut command_line, param, "123");
+        for param in required_params {
+            Self::append_example_parameter(&mut command_line, param, "example");
         }
         command_line.push_str(" --body '{\"name\": \"example\", \"value\": 42}'");
 

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,6 +1,6 @@
 //! Documentation and help system for improved CLI discoverability
 
-use crate::cache::models::{CachedCommand, CachedSpec};
+use crate::cache::models::{CachedCommand, CachedParameter, CachedSpec, CommandExample};
 use crate::constants;
 use crate::error::Error;
 use crate::utils::to_kebab_case;
@@ -45,23 +45,14 @@ impl DocumentationGenerator {
                 ))
             })?;
 
-        let effective_tag = Self::effective_group(command);
-        let effective_operation = Self::effective_operation(command);
-
         let mut help = String::new();
 
         // Build help sections
         Self::add_command_header(&mut help, command);
-        Self::add_usage_section(&mut help, api_name, &effective_tag, &effective_operation);
+        Self::add_usage_section(&mut help, api_name, command);
         Self::add_parameters_section(&mut help, command);
         Self::add_request_body_section(&mut help, command);
-        Self::add_examples_section(
-            &mut help,
-            api_name,
-            &effective_tag,
-            &effective_operation,
-            command,
-        );
+        Self::add_examples_section(&mut help, api_name, command);
         Self::add_responses_section(&mut help, command);
         Self::add_authentication_section(&mut help, command);
         Self::add_metadata_section(&mut help, command);
@@ -168,13 +159,38 @@ impl DocumentationGenerator {
     }
 
     /// Add usage section with command syntax
-    fn add_usage_section(help: &mut String, api_name: &str, tag: &str, operation_id: &str) {
+    fn add_usage_section(help: &mut String, api_name: &str, command: &CachedCommand) {
         help.push_str("## Usage\n\n");
         write!(
             help,
-            "```bash\naperture api {api_name} {tag} {operation_id}\n```\n\n"
+            "```bash\n{}\n```\n\n",
+            Self::canonical_usage(api_name, command)
         )
         .ok();
+    }
+
+    /// Builds canonical usage output from the effective runtime command model.
+    #[must_use]
+    pub(crate) fn canonical_usage(api_name: &str, command: &CachedCommand) -> String {
+        let mut usage = Self::base_command(api_name, command);
+
+        for param in &command.parameters {
+            if !param.required {
+                continue;
+            }
+            usage.push(' ');
+            usage.push_str(&Self::required_parameter_usage_fragment(param));
+        }
+
+        if command
+            .request_body
+            .as_ref()
+            .is_some_and(|body| body.required)
+        {
+            usage.push_str(" --body '{\"key\": \"value\"}'");
+        }
+
+        usage
     }
 
     /// Add parameters section if parameters exist
@@ -218,33 +234,176 @@ impl DocumentationGenerator {
     }
 
     /// Add examples section with command examples
-    fn add_examples_section(
-        help: &mut String,
-        api_name: &str,
-        tag: &str,
-        operation_id: &str,
-        command: &CachedCommand,
-    ) {
-        if command.examples.is_empty() {
-            help.push_str("## Example\n\n");
-            help.push_str(&Self::generate_basic_example(
-                api_name,
-                tag,
-                operation_id,
-                command,
-            ));
-            return;
-        }
+    fn add_examples_section(help: &mut String, api_name: &str, command: &CachedCommand) {
+        let examples = Self::canonical_examples(api_name, command);
 
-        help.push_str("## Examples\n\n");
-        for (i, example) in command.examples.iter().enumerate() {
-            write!(help, "### Example {}\n\n", i + 1).ok();
+        help.push_str(if examples.len() > 1 {
+            "## Examples\n\n"
+        } else {
+            "## Example\n\n"
+        });
+
+        for (i, example) in examples.iter().enumerate() {
+            if examples.len() > 1 {
+                write!(help, "### Example {}\n\n", i + 1).ok();
+            }
             write!(help, "**{}**\n\n", example.description).ok();
             if let Some(ref explanation) = example.explanation {
                 write!(help, "{explanation}\n\n").ok();
             }
             write!(help, "```bash\n{}\n```\n\n", example.command_line).ok();
         }
+    }
+
+    /// Builds canonical examples from the effective runtime command model.
+    #[must_use]
+    pub(crate) fn canonical_examples(
+        api_name: &str,
+        command: &CachedCommand,
+    ) -> Vec<CommandExample> {
+        let base_cmd = Self::base_command(api_name, command);
+        let required_params: Vec<&CachedParameter> =
+            command.parameters.iter().filter(|p| p.required).collect();
+        let optional_query_params: Vec<&CachedParameter> = command
+            .parameters
+            .iter()
+            .filter(|p| !p.required && p.location == "query")
+            .take(2)
+            .collect();
+
+        let mut examples = Vec::new();
+        Self::push_required_parameters_example(&mut examples, &base_cmd, command, &required_params);
+        Self::push_request_body_example(&mut examples, &base_cmd, command, &required_params);
+        Self::push_optional_parameters_example(
+            &mut examples,
+            &base_cmd,
+            &required_params,
+            &optional_query_params,
+        );
+
+        if examples.is_empty() {
+            examples.push(Self::build_basic_example(&base_cmd, command));
+        }
+
+        examples
+    }
+
+    fn push_required_parameters_example(
+        examples: &mut Vec<CommandExample>,
+        base_cmd: &str,
+        command: &CachedCommand,
+        required_params: &[&CachedParameter],
+    ) {
+        if required_params.is_empty() {
+            return;
+        }
+
+        let mut command_line = base_cmd.to_string();
+        for param in required_params {
+            Self::append_example_parameter(&mut command_line, param, "<value>");
+        }
+        examples.push(CommandExample {
+            description: "Basic usage with required parameters".to_string(),
+            command_line,
+            explanation: Some(format!("{} {}", command.method, command.path)),
+        });
+    }
+
+    fn push_request_body_example(
+        examples: &mut Vec<CommandExample>,
+        base_cmd: &str,
+        command: &CachedCommand,
+        required_params: &[&CachedParameter],
+    ) {
+        if command.request_body.is_none() {
+            return;
+        }
+
+        let mut command_line = base_cmd.to_string();
+        for param in required_params
+            .iter()
+            .copied()
+            .filter(|p| p.location == "path" || p.location == "query")
+        {
+            Self::append_example_parameter(&mut command_line, param, "123");
+        }
+        command_line.push_str(" --body '{\"name\": \"example\", \"value\": 42}'");
+
+        examples.push(CommandExample {
+            description: "With request body".to_string(),
+            command_line,
+            explanation: Some("Sends JSON data in the request body".to_string()),
+        });
+    }
+
+    fn push_optional_parameters_example(
+        examples: &mut Vec<CommandExample>,
+        base_cmd: &str,
+        required_params: &[&CachedParameter],
+        optional_query_params: &[&CachedParameter],
+    ) {
+        if required_params.is_empty() || optional_query_params.is_empty() {
+            return;
+        }
+
+        let mut command_line = base_cmd.to_string();
+        for param in required_params {
+            Self::append_example_parameter(&mut command_line, param, "value");
+        }
+        for param in optional_query_params {
+            Self::append_example_parameter(&mut command_line, param, "optional");
+        }
+
+        examples.push(CommandExample {
+            description: "With optional parameters".to_string(),
+            command_line,
+            explanation: Some(
+                "Includes optional query parameters for filtering or customization".to_string(),
+            ),
+        });
+    }
+
+    fn build_basic_example(base_cmd: &str, command: &CachedCommand) -> CommandExample {
+        CommandExample {
+            description: "Basic usage".to_string(),
+            command_line: base_cmd.to_string(),
+            explanation: Some(format!("Executes {} {}", command.method, command.path)),
+        }
+    }
+
+    fn base_command(api_name: &str, command: &CachedCommand) -> String {
+        let group = Self::effective_group(command);
+        let operation = Self::effective_operation(command);
+        format!("aperture api {api_name} {group} {operation}")
+    }
+
+    fn required_parameter_usage_fragment(param: &CachedParameter) -> String {
+        let flag = format!("--{}", to_kebab_case(&param.name));
+        if Self::is_boolean_parameter(param) {
+            return flag;
+        }
+
+        let placeholder = to_kebab_case(&param.name).replace('-', "_").to_uppercase();
+        format!("{flag} <{placeholder}>")
+    }
+
+    fn append_example_parameter(
+        command_line: &mut String,
+        param: &CachedParameter,
+        fallback: &str,
+    ) {
+        write!(command_line, " --{}", to_kebab_case(&param.name)).ok();
+
+        if Self::is_boolean_parameter(param) {
+            return;
+        }
+
+        let value = param.example.as_deref().unwrap_or(fallback);
+        write!(command_line, " {value}").ok();
+    }
+
+    fn is_boolean_parameter(param: &CachedParameter) -> bool {
+        param.schema_type.as_ref().is_some_and(|t| t == "boolean")
     }
 
     /// Add responses section if responses exist
@@ -284,53 +443,6 @@ impl DocumentationGenerator {
 
         if let Some(ref docs_url) = command.external_docs_url {
             write!(help, "📖 **External Documentation**: {docs_url}\n\n").ok();
-        }
-    }
-
-    /// Generate a basic example for a command
-    fn generate_basic_example(
-        api_name: &str,
-        tag: &str,
-        operation_id: &str,
-        command: &CachedCommand,
-    ) -> String {
-        let mut example = format!("```bash\naperture api {api_name} {tag} {operation_id}");
-
-        // Add required parameters
-        for param in &command.parameters {
-            if param.required {
-                let param_type = param.schema_type.as_deref().unwrap_or("string");
-                let example_value = Self::generate_example_value(param_type);
-                write!(
-                    example,
-                    " --{} {}",
-                    to_kebab_case(&param.name),
-                    example_value
-                )
-                .ok();
-            }
-        }
-
-        // Add request body if required
-        match command.request_body {
-            Some(ref body) if body.required => {
-                example.push_str(" --body '{\"key\": \"value\"}'");
-            }
-            _ => {}
-        }
-
-        example.push_str("\n```\n\n");
-        example
-    }
-
-    /// Generate example values for different parameter types
-    fn generate_example_value(param_type: &str) -> &'static str {
-        match param_type.to_lowercase().as_str() {
-            "string" => "\"example\"",
-            "integer" | "number" => "123",
-            "boolean" => "true",
-            "array" => "[\"item1\",\"item2\"]",
-            _ => "\"value\"",
         }
     }
 

--- a/src/engine/generator.rs
+++ b/src/engine/generator.rs
@@ -14,6 +14,7 @@
 
 use crate::cache::models::{CachedCommand, CachedParameter, CachedSpec};
 use crate::constants;
+use crate::docs::DocumentationGenerator;
 use crate::utils::to_kebab_case;
 use clap::{Arg, ArgAction, Command};
 use std::collections::HashMap;
@@ -27,16 +28,17 @@ fn to_static_str(s: String) -> &'static str {
     Box::leak(s.into_boxed_str())
 }
 
-/// Builds help text with examples for a command
-fn build_help_text_with_examples(cached_command: &CachedCommand) -> String {
+/// Builds help text with examples for a command.
+fn build_help_text_with_examples(cached_command: &CachedCommand, api_name: &str) -> String {
     let mut help_text = cached_command.description.clone().unwrap_or_default();
+    let examples = DocumentationGenerator::canonical_examples(api_name, cached_command);
 
-    if cached_command.examples.is_empty() {
+    if examples.is_empty() {
         return help_text;
     }
 
     help_text.push_str("\n\nExamples:");
-    for example in &cached_command.examples {
+    for example in examples {
         write!(
             &mut help_text,
             "\n  {}\n    {}",
@@ -45,7 +47,7 @@ fn build_help_text_with_examples(cached_command: &CachedCommand) -> String {
         .expect("writing to String buffer cannot fail");
 
         // Add explanation if present
-        if let Some(explanation) = example.explanation.as_ref() {
+        if let Some(explanation) = example.explanation {
             write!(&mut help_text, "\n    ({explanation})")
                 .expect("writing to String buffer cannot fail");
         }
@@ -82,6 +84,16 @@ pub fn generate_command_tree(spec: &CachedSpec) -> Command {
 /// Generates a dynamic clap command tree with optional legacy positional parameter syntax.
 #[must_use]
 pub fn generate_command_tree_with_flags(spec: &CachedSpec, use_positional_args: bool) -> Command {
+    generate_command_tree_for_api_with_flags(spec, "<api>", use_positional_args)
+}
+
+/// Generates a dynamic clap command tree with examples tied to the provided API context.
+#[must_use]
+pub fn generate_command_tree_for_api_with_flags(
+    spec: &CachedSpec,
+    api_name: &str,
+    use_positional_args: bool,
+) -> Command {
     let mut root_command = Command::new(constants::CLI_ROOT_COMMAND)
         .version(to_static_str(spec.version.clone()))
         .about(format!("CLI for {} API", spec.name))
@@ -138,7 +150,7 @@ pub fn generate_command_tree_with_flags(spec: &CachedSpec, use_positional_args: 
             let subcommand_name_static = to_static_str(subcommand_name);
 
             // Build help text with examples
-            let help_text = build_help_text_with_examples(cached_command);
+            let help_text = build_help_text_with_examples(cached_command, api_name);
 
             let mut operation_command = Command::new(subcommand_name_static).about(help_text);
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -370,7 +370,7 @@ fn effective_command_path(command: &CachedCommand) -> String {
 
 fn format_param_flag(p: &CachedParameter) -> String {
     let required = if p.required { "*" } else { "" };
-    format!("--{}{}", p.name, required)
+    format!("--{}{}", to_kebab_case(&p.name), required)
 }
 
 /// Format search results for display

--- a/tests/discovery_structured_output_integration_tests.rs
+++ b/tests/discovery_structured_output_integration_tests.rs
@@ -194,7 +194,7 @@ fn docs_support_json_for_all_modes() {
     assert_eq!(op_json["operation"]["name"], "get-user-by-id");
     assert_eq!(
         op_json["operation"]["usage"],
-        "aperture api test-api users get-user-by-id"
+        "aperture api test-api users get-user-by-id --id <ID>"
     );
     assert!(op_json["operation"]["parameters"]
         .as_array()

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -170,6 +170,33 @@ fn test_generate_command_help_with_request_body() {
 }
 
 #[test]
+fn test_request_body_example_includes_all_required_flags() {
+    let mut spec = create_test_spec();
+    spec.commands[1].parameters.push(CachedParameter {
+        name: "traceId".to_string(),
+        location: "header".to_string(),
+        required: true,
+        description: Some("Trace ID".to_string()),
+        schema: None,
+        schema_type: Some("string".to_string()),
+        format: None,
+        default_value: None,
+        enum_values: vec![],
+        example: None,
+    });
+
+    let mut specs = BTreeMap::new();
+    specs.insert("testapi".to_string(), spec);
+
+    let doc_gen = DocumentationGenerator::new(specs);
+    let help = doc_gen
+        .generate_command_help("testapi", "users", "create-user")
+        .unwrap();
+
+    assert!(help.contains("aperture api testapi users create-user --trace-id example --body"));
+}
+
+#[test]
 fn test_generate_api_overview() {
     let mut specs = BTreeMap::new();
     specs.insert("testapi".to_string(), create_test_spec());

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -140,11 +140,11 @@ fn test_generate_command_help() {
     assert!(help.contains("# GET /users/{id}"));
     assert!(help.contains("**Get user by ID**"));
     assert!(help.contains("## Usage"));
-    assert!(help.contains("aperture api testapi users get-user-by-id"));
+    assert!(help.contains("aperture api testapi users get-user-by-id --id <ID>"));
     assert!(help.contains("## Parameters"));
     assert!(help.contains("--id"));
     assert!(help.contains("**(required)**"));
-    assert!(help.contains("## Examples"));
+    assert!(help.contains("## Example"));
     assert!(help.contains("## Responses"));
     assert!(help.contains("**200**: User found successfully"));
     assert!(help.contains("**404**: User not found"));
@@ -328,19 +328,38 @@ fn test_command_help_resolves_and_displays_mapped_names() {
     let help = doc_gen
         .generate_command_help("testapi", "accounts", "fetch")
         .unwrap();
-    assert!(help.contains("aperture api testapi accounts fetch"));
+    assert!(help.contains("aperture api testapi accounts fetch --id <ID>"));
 
     // Aliases should resolve too.
     let help_by_alias = doc_gen
         .generate_command_help("testapi", "accounts", "get")
         .unwrap();
-    assert!(help_by_alias.contains("aperture api testapi accounts fetch"));
+    assert!(help_by_alias.contains("aperture api testapi accounts fetch --id <ID>"));
 
     // Legacy names still resolve, but output should show effective mapped path.
     let help_legacy = doc_gen
         .generate_command_help("testapi", "users", "get-user-by-id")
         .unwrap();
-    assert!(help_legacy.contains("aperture api testapi accounts fetch"));
+    assert!(help_legacy.contains("aperture api testapi accounts fetch --id <ID>"));
+}
+
+#[test]
+fn test_command_help_examples_use_effective_names_and_kebab_flags() {
+    let mut spec = create_test_spec();
+    spec.commands[0].parameters[0].name = "userId".to_string();
+    spec.commands[0].display_group = Some("Accounts".to_string());
+    spec.commands[0].display_name = Some("Fetch".to_string());
+
+    let mut specs = BTreeMap::new();
+    specs.insert("testapi".to_string(), spec);
+
+    let doc_gen = DocumentationGenerator::new(specs);
+    let help = doc_gen
+        .generate_command_help("testapi", "accounts", "fetch")
+        .unwrap();
+
+    assert!(help.contains("aperture api testapi accounts fetch --user-id <USER_ID>"));
+    assert!(!help.contains("--userId"));
 }
 
 #[test]

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -359,7 +359,9 @@ fn test_command_help_examples_use_effective_names_and_kebab_flags() {
         .unwrap();
 
     assert!(help.contains("aperture api testapi accounts fetch --user-id <USER_ID>"));
+    assert!(help.contains("aperture api testapi accounts fetch --user-id example"));
     assert!(!help.contains("--userId"));
+    assert!(!help.contains("--user-id <value>"));
 }
 
 #[test]

--- a/tests/engine_generator_tests.rs
+++ b/tests/engine_generator_tests.rs
@@ -478,7 +478,7 @@ fn test_help_examples_use_effective_context_and_kebab_flags() {
         .map(std::string::ToString::to_string)
         .unwrap_or_default();
 
-    assert!(about.contains("aperture api test-api accounts fetch --user-id <value>"));
+    assert!(about.contains("aperture api test-api accounts fetch --user-id example"));
     assert!(!about.contains("--userId"));
 }
 

--- a/tests/engine_generator_tests.rs
+++ b/tests/engine_generator_tests.rs
@@ -2,7 +2,9 @@ use aperture_cli::cache::models::{
     CachedCommand, CachedParameter, CachedRequestBody, CachedResponse, CachedSpec, PaginationInfo,
 };
 use aperture_cli::constants;
-use aperture_cli::engine::generator::generate_command_tree;
+use aperture_cli::engine::generator::{
+    generate_command_tree, generate_command_tree_for_api_with_flags,
+};
 use std::collections::HashMap;
 
 // Helper macros for creating test data with default values
@@ -446,6 +448,38 @@ fn test_hidden_command_not_visible() {
     let group = command.get_subcommands().next().unwrap();
     let op = group.get_subcommands().next().unwrap();
     assert!(op.is_hide_set(), "Expected command to be hidden");
+}
+
+#[test]
+fn test_help_examples_use_effective_context_and_kebab_flags() {
+    let mut spec = empty_spec("mapping-test");
+    let mut cmd = cached_command!(
+        "User Management",
+        "getUserById",
+        "GET",
+        "/users/{id}",
+        vec![cached_parameter!("userId", "path", true)],
+        None,
+        vec![]
+    );
+    cmd.display_group = Some("accounts".to_string());
+    cmd.display_name = Some("fetch".to_string());
+    spec.commands.push(cmd);
+
+    let command = generate_command_tree_for_api_with_flags(&spec, "test-api", false);
+    let group = command
+        .find_subcommand("accounts")
+        .expect("accounts group should exist");
+    let operation = group
+        .find_subcommand("fetch")
+        .expect("fetch operation should exist");
+    let about = operation
+        .get_about()
+        .map(std::string::ToString::to_string)
+        .unwrap_or_default();
+
+    assert!(about.contains("aperture api test-api accounts fetch --user-id <value>"));
+    assert!(!about.contains("--userId"));
 }
 
 #[test]

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -277,6 +277,22 @@ fn test_format_search_results() {
 }
 
 #[test]
+fn test_search_verbose_parameters_use_kebab_case_flags() {
+    let searcher = CommandSearcher::new();
+    let mut spec = create_test_spec("test-api");
+    spec.commands[0].parameters[0].name = "userId".to_string();
+
+    let mut specs = BTreeMap::new();
+    specs.insert("test-api".to_string(), spec);
+
+    let results = searcher.search(&specs, "getUser", None).unwrap();
+    let output = format_search_results(&results, true);
+
+    assert!(output.iter().any(|line| line.contains("--user-id*")));
+    assert!(!output.iter().any(|line| line.contains("--userId")));
+}
+
+#[test]
 fn test_empty_search_results() {
     let results = vec![];
     let output = format_search_results(&results, false);


### PR DESCRIPTION
## Summary
- generate canonical docs usage and examples from effective command metadata
- include required flags in usage output and normalize flags to kebab-case across docs/search/example rendering
- make runtime help and --show-examples render context-aware canonical examples that respect command mappings

Closes #135

## Validation
- cargo test
- cargo fmt --check
- cargo clippy