### PR TITLE
fix: resolve clippy warnings in integration matrix

### DIFF
--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -755,7 +755,7 @@ impl BatchProcessor {
             cache_dir: config_dir
                 .join(crate::constants::DIR_CACHE)
                 .join(crate::constants::DIR_RESPONSES),
-            default_ttl: std::time::Duration::from_secs(300),
+            default_ttl: std::time::Duration::from_mins(5),
             max_entries: 1000,
             enabled: true,
             allow_authenticated: false,

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -94,29 +94,26 @@ mod tests {
     fn test_parse_duration_milliseconds() {
         assert_eq!(parse_duration("100ms").unwrap(), Duration::from_millis(100));
         assert_eq!(parse_duration("500ms").unwrap(), Duration::from_millis(500));
-        assert_eq!(
-            parse_duration("1000ms").unwrap(),
-            Duration::from_millis(1000)
-        );
+        assert_eq!(parse_duration("1000ms").unwrap(), Duration::from_secs(1));
     }
 
     #[test]
     fn test_parse_duration_seconds() {
         assert_eq!(parse_duration("1s").unwrap(), Duration::from_secs(1));
         assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
-        assert_eq!(parse_duration("120s").unwrap(), Duration::from_secs(120));
+        assert_eq!(parse_duration("120s").unwrap(), Duration::from_mins(2));
     }
 
     #[test]
     fn test_parse_duration_minutes() {
-        assert_eq!(parse_duration("1m").unwrap(), Duration::from_secs(60));
-        assert_eq!(parse_duration("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(parse_duration("1m").unwrap(), Duration::from_mins(1));
+        assert_eq!(parse_duration("5m").unwrap(), Duration::from_mins(5));
     }
 
     #[test]
     fn test_parse_duration_plain_number() {
         assert_eq!(parse_duration("500").unwrap(), Duration::from_millis(500));
-        assert_eq!(parse_duration("1000").unwrap(), Duration::from_millis(1000));
+        assert_eq!(parse_duration("1000").unwrap(), Duration::from_secs(1));
     }
 
     #[test]

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -1195,7 +1195,7 @@ fn build_url_from_params(
     // Append query parameters
     if !query_params.is_empty() {
         let mut qs_pairs: Vec<(&String, &String)> = query_params.iter().collect();
-        qs_pairs.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        qs_pairs.sort_by_key(|(k1, _)| *k1);
 
         let qs: Vec<String> = qs_pairs
             .into_iter()

--- a/src/resilience/mod.rs
+++ b/src/resilience/mod.rs
@@ -417,7 +417,7 @@ mod tests {
         headers.insert("retry-after", "120".parse().unwrap());
 
         let duration = parse_retry_after_header(&headers);
-        assert_eq!(duration, Some(Duration::from_secs(120)));
+        assert_eq!(duration, Some(Duration::from_mins(2)));
     }
 
     #[test]
@@ -504,7 +504,7 @@ mod tests {
         };
 
         // Server says wait 60 seconds, but we cap at 5 seconds
-        let retry_after = Some(Duration::from_secs(60));
+        let retry_after = Some(Duration::from_mins(1));
         let delay = calculate_retry_delay_with_header(&config, 0, retry_after);
         assert_eq!(delay.as_millis(), 5000);
     }

--- a/src/response_cache.rs
+++ b/src/response_cache.rs
@@ -595,7 +595,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let config = CacheConfig {
             cache_dir: temp_dir.path().to_path_buf(),
-            default_ttl: Duration::from_secs(60),
+            default_ttl: Duration::from_mins(1),
             max_entries: 10,
             enabled: true,
             allow_authenticated: false,
@@ -707,7 +707,7 @@ mod tests {
                 200,
                 &headers,
                 request_info,
-                Some(Duration::from_secs(60)),
+                Some(Duration::from_mins(1)),
             )
             .await
             .unwrap();
@@ -803,7 +803,7 @@ mod tests {
                 200,
                 &HashMap::new(),
                 request_info,
-                Some(Duration::from_secs(300)),
+                Some(Duration::from_mins(5)),
             )
             .await
             .unwrap();

--- a/src/response_cache.rs
+++ b/src/response_cache.rs
@@ -26,7 +26,7 @@ impl Default for CacheConfig {
     fn default() -> Self {
         Self {
             cache_dir: PathBuf::from(".cache/responses"),
-            default_ttl: Duration::from_secs(300), // 5 minutes
+            default_ttl: Duration::from_mins(5), // 5 minutes
             max_entries: 1000,
             enabled: true,
             allow_authenticated: false, // Secure by default
@@ -440,7 +440,7 @@ impl ResponseCache {
             .ok()
             .and_then(|m| m.modified().ok())
             .is_some_and(|modified| {
-                now.duration_since(modified).unwrap_or(Duration::ZERO) > Duration::from_secs(3600)
+                now.duration_since(modified).unwrap_or(Duration::ZERO) > Duration::from_hours(1)
             });
         if is_stale {
             stale_files.push(entry.path());

--- a/src/search.rs
+++ b/src/search.rs
@@ -101,7 +101,7 @@ impl CommandSearcher {
         }
 
         // Sort by score (highest first)
-        results.sort_by(|a, b| b.score.cmp(&a.score));
+        results.sort_by_key(|b| std::cmp::Reverse(b.score));
 
         Ok(results)
     }
@@ -315,7 +315,7 @@ impl CommandSearcher {
         }
 
         // Sort by score and take top results
-        suggestions.sort_by(|a, b| b.1.cmp(&a.1));
+        suggestions.sort_by_key(|b| std::cmp::Reverse(b.1));
         suggestions.truncate(max_results);
 
         suggestions

--- a/tests/atomic_io_tests.rs
+++ b/tests/atomic_io_tests.rs
@@ -124,7 +124,7 @@ async fn test_concurrent_response_cache_store_no_corruption() {
     let dir = TempDir::new().unwrap();
     let config = CacheConfig {
         cache_dir: dir.path().to_path_buf(),
-        default_ttl: Duration::from_secs(300),
+        default_ttl: Duration::from_mins(5),
         max_entries: 100,
         enabled: true,
         allow_authenticated: false,
@@ -184,7 +184,7 @@ async fn test_concurrent_store_same_key_no_corruption() {
     let dir = TempDir::new().unwrap();
     let config = CacheConfig {
         cache_dir: dir.path().to_path_buf(),
-        default_ttl: Duration::from_secs(300),
+        default_ttl: Duration::from_mins(5),
         max_entries: 100,
         enabled: true,
         allow_authenticated: false,

--- a/tests/command_syntax_integration_tests.rs
+++ b/tests/command_syntax_integration_tests.rs
@@ -118,7 +118,7 @@ fn create_test_cache_config() -> (CacheConfig, TempDir) {
     let temp_dir = TempDir::new().unwrap();
     let cache_config = CacheConfig {
         cache_dir: temp_dir.path().to_path_buf(),
-        default_ttl: Duration::from_secs(60),
+        default_ttl: Duration::from_mins(1),
         max_entries: 100,
         enabled: true,
         allow_authenticated: false,
@@ -547,7 +547,7 @@ async fn test_cache_with_custom_ttl() {
     assert_eq!(stats.valid_entries, 1);
 
     // Wait for TTL to expire (800ms TTL + buffer)
-    tokio::time::sleep(Duration::from_millis(1000)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Second request should hit API again due to expiration
     let result2 = execute_request(

--- a/tests/executor_domain_tests.rs
+++ b/tests/executor_domain_tests.rs
@@ -153,7 +153,7 @@ async fn execute_returns_cached_result_on_repeat_call() {
     let cache_dir = tempdir().expect("tempdir should be created");
     let cache_config = CacheConfig {
         cache_dir: cache_dir.path().to_path_buf(),
-        default_ttl: Duration::from_secs(60),
+        default_ttl: Duration::from_mins(1),
         max_entries: 100,
         enabled: true,
         allow_authenticated: false,

--- a/tests/response_cache_integration_tests.rs
+++ b/tests/response_cache_integration_tests.rs
@@ -64,7 +64,7 @@ fn create_test_cache_config() -> (CacheConfig, TempDir) {
     let temp_dir = TempDir::new().unwrap();
     let cache_config = CacheConfig {
         cache_dir: temp_dir.path().to_path_buf(),
-        default_ttl: Duration::from_secs(60),
+        default_ttl: Duration::from_mins(1),
         max_entries: 10,
         enabled: true,
         allow_authenticated: false,
@@ -466,7 +466,7 @@ async fn test_authenticated_requests_not_cached_by_default() {
     let temp_dir = TempDir::new().unwrap();
     let cache_config = CacheConfig {
         cache_dir: temp_dir.path().to_path_buf(),
-        default_ttl: Duration::from_secs(300),
+        default_ttl: Duration::from_mins(5),
         max_entries: 100,
         enabled: true,
         allow_authenticated: false, // Default: don't cache authenticated requests
@@ -549,7 +549,7 @@ async fn test_auth_headers_scrubbed_when_caching_opted_in() {
     let temp_dir = TempDir::new().unwrap();
     let cache_config = CacheConfig {
         cache_dir: temp_dir.path().to_path_buf(),
-        default_ttl: Duration::from_secs(300),
+        default_ttl: Duration::from_mins(5),
         max_entries: 100,
         enabled: true,
         allow_authenticated: true, // Opt-in: allow caching but headers must be scrubbed


### PR DESCRIPTION
## Summary
- fix clippy `duration_suboptimal_units` findings by using larger-unit constructors for cache TTLs
- replace `sort_by` closures with `sort_by_key` in URL query normalization and search ranking logic
- keep behavior unchanged while removing warnings that were promoted to errors in CI

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features integration -- -D warnings`
- `cargo clippy -- -D warnings`
- `cargo test`
