### PR TITLE
feat: add shell completion for static and dynamic command surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Generate shell completion scripts:
 aperture completion bash
 aperture completion zsh
 aperture completion fish
+aperture completion nu
 aperture completion powershell
 ```
 
@@ -116,6 +117,11 @@ aperture completion zsh > ~/.zfunc/_aperture
 
 # fish
 aperture completion fish > ~/.config/fish/completions/aperture.fish
+
+# Nushell
+aperture completion nu > ~/.config/nushell/completions/aperture.nu
+# then add this to ~/.config/nushell/config.nu if not already sourced:
+source ~/.config/nushell/completions/aperture.nu
 
 # PowerShell (current user profile)
 aperture completion powershell | Out-String | Invoke-Expression

--- a/README.md
+++ b/README.md
@@ -93,6 +93,46 @@ Stable top-level JSON shapes:
 - `docs <api> <tag> <operation> --format json` → `{ mode: "operation", api, operation }`
 - `config api list --json` → `[{ name, ... }]` (verbose mode adds version/endpoint detail)
 
+## Shell Completion
+
+Generate shell completion scripts:
+
+```bash
+aperture completion bash
+aperture completion zsh
+aperture completion fish
+aperture completion powershell
+```
+
+Install examples:
+
+```bash
+# bash
+aperture completion bash > ~/.local/share/bash-completion/completions/aperture
+
+# zsh
+mkdir -p ~/.zfunc
+aperture completion zsh > ~/.zfunc/_aperture
+
+# fish
+aperture completion fish > ~/.config/fish/completions/aperture.fish
+
+# PowerShell (current user profile)
+aperture completion powershell | Out-String | Invoke-Expression
+```
+
+Completion covers:
+
+- static top-level and `config` command paths,
+- configured context names,
+- dynamic `api <context> <group> <operation>` names,
+- operation flags derived from cached specs.
+
+Trade-offs:
+
+- dynamic suggestions come from local cached specs, so run `aperture config api add` / `aperture config api reinit` after spec changes,
+- value completion is not provided for parameter values (only command/flag names).
+
 ## Agent Integration
 
 Aperture provides features specifically for programmatic use:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -60,6 +60,7 @@ Aperture can generate completion scripts for major shells:
 aperture completion bash
 aperture completion zsh
 aperture completion fish
+aperture completion nu
 aperture completion powershell
 ```
 
@@ -75,6 +76,11 @@ aperture completion zsh > ~/.zfunc/_aperture
 
 # fish
 aperture completion fish > ~/.config/fish/completions/aperture.fish
+
+# Nushell
+aperture completion nu > ~/.config/nushell/completions/aperture.nu
+# then add this to ~/.config/nushell/config.nu if not already sourced:
+source ~/.config/nushell/completions/aperture.nu
 
 # PowerShell
 aperture completion powershell | Out-String | Invoke-Expression

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -52,6 +52,45 @@ Top-level response shapes are stable for scripting:
 - `docs <api> <tag> <operation> --format json` → `{ mode: "operation", api, operation }`
 - `config api list --json` → `[{ name, ... }]` (`--verbose` adds endpoint details)
 
+### Shell Completion
+
+Aperture can generate completion scripts for major shells:
+
+```bash
+aperture completion bash
+aperture completion zsh
+aperture completion fish
+aperture completion powershell
+```
+
+Install generated scripts:
+
+```bash
+# bash
+aperture completion bash > ~/.local/share/bash-completion/completions/aperture
+
+# zsh
+mkdir -p ~/.zfunc
+aperture completion zsh > ~/.zfunc/_aperture
+
+# fish
+aperture completion fish > ~/.config/fish/completions/aperture.fish
+
+# PowerShell
+aperture completion powershell | Out-String | Invoke-Expression
+```
+
+Completion behavior:
+
+- completes static top-level and `config` command paths,
+- completes configured API context names,
+- completes dynamic groups, operations, and operation flags under `aperture api <context> ...`.
+
+Known trade-offs:
+
+- dynamic suggestions are driven by local cached specs; refresh cache after spec updates,
+- completion suggests command/flag names, not parameter values.
+
 ### 3. Execute Commands
 
 ```bash

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -55,7 +55,7 @@ const API_EXECUTION_FLAGS: &[&str] = &[
     "--force-retry",
 ];
 
-const API_EXECUTION_FLAGS_WITH_VALUES: &[&str] = &[
+const API_PREFIX_FLAGS_WITH_VALUES: &[&str] = &[
     "--idempotency-key",
     "--format",
     "--jq",
@@ -141,17 +141,37 @@ fn is_binary_name(word: &str) -> bool {
 }
 
 fn complete_words(input: &CompletionInput, catalog: &CompletionCatalog) -> Vec<String> {
-    let Some(command) = input.before_cursor.first().map(String::as_str) else {
+    let before_cursor = strip_leading_global_flags(&input.before_cursor);
+
+    let Some(command) = before_cursor.first().map(String::as_str) else {
         return filter_candidates(top_level_candidates(), &input.current);
     };
 
-    let args_after_command = &input.before_cursor[1..];
+    let args_after_command = strip_leading_global_flags(&before_cursor[1..]);
 
     if let Some(primary) = complete_primary_command(command, args_after_command, input, catalog) {
         return primary;
     }
 
     complete_secondary_command(command, args_after_command, input, catalog)
+}
+
+fn strip_leading_global_flags(tokens: &[String]) -> &[String] {
+    let mut index = 0;
+
+    while tokens
+        .get(index)
+        .is_some_and(|token| is_global_flag_token(token))
+    {
+        index += 1;
+    }
+
+    &tokens[index..]
+}
+
+fn is_global_flag_token(token: &str) -> bool {
+    GLOBAL_FLAGS.iter().any(|flag| flag == &token)
+        || (token.starts_with('-') && token.chars().skip(1).all(|ch| ch == 'v'))
 }
 
 fn complete_primary_command(
@@ -470,7 +490,7 @@ fn api_execution_flag_step(token: &str) -> usize {
         return 1;
     }
 
-    if API_EXECUTION_FLAGS_WITH_VALUES
+    if API_PREFIX_FLAGS_WITH_VALUES
         .iter()
         .any(|flag| flag == &token)
     {

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -1,0 +1,22 @@
+use crate::cli::CompletionShell;
+use crate::error::Error;
+
+pub fn execute_completion_script_command(shell: &CompletionShell) -> Result<(), Error> {
+    let _ = shell;
+    Err(Error::invalid_command(
+        "completion",
+        "completion script generation is not implemented",
+    ))
+}
+
+pub fn execute_completion_runtime_command(
+    shell: &CompletionShell,
+    cword: usize,
+    words: &[String],
+) -> Result<(), Error> {
+    let _ = (shell, cword, words);
+    Err(Error::invalid_command(
+        "completion",
+        "runtime completion is not implemented",
+    ))
+}

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -707,10 +707,11 @@ compdef _aperture_completion aperture
 fn fish_completion_script() -> String {
     r#"function __aperture_complete
     set -l words (commandline -opc)
-    set -l cword (math (count $words) - 1)
+    set -l current (commandline -ct)
+    set -l cword (count $words)
 
-    if test $cword -lt 0
-        set cword 0
+    if test -n "$current"
+        set words $words $current
     end
 
     aperture __complete fish $cword $words 2>/dev/null
@@ -762,7 +763,16 @@ fn powershell_completion_script() -> String {
         return
     }
 
-    $cword = $words.Count - 1
+    if ([string]::IsNullOrEmpty($wordToComplete)) {
+        $cword = $words.Count
+    } else {
+        if ($words[-1] -ne $wordToComplete) {
+            $words += $wordToComplete
+        }
+
+        $cword = $words.Count - 1
+    }
+
     $results = aperture __complete powershell $cword @words 2>$null
 
     foreach ($result in $results) {

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -297,6 +297,8 @@ fn complete_docs(args: &[String], current: &str, catalog: &CompletionCatalog) ->
 }
 
 fn complete_config(args: &[String], current: &str, catalog: &CompletionCatalog) -> Vec<String> {
+    let args = strip_leading_option_tokens(args);
+
     let Some(domain) = args.first().map(String::as_str) else {
         return filter_candidates(CONFIG_DOMAINS.iter().map(ToString::to_string), current);
     };
@@ -315,6 +317,8 @@ fn complete_config(args: &[String], current: &str, catalog: &CompletionCatalog) 
 }
 
 fn complete_config_api(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let args = strip_leading_option_tokens(args);
+
     let Some(command) = args.first().map(String::as_str) else {
         return filter_candidates(CONFIG_API_COMMANDS.iter().map(ToString::to_string), current);
     };
@@ -338,6 +342,8 @@ fn complete_config_api(args: &[String], current: &str, contexts: &[String]) -> V
 }
 
 fn complete_config_url(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let args = strip_leading_option_tokens(args);
+
     let Some(command) = args.first().map(String::as_str) else {
         return filter_candidates(CONFIG_URL_COMMANDS.iter().map(ToString::to_string), current);
     };
@@ -349,6 +355,8 @@ fn complete_config_url(args: &[String], current: &str, contexts: &[String]) -> V
 }
 
 fn complete_config_secret(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let args = strip_leading_option_tokens(args);
+
     let Some(command) = args.first().map(String::as_str) else {
         return filter_candidates(
             CONFIG_SECRET_COMMANDS.iter().map(ToString::to_string),
@@ -365,6 +373,8 @@ fn complete_config_secret(args: &[String], current: &str, contexts: &[String]) -
 }
 
 fn complete_config_cache(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let args = strip_leading_option_tokens(args);
+
     let Some(command) = args.first().map(String::as_str) else {
         return filter_candidates(
             CONFIG_CACHE_COMMANDS.iter().map(ToString::to_string),
@@ -391,6 +401,8 @@ fn complete_config_cache(args: &[String], current: &str, contexts: &[String]) ->
 }
 
 fn complete_config_setting(args: &[String], current: &str) -> Vec<String> {
+    let args = strip_leading_option_tokens(args);
+
     if args.is_empty() {
         return filter_candidates(
             CONFIG_SETTING_COMMANDS.iter().map(ToString::to_string),
@@ -402,6 +414,8 @@ fn complete_config_setting(args: &[String], current: &str) -> Vec<String> {
 }
 
 fn complete_config_mapping(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let args = strip_leading_option_tokens(args);
+
     let Some(command) = args.first().map(String::as_str) else {
         return filter_candidates(
             CONFIG_MAPPING_COMMANDS.iter().map(ToString::to_string),
@@ -420,7 +434,11 @@ fn complete_when_only_subcommand_token(
     current: &str,
     contexts: &[String],
 ) -> Vec<String> {
-    if args.len() == 1 {
+    let remaining = args
+        .split_first()
+        .map_or(&[][..], |(_, rest)| strip_leading_option_tokens(rest));
+
+    if remaining.is_empty() {
         return filter_candidates(contexts.iter().cloned(), current);
     }
 

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -66,6 +66,7 @@ const API_PREFIX_FLAGS_WITH_VALUES: &[&str] = &[
     "--retry",
     "--retry-delay",
     "--retry-max-delay",
+    "--server-var",
 ];
 
 const API_DYNAMIC_GLOBAL_FLAGS: &[&str] = &["--help", "--jq", "--format", "--server-var"];

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -32,7 +32,7 @@ const CONFIG_CACHE_COMMANDS: &[&str] = &["clear", "stats"];
 const CONFIG_SETTING_COMMANDS: &[&str] = &["set", "get", "list"];
 const CONFIG_MAPPING_COMMANDS: &[&str] = &["set", "list", "remove"];
 
-const SHELL_NAMES: &[&str] = &["bash", "zsh", "fish", "powershell"];
+const SHELL_NAMES: &[&str] = &["bash", "zsh", "fish", "nu", "powershell"];
 
 const API_EXECUTION_FLAGS: &[&str] = &[
     "--help",
@@ -92,6 +92,7 @@ pub fn execute_completion_script_command(shell: &CompletionShell) -> Result<(), 
         CompletionShell::Bash => bash_completion_script(),
         CompletionShell::Zsh => zsh_completion_script(),
         CompletionShell::Fish => fish_completion_script(),
+        CompletionShell::Nu => nu_completion_script(),
         CompletionShell::PowerShell => powershell_completion_script(),
     };
 
@@ -664,6 +665,38 @@ fn fish_completion_script() -> String {
 end
 
 complete -c aperture -f -a "(__aperture_complete)"
+"#
+    .to_string()
+}
+
+fn nu_completion_script() -> String {
+    r#"let previous_aperture_completer = (try {
+    $env.config.completions.external.completer
+} catch {
+    null
+})
+
+let aperture_completer = {|spans|
+    if ($spans | is-empty) {
+        return []
+    }
+
+    if $spans.0 == "aperture" {
+        ^aperture __complete nu (($spans | length) - 1) ...$spans
+        | lines
+        | where {|line| $line != "" }
+        | each {|line| { value: $line, description: "" } }
+    } else if $previous_aperture_completer != null {
+        do $previous_aperture_completer $spans
+    } else {
+        []
+    }
+}
+
+$env.config = ($env.config
+    | upsert completions.external.enable true
+    | upsert completions.external.completer $aperture_completer
+)
 "#
     .to_string()
 }

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -142,7 +142,7 @@ fn is_binary_name(word: &str) -> bool {
 }
 
 fn complete_words(input: &CompletionInput, catalog: &CompletionCatalog) -> Vec<String> {
-    let before_cursor = strip_leading_global_flags(&input.before_cursor);
+    let before_cursor = strip_leading_option_tokens(&input.before_cursor);
 
     let Some(command) = before_cursor.first().map(String::as_str) else {
         return filter_candidates(top_level_candidates(), &input.current);
@@ -155,6 +155,19 @@ fn complete_words(input: &CompletionInput, catalog: &CompletionCatalog) -> Vec<S
     }
 
     complete_secondary_command(command, args_after_command, input, catalog)
+}
+
+fn strip_leading_option_tokens(tokens: &[String]) -> &[String] {
+    let mut index = 0;
+
+    while tokens
+        .get(index)
+        .is_some_and(|token| token.starts_with('-'))
+    {
+        index += 1;
+    }
+
+    &tokens[index..]
 }
 
 fn strip_leading_global_flags(tokens: &[String]) -> &[String] {

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -1,22 +1,689 @@
+use crate::cache::models::{CachedCommand, CachedSpec};
 use crate::cli::CompletionShell;
+use crate::config::manager::{get_config_dir, ConfigManager};
+use crate::constants;
+use crate::engine::loader;
 use crate::error::Error;
+use crate::fs::OsFileSystem;
+use crate::utils::to_kebab_case;
+use std::collections::{BTreeSet, HashMap};
+use std::path::PathBuf;
+
+const TOP_LEVEL_COMMANDS: &[&str] = &[
+    "completion",
+    "config",
+    "commands",
+    "list-commands",
+    "api",
+    "search",
+    "run",
+    "exec",
+    "docs",
+    "overview",
+];
+
+const GLOBAL_FLAGS: &[&str] = &["--help", "--json-errors", "--quiet", "-q", "-v"];
+
+const CONFIG_DOMAINS: &[&str] = &["api", "url", "secret", "cache", "setting", "mapping"];
+const CONFIG_API_COMMANDS: &[&str] = &["add", "list", "remove", "edit", "reinit"];
+const CONFIG_URL_COMMANDS: &[&str] = &["set", "get", "list"];
+const CONFIG_SECRET_COMMANDS: &[&str] = &["set", "list", "remove", "clear"];
+const CONFIG_CACHE_COMMANDS: &[&str] = &["clear", "stats"];
+const CONFIG_SETTING_COMMANDS: &[&str] = &["set", "get", "list"];
+const CONFIG_MAPPING_COMMANDS: &[&str] = &["set", "list", "remove"];
+
+const SHELL_NAMES: &[&str] = &["bash", "zsh", "fish", "powershell"];
+
+const API_EXECUTION_FLAGS: &[&str] = &[
+    "--help",
+    "--describe-json",
+    "--dry-run",
+    "--idempotency-key",
+    "--format",
+    "--jq",
+    "--batch-file",
+    "--batch-concurrency",
+    "--batch-rate-limit",
+    "--cache",
+    "--no-cache",
+    "--cache-ttl",
+    "--positional-args",
+    "--auto-paginate",
+    "--retry",
+    "--retry-delay",
+    "--retry-max-delay",
+    "--force-retry",
+];
+
+const API_EXECUTION_FLAGS_WITH_VALUES: &[&str] = &[
+    "--idempotency-key",
+    "--format",
+    "--jq",
+    "--batch-file",
+    "--batch-concurrency",
+    "--batch-rate-limit",
+    "--cache-ttl",
+    "--retry",
+    "--retry-delay",
+    "--retry-max-delay",
+];
+
+const API_DYNAMIC_GLOBAL_FLAGS: &[&str] = &["--help", "--jq", "--format", "--server-var"];
+
+#[derive(Default)]
+struct CompletionCatalog {
+    contexts: Vec<String>,
+    specs: HashMap<String, CachedSpec>,
+}
+
+struct CompletionInput {
+    before_cursor: Vec<String>,
+    current: String,
+}
+
+#[derive(Default)]
+struct ApiCompletionState {
+    context: Option<String>,
+    dynamic_path: Vec<String>,
+}
 
 pub fn execute_completion_script_command(shell: &CompletionShell) -> Result<(), Error> {
-    let _ = shell;
-    Err(Error::invalid_command(
-        "completion",
-        "completion script generation is not implemented",
-    ))
+    let script = match shell {
+        CompletionShell::Bash => bash_completion_script(),
+        CompletionShell::Zsh => zsh_completion_script(),
+        CompletionShell::Fish => fish_completion_script(),
+        CompletionShell::PowerShell => powershell_completion_script(),
+    };
+
+    // ast-grep-ignore: no-println
+    println!("{script}");
+    Ok(())
 }
 
 pub fn execute_completion_runtime_command(
-    shell: &CompletionShell,
+    _shell: &CompletionShell,
     cword: usize,
     words: &[String],
 ) -> Result<(), Error> {
-    let _ = (shell, cword, words);
-    Err(Error::invalid_command(
-        "completion",
-        "runtime completion is not implemented",
-    ))
+    let catalog = load_completion_catalog().unwrap_or_default();
+    let input = normalize_completion_input(words, cword);
+    let suggestions = complete_words(&input, &catalog);
+
+    for suggestion in suggestions {
+        // ast-grep-ignore: no-println
+        println!("{suggestion}");
+    }
+
+    Ok(())
+}
+
+fn normalize_completion_input(words: &[String], cword: usize) -> CompletionInput {
+    let (trimmed_words, adjusted_cword) = if words.first().is_some_and(|word| is_binary_name(word))
+    {
+        (&words[1..], cword.saturating_sub(1))
+    } else {
+        (words, cword)
+    };
+
+    let safe_cursor = adjusted_cword.min(trimmed_words.len());
+    let current = trimmed_words.get(safe_cursor).cloned().unwrap_or_default();
+    let before_cursor = trimmed_words[..safe_cursor].to_vec();
+
+    CompletionInput {
+        before_cursor,
+        current,
+    }
+}
+
+fn is_binary_name(word: &str) -> bool {
+    word == "aperture" || word.ends_with("/aperture")
+}
+
+fn complete_words(input: &CompletionInput, catalog: &CompletionCatalog) -> Vec<String> {
+    let Some(command) = input.before_cursor.first().map(String::as_str) else {
+        return filter_candidates(top_level_candidates(), &input.current);
+    };
+
+    let args_after_command = &input.before_cursor[1..];
+
+    if let Some(primary) = complete_primary_command(command, args_after_command, input, catalog) {
+        return primary;
+    }
+
+    complete_secondary_command(command, args_after_command, input, catalog)
+}
+
+fn complete_primary_command(
+    command: &str,
+    args_after_command: &[String],
+    input: &CompletionInput,
+    catalog: &CompletionCatalog,
+) -> Option<Vec<String>> {
+    match command {
+        "completion" => Some(filter_candidates(
+            SHELL_NAMES.iter().map(ToString::to_string),
+            &input.current,
+        )),
+        "config" => Some(complete_config(args_after_command, &input.current, catalog)),
+        "commands" | "list-commands" => Some(complete_single_context_argument(
+            args_after_command,
+            &input.current,
+            &catalog.contexts,
+        )),
+        "api" => Some(complete_api(args_after_command, &input.current, catalog)),
+        _ => None,
+    }
+}
+
+fn complete_secondary_command(
+    command: &str,
+    args_after_command: &[String],
+    input: &CompletionInput,
+    catalog: &CompletionCatalog,
+) -> Vec<String> {
+    match command {
+        "docs" => complete_docs(args_after_command, &input.current, catalog),
+        "overview" => complete_overview(args_after_command, &input.current, &catalog.contexts),
+        "search" => complete_search(args_after_command, &input.current, &catalog.contexts),
+        "run" | "exec" => complete_run(args_after_command, &input.current, &catalog.contexts),
+        _ => Vec::new(),
+    }
+}
+
+fn top_level_candidates() -> impl Iterator<Item = String> {
+    TOP_LEVEL_COMMANDS
+        .iter()
+        .chain(GLOBAL_FLAGS.iter())
+        .map(ToString::to_string)
+}
+
+fn complete_single_context_argument(
+    args: &[String],
+    current: &str,
+    contexts: &[String],
+) -> Vec<String> {
+    if args.is_empty() {
+        return filter_candidates(contexts.iter().cloned(), current);
+    }
+
+    Vec::new()
+}
+
+fn complete_overview(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    if args.is_empty() {
+        return filter_candidates(
+            contexts
+                .iter()
+                .cloned()
+                .chain(std::iter::once("--all".to_string())),
+            current,
+        );
+    }
+
+    Vec::new()
+}
+
+fn complete_search(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    if args.last().is_some_and(|arg| arg == "--api") {
+        return filter_candidates(contexts.iter().cloned(), current);
+    }
+
+    Vec::new()
+}
+
+fn complete_run(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    if args.last().is_some_and(|arg| arg == "--api") {
+        return filter_candidates(contexts.iter().cloned(), current);
+    }
+
+    Vec::new()
+}
+
+fn complete_docs(args: &[String], current: &str, catalog: &CompletionCatalog) -> Vec<String> {
+    if args.is_empty() {
+        return filter_candidates(catalog.contexts.iter().cloned(), current);
+    }
+
+    let Some(context) = args.first() else {
+        return Vec::new();
+    };
+    let Some(spec) = catalog.specs.get(context) else {
+        return Vec::new();
+    };
+
+    if args.len() == 1 {
+        return filter_candidates(group_names(spec), current);
+    }
+    if args.len() == 2 {
+        return filter_candidates(operation_names_for_group(spec, &args[1]), current);
+    }
+
+    Vec::new()
+}
+
+fn complete_config(args: &[String], current: &str, catalog: &CompletionCatalog) -> Vec<String> {
+    let Some(domain) = args.first().map(String::as_str) else {
+        return filter_candidates(CONFIG_DOMAINS.iter().map(ToString::to_string), current);
+    };
+
+    let rest = &args[1..];
+
+    match domain {
+        "api" => complete_config_api(rest, current, &catalog.contexts),
+        "url" => complete_config_url(rest, current, &catalog.contexts),
+        "secret" => complete_config_secret(rest, current, &catalog.contexts),
+        "cache" => complete_config_cache(rest, current, &catalog.contexts),
+        "setting" => complete_config_setting(rest, current),
+        "mapping" => complete_config_mapping(rest, current, &catalog.contexts),
+        _ => Vec::new(),
+    }
+}
+
+fn complete_config_api(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let Some(command) = args.first().map(String::as_str) else {
+        return filter_candidates(CONFIG_API_COMMANDS.iter().map(ToString::to_string), current);
+    };
+
+    match command {
+        "remove" | "edit" => complete_when_only_subcommand_token(args, current, contexts),
+        "reinit" => {
+            if args.len() == 1 {
+                return filter_candidates(
+                    contexts
+                        .iter()
+                        .cloned()
+                        .chain(std::iter::once("--all".to_string())),
+                    current,
+                );
+            }
+            Vec::new()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn complete_config_url(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let Some(command) = args.first().map(String::as_str) else {
+        return filter_candidates(CONFIG_URL_COMMANDS.iter().map(ToString::to_string), current);
+    };
+
+    match command {
+        "set" | "get" => complete_when_only_subcommand_token(args, current, contexts),
+        _ => Vec::new(),
+    }
+}
+
+fn complete_config_secret(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let Some(command) = args.first().map(String::as_str) else {
+        return filter_candidates(
+            CONFIG_SECRET_COMMANDS.iter().map(ToString::to_string),
+            current,
+        );
+    };
+
+    match command {
+        "set" | "list" | "remove" | "clear" => {
+            complete_when_only_subcommand_token(args, current, contexts)
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn complete_config_cache(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let Some(command) = args.first().map(String::as_str) else {
+        return filter_candidates(
+            CONFIG_CACHE_COMMANDS.iter().map(ToString::to_string),
+            current,
+        );
+    };
+
+    match command {
+        "clear" => {
+            if args.len() == 1 {
+                return filter_candidates(
+                    contexts
+                        .iter()
+                        .cloned()
+                        .chain(std::iter::once("--all".to_string())),
+                    current,
+                );
+            }
+            Vec::new()
+        }
+        "stats" => complete_when_only_subcommand_token(args, current, contexts),
+        _ => Vec::new(),
+    }
+}
+
+fn complete_config_setting(args: &[String], current: &str) -> Vec<String> {
+    if args.is_empty() {
+        return filter_candidates(
+            CONFIG_SETTING_COMMANDS.iter().map(ToString::to_string),
+            current,
+        );
+    }
+
+    Vec::new()
+}
+
+fn complete_config_mapping(args: &[String], current: &str, contexts: &[String]) -> Vec<String> {
+    let Some(command) = args.first().map(String::as_str) else {
+        return filter_candidates(
+            CONFIG_MAPPING_COMMANDS.iter().map(ToString::to_string),
+            current,
+        );
+    };
+
+    match command {
+        "set" | "list" | "remove" => complete_when_only_subcommand_token(args, current, contexts),
+        _ => Vec::new(),
+    }
+}
+
+fn complete_when_only_subcommand_token(
+    args: &[String],
+    current: &str,
+    contexts: &[String],
+) -> Vec<String> {
+    if args.len() == 1 {
+        return filter_candidates(contexts.iter().cloned(), current);
+    }
+
+    Vec::new()
+}
+
+fn complete_api(args: &[String], current: &str, catalog: &CompletionCatalog) -> Vec<String> {
+    let state = parse_api_completion_state(args);
+
+    let Some(context) = state.context.as_deref() else {
+        return filter_candidates(
+            catalog
+                .contexts
+                .iter()
+                .cloned()
+                .chain(API_EXECUTION_FLAGS.iter().map(ToString::to_string)),
+            current,
+        );
+    };
+
+    let Some(spec) = catalog.specs.get(context) else {
+        return Vec::new();
+    };
+
+    if state.dynamic_path.is_empty() {
+        return filter_candidates(
+            group_names(spec)
+                .into_iter()
+                .chain(API_EXECUTION_FLAGS.iter().map(ToString::to_string)),
+            current,
+        );
+    }
+
+    let Some(group) = state.dynamic_path.first() else {
+        return Vec::new();
+    };
+
+    if state.dynamic_path.len() == 1 {
+        return filter_candidates(operation_names_for_group(spec, group), current);
+    }
+
+    let Some(operation) = state.dynamic_path.get(1) else {
+        return Vec::new();
+    };
+
+    filter_candidates(operation_flags(spec, group, operation), current)
+}
+
+fn parse_api_completion_state(args: &[String]) -> ApiCompletionState {
+    let mut state = ApiCompletionState::default();
+    let mut index = 0;
+
+    while index < args.len() {
+        let token = &args[index];
+
+        if state.context.is_none() && token.starts_with('-') {
+            index += api_execution_flag_step(token);
+            continue;
+        }
+
+        if state.context.is_none() {
+            state.context = Some(token.clone());
+            index += 1;
+            continue;
+        }
+
+        if state.dynamic_path.is_empty() && token.starts_with('-') {
+            index += api_execution_flag_step(token);
+            continue;
+        }
+
+        state.dynamic_path.push(token.clone());
+        index += 1;
+    }
+
+    state
+}
+
+fn api_execution_flag_step(token: &str) -> usize {
+    if token.contains('=') {
+        return 1;
+    }
+
+    if API_EXECUTION_FLAGS_WITH_VALUES
+        .iter()
+        .any(|flag| flag == &token)
+    {
+        return 2;
+    }
+
+    1
+}
+
+fn group_names(spec: &CachedSpec) -> Vec<String> {
+    spec.commands
+        .iter()
+        .filter(|command| !command.hidden)
+        .map(effective_group_name)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn operation_names_for_group(spec: &CachedSpec, group: &str) -> Vec<String> {
+    spec.commands
+        .iter()
+        .filter(|command| !command.hidden && effective_group_name(command) == group)
+        .flat_map(|command| {
+            std::iter::once(effective_operation_name(command))
+                .chain(command.aliases.iter().map(|alias| to_kebab_case(alias)))
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn operation_flags(spec: &CachedSpec, group: &str, operation: &str) -> Vec<String> {
+    let Some(command) = find_command_for_operation(spec, group, operation) else {
+        return Vec::new();
+    };
+
+    let mut flags = command
+        .parameters
+        .iter()
+        .map(|parameter| format!("--{}", to_kebab_case(&parameter.name)))
+        .collect::<BTreeSet<_>>();
+
+    if command.request_body.is_some() {
+        flags.insert("--body".to_string());
+        flags.insert("--body-file".to_string());
+    }
+
+    flags.insert("--header".to_string());
+    flags.insert("-H".to_string());
+    flags.insert("--show-examples".to_string());
+
+    for flag in API_DYNAMIC_GLOBAL_FLAGS {
+        flags.insert((*flag).to_string());
+    }
+
+    flags.into_iter().collect()
+}
+
+fn find_command_for_operation<'a>(
+    spec: &'a CachedSpec,
+    group: &str,
+    operation: &str,
+) -> Option<&'a CachedCommand> {
+    spec.commands.iter().find(|command| {
+        if command.hidden || effective_group_name(command) != group {
+            return false;
+        }
+
+        if effective_operation_name(command) == operation {
+            return true;
+        }
+
+        command
+            .aliases
+            .iter()
+            .map(|alias| to_kebab_case(alias))
+            .any(|alias| alias == operation)
+    })
+}
+
+fn effective_group_name(command: &CachedCommand) -> String {
+    command.display_group.as_ref().map_or_else(
+        || {
+            if command.name.is_empty() {
+                constants::DEFAULT_GROUP.to_string()
+            } else {
+                to_kebab_case(&command.name)
+            }
+        },
+        |display_group| to_kebab_case(display_group),
+    )
+}
+
+fn effective_operation_name(command: &CachedCommand) -> String {
+    command.display_name.as_ref().map_or_else(
+        || {
+            if command.operation_id.is_empty() {
+                command.method.to_lowercase()
+            } else {
+                to_kebab_case(&command.operation_id)
+            }
+        },
+        |display_name| to_kebab_case(display_name),
+    )
+}
+
+fn filter_candidates<I>(candidates: I, current: &str) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    candidates
+        .into_iter()
+        .filter(|candidate| current.is_empty() || candidate.starts_with(current))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn load_completion_catalog() -> Result<CompletionCatalog, Error> {
+    let manager = build_manager()?;
+
+    let mut contexts = manager.list_specs()?;
+    contexts.sort_unstable();
+
+    let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
+    let specs = contexts
+        .iter()
+        .filter_map(|context| {
+            loader::load_cached_spec(&cache_dir, context)
+                .ok()
+                .map(|spec| (context.clone(), spec))
+        })
+        .collect();
+
+    Ok(CompletionCatalog { contexts, specs })
+}
+
+fn build_manager() -> Result<ConfigManager<OsFileSystem>, Error> {
+    if let Ok(config_dir) = std::env::var(constants::ENV_APERTURE_CONFIG_DIR) {
+        return Ok(ConfigManager::with_fs(
+            OsFileSystem,
+            PathBuf::from(config_dir),
+        ));
+    }
+
+    let config_dir = get_config_dir()?;
+    Ok(ConfigManager::with_fs(OsFileSystem, config_dir))
+}
+
+fn bash_completion_script() -> String {
+    r#"_aperture_completion() {
+    local IFS=$'\n'
+    local output
+    output="$(aperture __complete bash "${COMP_CWORD}" "${COMP_WORDS[@]}" 2>/dev/null)"
+
+    COMPREPLY=()
+    for line in $output; do
+        COMPREPLY+=("$line")
+    done
+}
+
+complete -F _aperture_completion aperture
+"#
+    .to_string()
+}
+
+fn zsh_completion_script() -> String {
+    r#"#compdef aperture
+
+_aperture_completion() {
+  local -a candidates
+  candidates=("${(@f)$(aperture __complete zsh $((CURRENT - 1)) "${words[@]}" 2>/dev/null)}")
+  _describe 'aperture commands' candidates
+}
+
+compdef _aperture_completion aperture
+"#
+    .to_string()
+}
+
+fn fish_completion_script() -> String {
+    r#"function __aperture_complete
+    set -l words (commandline -opc)
+    set -l cword (math (count $words) - 1)
+
+    if test $cword -lt 0
+        set cword 0
+    end
+
+    aperture __complete fish $cword $words 2>/dev/null
+end
+
+complete -c aperture -f -a "(__aperture_complete)"
+"#
+    .to_string()
+}
+
+fn powershell_completion_script() -> String {
+    r"Register-ArgumentCompleter -Native -CommandName aperture -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $words = @($commandAst.CommandElements | ForEach-Object { $_.Extent.Text })
+    if ($words.Count -eq 0) {
+        return
+    }
+
+    $cword = $words.Count - 1
+    $results = aperture __complete powershell $cword @words 2>$null
+
+    foreach ($result in $results) {
+        [System.Management.Automation.CompletionResult]::new($result, $result, 'ParameterValue', $result)
+    }
+}
+"
+    .to_string()
 }

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -10,6 +10,8 @@
     clippy::implicit_hasher
 )]
 pub mod api;
+#[allow(clippy::missing_errors_doc)]
+pub mod completion;
 #[allow(
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1058,7 +1058,7 @@ pub enum ConfigCommands {
 
 #[cfg(test)]
 mod tests {
-    use super::{Cli, Commands, ConfigCommands, ConfigUrlCommands};
+    use super::{Cli, Commands, CompletionShell, ConfigCommands, ConfigUrlCommands};
     use clap::{CommandFactory, Parser};
 
     #[test]
@@ -1108,6 +1108,37 @@ mod tests {
                 assert_eq!(args, vec!["get-user-by-id", "--id", "123"]);
             }
             other => panic!("expected Commands::Exec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completion_command_parses() {
+        let cli = Cli::try_parse_from(["aperture", "completion", "bash"]).unwrap();
+
+        match cli.command {
+            Commands::Completion { shell } => {
+                assert!(matches!(shell, CompletionShell::Bash));
+            }
+            other => panic!("expected completion command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hidden_complete_command_parses() {
+        let cli = Cli::try_parse_from(["aperture", "__complete", "bash", "2", "aperture", "api"])
+            .unwrap();
+
+        match cli.command {
+            Commands::Complete {
+                shell,
+                cword,
+                words,
+            } => {
+                assert!(matches!(shell, CompletionShell::Bash));
+                assert_eq!(cword, 2);
+                assert_eq!(words, vec!["aperture", "api"]);
+            }
+            other => panic!("expected hidden complete command, got {other:?}"),
         }
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1127,6 +1127,13 @@ mod tests {
     }
 
     #[test]
+    fn completion_command_rejects_unknown_shell_name() {
+        let err = Cli::try_parse_from(["aperture", "completion", "invalid-shell"]).unwrap_err();
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+    }
+
+    #[test]
     fn hidden_complete_command_parses() {
         let cli = Cli::try_parse_from(["aperture", "__complete", "bash", "2", "aperture", "api"])
             .unwrap();
@@ -1204,6 +1211,13 @@ mod tests {
             }
             other => panic!("expected hidden complete command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn hidden_complete_command_rejects_empty_shell_name() {
+        let err = Cli::try_parse_from(["aperture", "__complete", "", "2", "aperture"]).unwrap_err();
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -34,6 +34,7 @@ pub enum CompletionShell {
     /// Fish shell
     Fish,
     /// `PowerShell`
+    #[value(name = "powershell", alias = "power-shell")]
     PowerShell,
 }
 
@@ -1137,6 +1138,37 @@ mod tests {
                 assert!(matches!(shell, CompletionShell::Bash));
                 assert_eq!(cword, 2);
                 assert_eq!(words, vec!["aperture", "api"]);
+            }
+            other => panic!("expected hidden complete command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completion_command_accepts_documented_powershell_name() {
+        let cli = Cli::try_parse_from(["aperture", "completion", "powershell"]).unwrap();
+
+        match cli.command {
+            Commands::Completion { shell } => {
+                assert!(matches!(shell, CompletionShell::PowerShell));
+            }
+            other => panic!("expected completion command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hidden_complete_command_accepts_documented_powershell_name() {
+        let cli =
+            Cli::try_parse_from(["aperture", "__complete", "powershell", "2", "aperture"]).unwrap();
+
+        match cli.command {
+            Commands::Complete {
+                shell,
+                cword,
+                words,
+            } => {
+                assert!(matches!(shell, CompletionShell::PowerShell));
+                assert_eq!(cword, 2);
+                assert_eq!(words, vec!["aperture"]);
             }
             other => panic!("expected hidden complete command, got {other:?}"),
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,6 +33,8 @@ pub enum CompletionShell {
     Zsh,
     /// Fish shell
     Fish,
+    /// Nushell
+    Nu,
     /// `PowerShell`
     #[value(name = "powershell", alias = "power-shell")]
     PowerShell,
@@ -1138,6 +1140,36 @@ mod tests {
                 assert!(matches!(shell, CompletionShell::Bash));
                 assert_eq!(cword, 2);
                 assert_eq!(words, vec!["aperture", "api"]);
+            }
+            other => panic!("expected hidden complete command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completion_command_accepts_nu_shell_name() {
+        let cli = Cli::try_parse_from(["aperture", "completion", "nu"]).unwrap();
+
+        match cli.command {
+            Commands::Completion { shell } => {
+                assert!(matches!(shell, CompletionShell::Nu));
+            }
+            other => panic!("expected completion command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hidden_complete_command_accepts_nu_shell_name() {
+        let cli = Cli::try_parse_from(["aperture", "__complete", "nu", "2", "aperture"]).unwrap();
+
+        match cli.command {
+            Commands::Complete {
+                shell,
+                cword,
+                words,
+            } => {
+                assert!(matches!(shell, CompletionShell::Nu));
+                assert_eq!(cword, 2);
+                assert_eq!(words, vec!["aperture"]);
             }
             other => panic!("expected hidden complete command, got {other:?}"),
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -25,6 +25,18 @@ pub enum DiscoveryFormat {
     Json,
 }
 
+#[derive(ValueEnum, Clone, Debug)]
+pub enum CompletionShell {
+    /// GNU Bash
+    Bash,
+    /// Z shell
+    Zsh,
+    /// Fish shell
+    Fish,
+    /// `PowerShell`
+    PowerShell,
+}
+
 /// Flags that are only meaningful for execution-oriented commands (`api`, `run`).
 #[derive(Args, Debug, Clone)]
 #[allow(clippy::struct_excessive_bools)]
@@ -214,6 +226,23 @@ impl Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
+    /// Generate shell completion scripts
+    Completion {
+        /// Target shell
+        #[arg(value_enum)]
+        shell: CompletionShell,
+    },
+    #[command(name = "__complete", hide = true)]
+    Complete {
+        /// Target shell
+        #[arg(value_enum)]
+        shell: CompletionShell,
+        /// Zero-based index of the word currently being completed
+        cword: usize,
+        /// Command words for the current invocation
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        words: Vec<String>,
+    },
     /// Manage configuration in domain-specific groups
     #[command(
         long_about = "Manage Aperture configuration using domain-oriented subcommands.\n\n\

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,25 @@ fn run_overview_command(
     )
 }
 
-async fn run_non_config_command(
+fn run_completion_command(cli: &Cli) -> Option<Result<(), Error>> {
+    match &cli.command {
+        Commands::Completion { shell } => {
+            Some(aperture_cli::cli::commands::completion::execute_completion_script_command(shell))
+        }
+        Commands::Complete {
+            shell,
+            cword,
+            words,
+        } => Some(
+            aperture_cli::cli::commands::completion::execute_completion_runtime_command(
+                shell, *cword, words,
+            ),
+        ),
+        _ => None,
+    }
+}
+
+async fn run_user_command(
     cli: &Cli,
     manager: &ConfigManager<OsFileSystem>,
     output: &Output,
@@ -155,8 +173,21 @@ async fn run_non_config_command(
         Commands::Overview { api, all, format } => {
             run_overview_command(manager, api.as_deref(), *all, format, output)
         }
+        Commands::Completion { .. } | Commands::Complete { .. } => unreachable!(),
         Commands::Config { .. } => unreachable!("config commands are handled separately"),
     }
+}
+
+async fn run_non_config_command(
+    cli: &Cli,
+    manager: &ConfigManager<OsFileSystem>,
+    output: &Output,
+) -> Result<(), Error> {
+    if let Some(result) = run_completion_command(cli) {
+        return result;
+    }
+
+    run_user_command(cli, manager, output).await
 }
 
 #[allow(clippy::too_many_lines, clippy::cognitive_complexity)]

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -158,6 +158,15 @@ fn runtime_completion_suggests_config_domains_after_global_flags() {
 }
 
 #[test]
+fn runtime_completion_tolerates_unknown_top_level_flag_prefix() {
+    aperture_cmd()
+        .args(["__complete", "bash", "2", "aperture", "--unknown", "a"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("api"));
+}
+
+#[test]
 fn runtime_completion_suggests_contexts_groups_operations_and_flags() {
     let fixture = write_completion_fixture();
 

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -108,6 +108,16 @@ fn completion_command_generates_bash_script() {
 }
 
 #[test]
+fn completion_command_generates_fish_script_with_cursor_handling() {
+    aperture_cmd()
+        .args(["completion", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("commandline -ct"))
+        .stdout(predicate::str::contains("set -l cword (count $words)"));
+}
+
+#[test]
 fn completion_command_generates_nu_script() {
     aperture_cmd()
         .args(["completion", "nu"])
@@ -128,7 +138,11 @@ fn completion_command_generates_powershell_script_with_documented_shell_name() {
         .stdout(predicate::str::contains(
             "aperture __complete powershell $cword",
         ))
-        .stdout(predicate::str::contains("Register-ArgumentCompleter"));
+        .stdout(predicate::str::contains("Register-ArgumentCompleter"))
+        .stdout(predicate::str::contains(
+            "[string]::IsNullOrEmpty($wordToComplete)",
+        ))
+        .stdout(predicate::str::contains("$words += $wordToComplete"));
 }
 
 #[test]

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -108,6 +108,18 @@ fn completion_command_generates_bash_script() {
 }
 
 #[test]
+fn completion_command_generates_nu_script() {
+    aperture_cmd()
+        .args(["completion", "nu"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("aperture __complete nu"))
+        .stdout(predicate::str::contains(
+            "upsert completions.external.completer",
+        ));
+}
+
+#[test]
 fn completion_command_generates_powershell_script_with_documented_shell_name() {
     aperture_cmd()
         .args(["completion", "powershell"])
@@ -178,6 +190,18 @@ fn runtime_completion_suggests_contexts_groups_operations_and_flags() {
         .success()
         .stdout(predicate::str::contains("--user-id"))
         .stdout(predicate::str::contains("--header"));
+}
+
+#[test]
+fn runtime_completion_accepts_nu_shell_name() {
+    let fixture = write_completion_fixture();
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args(["__complete", "nu", "2", "aperture", "api", "p"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("petstore"));
 }
 
 #[test]

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -132,6 +132,32 @@ fn completion_command_generates_powershell_script_with_documented_shell_name() {
 }
 
 #[test]
+fn runtime_completion_suggests_commands_after_global_flags() {
+    aperture_cmd()
+        .args(["__complete", "bash", "2", "aperture", "--json-errors", "a"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("api"));
+}
+
+#[test]
+fn runtime_completion_suggests_config_domains_after_global_flags() {
+    aperture_cmd()
+        .args([
+            "__complete",
+            "bash",
+            "3",
+            "aperture",
+            "config",
+            "--json-errors",
+            "a",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("api"));
+}
+
+#[test]
 fn runtime_completion_suggests_contexts_groups_operations_and_flags() {
     let fixture = write_completion_fixture();
 

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -1,0 +1,169 @@
+mod common;
+
+use aperture_cli::cache::models::{
+    CachedCommand, CachedParameter, CachedResponse, CachedSpec, PaginationInfo,
+};
+use aperture_cli::constants;
+use common::aperture_cmd;
+use predicates::prelude::*;
+use std::collections::HashMap;
+use std::fs;
+use tempfile::TempDir;
+
+fn write_completion_fixture() -> TempDir {
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let config_dir = temp_dir.path();
+
+    let specs_dir = config_dir.join(constants::DIR_SPECS);
+    let cache_dir = config_dir.join(constants::DIR_CACHE);
+
+    fs::create_dir_all(&specs_dir).expect("specs directory should be created");
+    fs::create_dir_all(&cache_dir).expect("cache directory should be created");
+
+    fs::write(
+        specs_dir.join("petstore.yaml"),
+        "openapi: 3.0.0\ninfo:\n  title: Petstore\n  version: 1.0.0\npaths: {}\n",
+    )
+    .expect("spec placeholder should be written");
+
+    let cached_spec = CachedSpec {
+        cache_format_version: aperture_cli::cache::models::CACHE_FORMAT_VERSION,
+        name: "petstore".to_string(),
+        version: "1.0.0".to_string(),
+        commands: vec![CachedCommand {
+            name: "users".to_string(),
+            description: Some("User operations".to_string()),
+            summary: None,
+            operation_id: "getUserById".to_string(),
+            method: constants::HTTP_METHOD_GET.to_string(),
+            path: "/users/{userId}".to_string(),
+            parameters: vec![
+                CachedParameter {
+                    name: "userId".to_string(),
+                    location: constants::PARAM_LOCATION_PATH.to_string(),
+                    required: true,
+                    description: None,
+                    schema: Some(r#"{"type":"string"}"#.to_string()),
+                    schema_type: Some(constants::SCHEMA_TYPE_STRING.to_string()),
+                    format: None,
+                    default_value: None,
+                    enum_values: vec![],
+                    example: None,
+                },
+                CachedParameter {
+                    name: "limit".to_string(),
+                    location: constants::PARAM_LOCATION_QUERY.to_string(),
+                    required: false,
+                    description: None,
+                    schema: Some(r#"{"type":"integer"}"#.to_string()),
+                    schema_type: Some(constants::SCHEMA_TYPE_INTEGER.to_string()),
+                    format: None,
+                    default_value: None,
+                    enum_values: vec![],
+                    example: None,
+                },
+            ],
+            request_body: None,
+            responses: vec![CachedResponse {
+                status_code: "200".to_string(),
+                description: None,
+                content_type: Some(constants::CONTENT_TYPE_JSON.to_string()),
+                schema: Some(r#"{"type":"object"}"#.to_string()),
+                example: None,
+            }],
+            security_requirements: vec![],
+            tags: vec!["users".to_string()],
+            deprecated: false,
+            external_docs_url: None,
+            examples: vec![],
+            display_group: None,
+            display_name: None,
+            aliases: vec![],
+            hidden: false,
+            pagination: PaginationInfo::default(),
+        }],
+        base_url: Some("https://api.example.com".to_string()),
+        servers: vec!["https://api.example.com".to_string()],
+        security_schemes: HashMap::new(),
+        skipped_endpoints: vec![],
+        server_variables: HashMap::new(),
+    };
+
+    let bytes = postcard::to_allocvec(&cached_spec).expect("cache should serialize");
+    fs::write(cache_dir.join("petstore.bin"), bytes).expect("cache file should be written");
+
+    temp_dir
+}
+
+#[test]
+fn completion_command_generates_bash_script() {
+    aperture_cmd()
+        .args(["completion", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("aperture __complete bash"))
+        .stdout(predicate::str::contains(
+            "complete -F _aperture_completion aperture",
+        ));
+}
+
+#[test]
+fn runtime_completion_suggests_contexts_groups_operations_and_flags() {
+    let fixture = write_completion_fixture();
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args(["__complete", "bash", "2", "aperture", "api", "p"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("petstore"));
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args([
+            "__complete",
+            "bash",
+            "3",
+            "aperture",
+            "api",
+            "petstore",
+            "u",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("users"));
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args([
+            "__complete",
+            "bash",
+            "4",
+            "aperture",
+            "api",
+            "petstore",
+            "users",
+            "g",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("get-user-by-id"));
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args([
+            "__complete",
+            "bash",
+            "5",
+            "aperture",
+            "api",
+            "petstore",
+            "users",
+            "get-user-by-id",
+            "--",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--user-id"))
+        .stdout(predicate::str::contains("--header"));
+}

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -108,6 +108,18 @@ fn completion_command_generates_bash_script() {
 }
 
 #[test]
+fn completion_command_generates_powershell_script_with_documented_shell_name() {
+    aperture_cmd()
+        .args(["completion", "powershell"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "aperture __complete powershell $cword",
+        ))
+        .stdout(predicate::str::contains("Register-ArgumentCompleter"));
+}
+
+#[test]
 fn runtime_completion_suggests_contexts_groups_operations_and_flags() {
     let fixture = write_completion_fixture();
 
@@ -166,4 +178,38 @@ fn runtime_completion_suggests_contexts_groups_operations_and_flags() {
         .success()
         .stdout(predicate::str::contains("--user-id"))
         .stdout(predicate::str::contains("--header"));
+}
+
+#[test]
+fn runtime_completion_accepts_documented_powershell_shell_name() {
+    let fixture = write_completion_fixture();
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args(["__complete", "powershell", "2", "aperture", "api", "p"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("petstore"));
+}
+
+#[test]
+fn runtime_completion_tolerates_missing_execution_flag_value() {
+    let fixture = write_completion_fixture();
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args([
+            "__complete",
+            "bash",
+            "4",
+            "aperture",
+            "api",
+            "petstore",
+            "--format",
+            "",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("users"))
+        .stdout(predicate::str::contains("--dry-run"));
 }

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -243,6 +243,28 @@ fn runtime_completion_accepts_documented_powershell_shell_name() {
 }
 
 #[test]
+fn runtime_completion_tolerates_server_var_value_before_group() {
+    let fixture = write_completion_fixture();
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args([
+            "__complete",
+            "bash",
+            "5",
+            "aperture",
+            "api",
+            "petstore",
+            "--server-var",
+            "region=us",
+            "u",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("users"));
+}
+
+#[test]
 fn runtime_completion_tolerates_missing_execution_flag_value() {
     let fixture = write_completion_fixture();
 

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -108,6 +108,19 @@ fn completion_command_generates_bash_script() {
 }
 
 #[test]
+fn completion_command_generates_zsh_script() {
+    aperture_cmd()
+        .args(["completion", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#compdef aperture"))
+        .stdout(predicate::str::contains("aperture __complete zsh"))
+        .stdout(predicate::str::contains(
+            "compdef _aperture_completion aperture",
+        ));
+}
+
+#[test]
 fn completion_command_generates_fish_script_with_cursor_handling() {
     aperture_cmd()
         .args(["completion", "fish"])

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -305,6 +305,30 @@ fn runtime_completion_tolerates_server_var_value_before_group() {
 }
 
 #[test]
+fn runtime_completion_tolerates_duplicate_server_var_flags_before_group() {
+    let fixture = write_completion_fixture();
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args([
+            "__complete",
+            "bash",
+            "7",
+            "aperture",
+            "api",
+            "petstore",
+            "--server-var",
+            "region=us",
+            "--server-var",
+            "env=prod",
+            "u",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("users"));
+}
+
+#[test]
 fn runtime_completion_recovers_config_subcommands_and_contexts_after_unknown_flag_prefix() {
     let fixture = write_completion_fixture();
 

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -158,6 +158,23 @@ fn runtime_completion_suggests_config_domains_after_global_flags() {
 }
 
 #[test]
+fn runtime_completion_recovers_config_domains_after_unknown_flag_prefix() {
+    aperture_cmd()
+        .args([
+            "__complete",
+            "bash",
+            "3",
+            "aperture",
+            "config",
+            "--unknown",
+            "a",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("api"));
+}
+
+#[test]
 fn runtime_completion_tolerates_unknown_top_level_flag_prefix() {
     aperture_cmd()
         .args(["__complete", "bash", "2", "aperture", "--unknown", "a"])
@@ -271,6 +288,44 @@ fn runtime_completion_tolerates_server_var_value_before_group() {
         .assert()
         .success()
         .stdout(predicate::str::contains("users"));
+}
+
+#[test]
+fn runtime_completion_recovers_config_subcommands_and_contexts_after_unknown_flag_prefix() {
+    let fixture = write_completion_fixture();
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args([
+            "__complete",
+            "bash",
+            "4",
+            "aperture",
+            "config",
+            "api",
+            "--unknown",
+            "r",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("remove"));
+
+    aperture_cmd()
+        .env(constants::ENV_APERTURE_CONFIG_DIR, fixture.path())
+        .args([
+            "__complete",
+            "bash",
+            "5",
+            "aperture",
+            "config",
+            "api",
+            "remove",
+            "--unknown",
+            "p",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("petstore"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add top-level `completion` and hidden runtime `__complete` commands
- generate shell scripts for bash/zsh/fish/powershell that invoke dynamic completion at runtime
- add dynamic completion for contexts, API groups/operations, operation flags, and static config command paths
- document installation, coverage, and trade-offs in README and docs/guide

## Validation
- cargo test --test completion_integration_tests
- cargo test completion_command_parses
- cargo test hidden_complete_command_parses
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features

Closes #139