### PR TITLE
chore: remove decorative glyphs from docs output

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -30,12 +30,12 @@ run_step() {
     shift
 
     if "$@" > /dev/null 2>&1; then
-        echo -e "  ${GREEN}✓${NC} $label"
+        echo -e "  ${GREEN}[OK]${NC} $label"
         return 0
     fi
 
     FAILED=1
-    echo -e "  ${RED}✗${NC} $label"
+    echo -e "  ${RED}[FAIL]${NC} $label"
     # Re-run without suppression so the developer sees the actual errors.
     echo ""
     "$@" 2>&1 || true
@@ -71,7 +71,7 @@ echo "Staged Rust files: $STAGED_COUNT"
 
 if ! cargo fmt -- --check > /dev/null 2>&1; then
     if is_rustfmt_diff_failure cargo fmt -- --check; then
-        echo -e "  ${YELLOW}↻${NC} cargo fmt (auto-fixing)"
+        echo -e "  ${YELLOW}[FIX]${NC} cargo fmt (auto-fixing)"
         cargo fmt
 
         for file in $RUST_FILES; do
@@ -79,14 +79,14 @@ if ! cargo fmt -- --check > /dev/null 2>&1; then
         done
     else
         # Non-formatting failure (e.g. syntax error). Show it and bail.
-        echo -e "  ${RED}✗${NC} cargo fmt"
+        echo -e "  ${RED}[FAIL]${NC} cargo fmt"
         echo ""
         cargo fmt -- --check 2>&1 || true
         echo ""
         exit 1
     fi
 else
-    echo -e "  ${GREEN}✓${NC} cargo fmt"
+    echo -e "  ${GREEN}[OK]${NC} cargo fmt"
 fi
 
 # ── Clippy ────────────────────────────────────────────────────────────────────
@@ -98,7 +98,7 @@ run_step "cargo clippy" \
 
 if command -v ast-grep &> /dev/null && [ -f "sgconfig.yml" ]; then
     if [ "${SKIP_ASTGREP:-0}" = "1" ]; then
-        echo -e "  ${YELLOW}⚠${NC} ast-grep scan skipped (SKIP_ASTGREP=1)"
+        echo -e "  ${YELLOW}[WARN]${NC} ast-grep scan skipped (SKIP_ASTGREP=1)"
     else
         # shellcheck disable=SC2086
         run_step "ast-grep scan" ast-grep scan $RUST_FILES
@@ -123,4 +123,4 @@ if [ "$FAILED" -ne 0 ]; then
     exit 1
 fi
 
-echo -e "${GREEN}✅ All pre-commit checks passed.${NC}"
+echo -e "${GREEN}All pre-commit checks passed.${NC}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.9] - 2026-03-04
 
-### ⚙️ Miscellaneous Tasks
+### Miscellaneous Tasks
 
 - Batch update cargo dependencies (#112)
 - Trigger binary-size workflow on push to feature branch
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 - Align artifact action versions with rest of project
 - Bump version to 0.1.9
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Ensure dependent batch captures raw unfiltered response
 - Validate duplicate operation IDs in batch dependency graph
@@ -60,7 +60,7 @@ All notable changes to this project will be documented in this file.
 - Treat "skip" as record-offset in advance_offset_strategy
 - Warn when --format is ignored with --auto-paginate
 
-### 📚 Documentation
+### Documentation
 
 - Update changelog for v0.1.8 and automate via release CI
 - Add documentation for v0.1.8 features
@@ -74,7 +74,7 @@ All notable changes to this project will be documented in this file.
 - Update binary size claim to < 6 MB (default features, all platforms)
 - Add --auto-paginate section to agent integration guide
 
-### 🚀 Features
+### Features
 
 - Extend BatchOperation with capture, capture_append, and depends_on fields
 - Implement dependency graph validation and topological sort
@@ -88,7 +88,7 @@ All notable changes to this project will be documented in this file.
 - Add binary-sizes.json and automate population from CI
 - Implement --auto-paginate flag with cursor, offset, and link-header strategies
 
-### 🧪 Testing
+### Testing
 
 - Add integration tests for dependent batch workflows
 - Add coverage for --body-file flag
@@ -105,7 +105,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.8] - 2026-02-15
 
-### ⚙️ Miscellaneous Tasks
+### Miscellaneous Tasks
 
 - Remove duplicate crates.io publish step
 - Move entire release process to GitHub Actions
@@ -122,7 +122,7 @@ All notable changes to this project will be documented in this file.
 - Add nix build and flake check steps to CI workflow
 - Add nix result symlink to .gitignore
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Prevent panic on Unicode body truncation in logging
 - Standardize redaction markers to [REDACTED]
@@ -152,7 +152,7 @@ All notable changes to this project will be documented in this file.
 - Honor mapped command names in help and listings
 - Resolve mapped command names in operation translation
 
-### 📚 Documentation
+### Documentation
 
 - Add homebrew and cargo-binstall installation options
 - Add comprehensive debugging and logging guide
@@ -161,7 +161,7 @@ All notable changes to this project will be documented in this file.
 - Add Nix installation instructions to README
 - Add ADR 009 for custom command mapping approach
 
-### 🚀 Features
+### Features
 
 - Initialize tracing-subscriber for debug logging
 - Add -v flag for debug logging control
@@ -184,12 +184,12 @@ All notable changes to this project will be documented in this file.
 - Add CLI commands for managing command mappings
 - Add --remove-alias flag to config set-mapping command
 
-### 🚜 Refactor
+### Refactor
 
 - Decouple execution core from CLI layer (clap, stdout) (#77)
 - Resolve PR review findings for executor/CLI decoupling
 
-### 🧪 Testing
+### Testing
 
 - Add integration tests for logging functionality
 - **cache:** Add security tests for auth header scrubbing
@@ -200,7 +200,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.7] - 2026-01-26
 
-### ⚙️ Miscellaneous Tasks
+### Miscellaneous Tasks
 
 - Add ast-grep configuration with custom Rust linting rules
 - Suppress no-println warnings with ast-grep-ignore comments
@@ -212,11 +212,11 @@ All notable changes to this project will be documented in this file.
 - Upgrade reqwest from 0.12 to 0.13
 - Improve pre-commit hooks for better local testing
 
-### 🎨 Styling
+### Styling
 
 - Fix ast-grep linting issues
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Use sibling relationship for #[cfg(test)] module exclusion
 - Resolve clippy warnings in test files and align pre-commit with CI
@@ -234,14 +234,14 @@ All notable changes to this project will be documented in this file.
 - **config:** Add debug assertions for type mismatches in set_setting
 - Commit changelog before cargo release
 
-### 📚 Documentation
+### Documentation
 
 - Restructure README and split into focused documentation (#61)
 - Update binary size to 4.0MB (aws-lc-rs crypto backend)
 - **config:** Add checklist for adding new settings
 - Add documentation for v0.1.7 features
 
-### 🚀 Features
+### Features
 
 - **agent:** Expose response schemas in describe manifest (#60)
 - Add quiet mode for agent-friendly output suppression
@@ -266,7 +266,7 @@ All notable changes to this project will be documented in this file.
 - Integrate retry logic into batch execution
 - Enhance JSON error output with detailed retry info
 
-### 🚜 Refactor
+### Refactor
 
 - Replace .unwrap() with .expect() in production code
 - Eliminate all nested if statements (138 violations)
@@ -279,7 +279,7 @@ All notable changes to this project will be documented in this file.
 - Improve retry logic code quality
 - Remove unused retry_status_codes config field
 
-### 🧪 Testing
+### Testing
 
 - Add batch operations quiet mode integration test
 - Add assertion verifying command count matches available endpoints
@@ -292,12 +292,12 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.6] - 2025-11-12
 
-### ⚙️ Miscellaneous Tasks
+### Miscellaneous Tasks
 
 - Clean up unused imports and fix warnings
 - Enhance release script with changelog automation
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Resolve panic conditions and improve error handling
 - Resolve panic conditions and improve error handling for production stability
@@ -313,12 +313,12 @@ All notable changes to this project will be documented in this file.
 - Make boolean path parameters consistently optional
 - Ensure boolean parameters work correctly in positional args mode
 
-### 📚 Documentation
+### Documentation
 
 - Update CLAUDE.md to reflect working jq feature with v2.x
 - Update README to reflect working jq feature
 
-### 🚀 Features
+### Features
 
 - Add search command to CLI interface
 - Add enhanced help with examples
@@ -328,7 +328,7 @@ All notable changes to this project will be documented in this file.
 - Add original_tags field for full tag consistency in JSON manifests
 - Add boolean header parameter support
 
-### 🚜 Refactor
+### Refactor
 
 - Break down long generate_command_help function
 - Move inline imports to module/function level for better performance and readability
@@ -337,7 +337,7 @@ All notable changes to this project will be documented in this file.
 - Complete inline import elimination - move all remaining imports to proper scope
 - Complete standardization of import patterns
 
-### 🧪 Testing
+### Testing
 
 - Fix list-commands assertion to expect 'General' instead of 'default'
 - Add integration tests for --show-examples execution path
@@ -346,7 +346,7 @@ All notable changes to this project will be documented in this file.
 
 ### Release Highlights
 
-- **⚠️ Breaking**: CLI parameter flags now use kebab-case (e.g., `--user-id` instead of `--userId`)
+- **Breaking**: CLI parameter flags now use kebab-case (e.g., `--user-id` instead of `--userId`)
 - **Performance**: Binary size reduced by 67% (11MB → 3.6MB), test suite 75% faster (~30s → ~8s)
 - **New Feature**: Optional OpenAPI 3.1 support via `--features openapi31`
 - **Architecture**: Error system consolidated from 47+ types to 8 categories
@@ -356,17 +356,17 @@ All notable changes to this project will be documented in this file.
 
 - Add cargo-nextest configuration for optimized testing
 
-### ⚙️ Miscellaneous Tasks
+### Miscellaneous Tasks
 
 - Optimize GitHub Actions workflow for faster testing
 
-### ⚡ Performance
+### Performance
 
 - Implement binary caching in integration_tests.rs
 - Migrate remaining tests to cached binary
 - Implement MockServer pooling infrastructure
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Redact authentication headers in dry-run output
 - Convert parameter flags to kebab-case for CLI consistency
@@ -385,21 +385,21 @@ All notable changes to this project will be documented in this file.
 - Remove broken pooling infrastructure from test optimizations
 - Correct nextest thread configuration syntax
 
-### 📚 Documentation
+### Documentation
 
 - Update table of contents for JQ Support section
 - Add comprehensive code-level optimization analysis and plan
 - Add comprehensive documentation to error module
 - Add comprehensive ADR for test suite optimization
 
-### 🚀 Features
+### Features
 
 - Add OpenAPI 3.1 support with oas3 fallback parser
 - Make OpenAPI 3.1 support optional via openapi31 feature flag
 - Complete error consolidation with helper methods and direct usage migration
 - Complete error type consolidation for binary size reduction
 
-### 🚜 Refactor
+### Refactor
 
 - Optimize string allocations in error module using Cow
 - Centralize string literals into constants module
@@ -414,7 +414,7 @@ All notable changes to this project will be documented in this file.
 - Replace error macros with builder methods
 - Split HttpRequest into Network and HttpRequest error kinds
 
-### 🧪 Testing
+### Testing
 
 - Add comprehensive integration tests for kebab-case parameters
 - Update existing tests for kebab-case parameter flags
@@ -423,12 +423,12 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.4] - 2025-08-01
 
-### 🎨 Styling
+### Styling
 
 - Remove emojis from interactive configuration output
 - Remove all emojis from source code
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Include auth-related warnings when building skip_endpoints list
 - Add base64 encoding for basic auth credentials
@@ -448,7 +448,7 @@ All notable changes to this project will be documented in this file.
 - Preserve empty string defaults for server variables
 - Add URL encoding for server variable values
 
-### 📚 Documentation
+### Documentation
 
 - Update documentation for custom HTTP authentication support
 - Update documentation for partial API support with unsupported auth
@@ -459,7 +459,7 @@ All notable changes to this project will be documented in this file.
 - Add table of contents to README
 - Update documentation and reorganize historical files
 
-### 🚀 Features
+### Features
 
 - Add support for custom HTTP authentication schemes
 - Update validator to handle unsupported auth schemes in non-strict mode
@@ -487,7 +487,7 @@ All notable changes to this project will be documented in this file.
 - Integrate server variable resolution into request execution
 - Add template variable name validation
 
-### 🚜 Refactor
+### Refactor
 
 - Introduce AuthScheme enum and improve code organization
 - Improve code organization
@@ -499,7 +499,7 @@ All notable changes to this project will be documented in this file.
 - Flatten nested conditionals in contains_template_variables
 - Improve code readability based on PR review feedback
 
-### 🧪 Testing
+### Testing
 
 - Add comprehensive tests for custom HTTP authentication schemes
 - Add header injection validation tests
@@ -513,11 +513,11 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.3] - 2025-07-22
 
-### ⚡ Performance
+### Performance
 
 - Optimize content type validation to single iteration
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Prevent stack overflow from circular parameter references
 - Resolve parameter references in describe-json output
@@ -532,12 +532,12 @@ All notable changes to this project will be documented in this file.
 - Preserve strict mode preference during reinit
 - Standardize warning display across commands
 
-### 📚 Documentation
+### Documentation
 
 - Restore CHANGELOG.md release history
 - Update README with parameter reference support
 
-### 🚀 Features
+### Features
 
 - Add support for parameter references in OpenAPI specifications
 - Enable JQ filtering for --describe-json output
@@ -548,14 +548,14 @@ All notable changes to this project will be documented in this file.
 - Add --strict flag for partial spec acceptance with warnings
 - Add warnings for endpoints with mixed content types
 
-### 🚜 Refactor
+### Refactor
 
 - Extract parameter reference resolution to shared module
 - Reduce MAX_REFERENCE_DEPTH from 50 to 10
 - Improve content type handling and update docs
 - Flatten deeply nested code for improved readability
 
-### 🧪 Testing
+### Testing
 
 - Add comprehensive tests for circular parameter references
 - Add coverage for parameter names with special characters
@@ -563,29 +563,29 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.2] - 2025-07-12
 
-### ⚙️ Miscellaneous Tasks
+### Miscellaneous Tasks
 
 - Rename phase3_integration_tests.rs to command_syntax_integration_tests.rs
 - Prepare release v0.1.2
 
-### ⚡ Performance
+### Performance
 
 - Optimize cache version checking with global metadata file
 - Optimize timeout test execution with configurable timeouts
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Implement critical Phase 1 stability fixes
 - Replace jq-rs with jaq for pure Rust implementation
 - Resolve issues and improve JQ implementation
 - Address critical Phase 3 PR review issues
 
-### 📚 Documentation
+### Documentation
 
 - Add core enhancement roadmap for v0.1.x series
 - Add comprehensive Phase 3 features documentation
 
-### 🚀 Features
+### Features
 
 - Implement context-aware error messages for HTTP failures
 - Implement command discovery with list-commands subcommand
@@ -601,11 +601,11 @@ All notable changes to this project will be documented in this file.
 - Implement experimental flag-based parameter syntax
 - Stabilize flag-based parameter syntax as default
 
-### 🚜 Refactor
+### Refactor
 
 - Remove redundant HttpError variant
 
-### 🧪 Testing
+### Testing
 
 - Add ignored tests for remote spec support
 - Add ignored tests for JQ filtering feature
@@ -613,19 +613,19 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.1] - 2025-07-04
 
-### ⚙️ Miscellaneous Tasks
+### Miscellaneous Tasks
 
 - Prepare for v0.1.1 release
 
-### 🎨 Styling
+### Styling
 
 - Remove emojis from error messages
 
-### 📚 Documentation
+### Documentation
 
 - Add comprehensive code review and future improvements documentation
 
-### 🚀 Features
+### Features
 
 - Add specific error variants to replace generic Config errors
 - Enrich cached models with OpenAPI metadata for better agent support
@@ -634,7 +634,7 @@ All notable changes to this project will be documented in this file.
 - Add description and bearer_format fields to CachedSecurityScheme
 - Add comprehensive x-aperture-secret validation
 
-### 🚜 Refactor
+### Refactor
 
 - Extract validation and transformation logic into spec module
 - Use new spec module components in ConfigManager
@@ -643,23 +643,23 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0] - 2025-06-30
 
-### ⚙️ Miscellaneous Tasks
+### Miscellaneous Tasks
 
 - Init and add project docs
 - Update dependencies to latest compatible versions
 
-### 🎨 Styling
+### Styling
 
 - Apply cargo fmt formatting
 
-### 🐛 Bug Fixes
+### Bug Fixes
 
 - Add APERTURE_CONFIG_DIR support in main.rs
 - Implement mutex-based test isolation and resolve clippy warnings
 - Correct base URL resolution priority hierarchy
 - Resolve parallel test execution issues with environment variables
 
-### 📚 Documentation
+### Documentation
 
 - Update plan progress
 - Update plan.md to reflect Phase 2 completion
@@ -676,7 +676,7 @@ All notable changes to this project will be documented in this file.
 - Update ADR-005 to reflect complete x-aperture-secret implementation
 - Update documentation to reflect production-ready status
 
-### 🚀 Features
+### Features
 
 - Initialise project and configure development workflow
 - Define core application error enum and tests
@@ -719,12 +719,12 @@ All notable changes to this project will be documented in this file.
 - Prepare repository for open source release
 - Rename package to aperture-cli for crates.io uniqueness
 
-### 🚜 Refactor
+### Refactor
 
 - Move engine tests to tests directory
 - Pass base url as parameter to fix test isolation
 
-### 🧪 Testing
+### Testing
 
 - Add comprehensive integration tests with wiremock
 - Add comprehensive integration tests for agent features

--- a/cliff.toml
+++ b/cliff.toml
@@ -51,22 +51,22 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-  { message = "^feat", group = "🚀 Features" },
-  { message = "^fix", group = "🐛 Bug Fixes" },
-  { message = "^doc", group = "📚 Documentation" },
-  { message = "^perf", group = "⚡ Performance" },
-  { message = "^refactor|^arch", group = "🚜 Refactor" },
-  { message = "^style", group = "🎨 Styling" },
-  { message = "^test", group = "🧪 Testing" },
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor|^arch", group = "Refactor" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
   { message = "^chore\\(release\\): prepare for", skip = true },
   { message = "^chore: release ", skip = true },
   { message = "^docs: update changelog for ", skip = true },
   { message = "^chore\\(deps\\)|^deps", skip = true },
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },
-  { message = "^chore|^ci", group = "⚙️ Miscellaneous Tasks" },
-  { body = ".*security", group = "🛡️ Security" },
-  { message = "^revert", group = "◀️ Revert" },
+  { message = "^chore|^ci", group = "Miscellaneous Tasks" },
+  { body = ".*security", group = "Security" },
+  { message = "^revert", group = "Revert" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false

--- a/docs/adr/005-security-authentication-and-custom-headers.md
+++ b/docs/adr/005-security-authentication-and-custom-headers.md
@@ -80,7 +80,7 @@ Updated the agent manifest to expose security information:
 
 ## Implementation Completion
 
-**Status**: ✅ **FULLY IMPLEMENTED** as of December 2024
+**Status**: **FULLY IMPLEMENTED** as of December 2024
 
 ### Key Achievements
 - **x-aperture-secret extension parsing**: Complete implementation with openapiv3 2.2.0 upgrade

--- a/docs/archive/future_improvements_v0.1.md
+++ b/docs/archive/future_improvements_v0.1.md
@@ -2,7 +2,7 @@
 
 Based on comprehensive testing across multiple APIs (Assembla, PokéAPI, OpenWeatherMap, Sentry), this document outlines areas for enhancement to improve user experience and functionality. Each improvement is analyzed for architectural impact and integration with Aperture's existing module structure.
 
-## 🏗️ Architectural Context
+## Architectural Context
 
 Aperture follows key design patterns that must be preserved during improvements:
 
@@ -22,7 +22,7 @@ Aperture follows key design patterns that must be preserved during improvements:
 ## 🎯 High Priority Improvements
 
 ### 1. Query Parameter Authentication Support
-**🏗️ Architectural Impact: HIGH** | **Module: `src/config/models.rs`, `src/engine/executor.rs`**
+**Architectural Impact: HIGH** | **Module: `src/config/models.rs`, `src/engine/executor.rs`**
 
 **Current Limitation:** Environment variable injection only works for header-based authentication
 ```bash
@@ -50,7 +50,7 @@ aperture api openweathermap default get-forecast --lat "44.4268"
 - Ensure cached specs regenerate to include new security handling
 
 ### 2. Parameter Syntax Standardization
-**🏗️ Architectural Impact: MEDIUM** | **Module: `src/engine/generator.rs`**
+**Architectural Impact: MEDIUM** | **Module: `src/engine/generator.rs`**
 
 **Current State:** Inconsistent parameter styles across different APIs
 ```bash
@@ -86,7 +86,7 @@ aperture api sentry default get-project-issues --org "ouro" --project "core" --s
 - Update cached command generation to include both parameter styles
 
 ### 3. Enhanced Error Messages
-**🏗️ Architectural Impact: LOW** | **Module: `src/error.rs`**
+**Architectural Impact: LOW** | **Module: `src/error.rs`**
 
 **Current State:** Generic error messages with limited actionable guidance
 ```
@@ -121,10 +121,10 @@ Need help? Run: aperture api openweathermap --help
 - Configuration issues - Guide to `aperture config` commands
 - Network connectivity problems - Suggest `--dry-run` for debugging
 
-## 🚀 Medium Priority Enhancements
+## Medium Priority Enhancements
 
 ### 4. Configuration Management UX
-**🏗️ Architectural Impact: MEDIUM** | **Module: `src/config/manager.rs`, `src/config/url_resolver.rs`**
+**Architectural Impact: MEDIUM** | **Module: `src/config/manager.rs`, `src/config/url_resolver.rs`**
 
 **Current Limitations:**
 - Only supports local file paths
@@ -173,7 +173,7 @@ aperture config add myapi --interactive
 ```bash
 # Enhanced feedback during add
 aperture config add myapi spec.yaml
-✅ Spec validated successfully
+Spec validated successfully
 📊 Discovered 15 operations across 3 categories:
    • users (5 operations)
    • orders (7 operations) 
@@ -187,7 +187,7 @@ aperture config add myapi spec.yaml
 - Display security requirements from `x-aperture-secret` extensions
 
 ### 5. Output Formatting Options
-**🏗️ Architectural Impact: MEDIUM** | **Module: `src/engine/executor.rs`, `src/agent.rs`**
+**Architectural Impact: MEDIUM** | **Module: `src/engine/executor.rs`, `src/agent.rs`**
 
 **Current State:** JSON-only output
 
@@ -227,9 +227,9 @@ aperture api pokeapi pokemon api_v2_pokemon_retrieve pikachu --quiet
 aperture api assembla tickets get-ticket-by-number "tech-demonstrator" "3501" --verbose
 🔗 Request: GET https://api.assembla.com/v1/spaces/tech-demonstrator/tickets/3501
 📤 Headers: x-api-key, x-api-secret, user-agent
-⏱️  Response time: 234ms
+Response time: 234ms
 📥 Response size: 2.1KB
-✅ Status: 200 OK
+Status: 200 OK
 ```
 
 **Implementation Strategy:**
@@ -242,7 +242,7 @@ aperture api assembla tickets get-ticket-by-number "tech-demonstrator" "3501" --
 ## 🌟 Future Feature Requests
 
 ### 6. Response Filtering & Transformation
-**🏗️ Architectural Impact: HIGH** | **Module: `src/engine/executor.rs`, `src/filters/` (new)**
+**Architectural Impact: HIGH** | **Module: `src/engine/executor.rs`, `src/filters/` (new)**
 
 **JQ Integration:**
 ```bash
@@ -272,7 +272,7 @@ aperture api openweathermap forecast --extract "list[].main.temp_max"
 - Add filter validation and error handling through existing error system
 
 ### 7. Bulk Operations
-**🏗️ Architectural Impact: HIGH** | **Module: `src/engine/executor.rs`, `src/batch/` (new)**
+**Architectural Impact: HIGH** | **Module: `src/engine/executor.rs`, `src/batch/` (new)**
 
 **Batch Requests:**
 ```bash
@@ -302,7 +302,7 @@ aperture api myapi users get-user --batch user-ids.txt --parallel 5 --rate-limit
 - Preserve individual request error handling within batch context
 
 ### 8. Configuration Profiles
-**🏗️ Architectural Impact: MEDIUM** | **Module: `src/config/models.rs`, `src/config/manager.rs`**
+**Architectural Impact: MEDIUM** | **Module: `src/config/models.rs`, `src/config/manager.rs`**
 
 **Environment-based Profiles:**
 ```bash
@@ -339,7 +339,7 @@ aperture config profile delete staging
 - Environment variable substitution within profile context
 
 ### 9. Request/Response Caching
-**🏗️ Architectural Impact: MEDIUM** | **Module: `src/cache/` (extend existing), `src/engine/executor.rs`**
+**Architectural Impact: MEDIUM** | **Module: `src/cache/` (extend existing), `src/engine/executor.rs`**
 
 **Response Caching:**
 ```bash
@@ -364,7 +364,7 @@ aperture cache stats
 - Integration with existing file system abstraction for testability
 
 ### 10. Plugin System
-**🏗️ Architectural Impact: HIGH** | **Module: `src/plugins/` (new), `src/engine/loader.rs`**
+**Architectural Impact: HIGH** | **Module: `src/plugins/` (new), `src/engine/loader.rs`**
 
 **Custom Extensions:**
 ```bash
@@ -388,7 +388,7 @@ aperture api myapi data export --processor csv-converter
 - Plugin discovery through configuration directory scanning
 - Sandboxed execution environment with restricted file system access
 
-## 📋 Implementation Roadmap
+## Implementation Roadmap
 
 ### Phase 1: Core UX Improvements (Foundation)
 **Target Module Integration:**
@@ -418,7 +418,7 @@ aperture api myapi data export --processor csv-converter
 - [ ] **Advanced authentication flows** → Plugin-based auth extensions
 - [ ] **Testing & monitoring tools** → Plugin-based development tooling
 
-## 🏗️ Critical Architectural Decisions
+## Critical Architectural Decisions
 
 ### Design Principles Preservation
 All improvements must maintain Aperture's core architectural principles:
@@ -457,7 +457,7 @@ All improvements must maintain Aperture's core architectural principles:
 - Migration tooling for configuration format changes
 - Deprecation warnings with clear upgrade paths
 
-## 🧪 Testing Strategy
+## Testing Strategy
 
 Each improvement should include:
 
@@ -467,7 +467,7 @@ Each improvement should include:
 4. **Performance Tests:** Response time and resource usage
 5. **User Experience Tests:** Real-world usage scenarios
 
-## 📖 Documentation Updates
+## Documentation Updates
 
 Improvements should be accompanied by:
 

--- a/docs/archive/future_improvements_v0.1.md
+++ b/docs/archive/future_improvements_v0.1.md
@@ -19,7 +19,7 @@ Aperture follows key design patterns that must be preserved during improvements:
 - **`src/error.rs`**: Centralized error handling using `thiserror`
 - **`src/agent.rs`**: Agent-friendly feature implementations
 
-## 🎯 High Priority Improvements
+## High Priority Improvements
 
 ### 1. Query Parameter Authentication Support
 **Architectural Impact: HIGH** | **Module: `src/config/models.rs`, `src/engine/executor.rs`**
@@ -90,13 +90,13 @@ aperture api sentry default get-project-issues --org "ouro" --project "core" --s
 
 **Current State:** Generic error messages with limited actionable guidance
 ```
-🚫 Configuration Error
+Configuration Error
 Request failed with status 401 Unauthorized
 ```
 
 **Proposed Improvements:**
 ```
-🚫 Authentication Error (401 Unauthorized)
+Authentication Error (401 Unauthorized)
 API key invalid or expired for OpenWeatherMap API.
 
 Troubleshooting:
@@ -174,11 +174,11 @@ aperture config add myapi --interactive
 # Enhanced feedback during add
 aperture config add myapi spec.yaml
 Spec validated successfully
-📊 Discovered 15 operations across 3 categories:
+Discovered 15 operations across 3 categories:
    • users (5 operations)
    • orders (7 operations) 
    • products (3 operations)
-🔐 Authentication: Bearer token (MYAPI_TOKEN required)
+Authentication: Bearer token (MYAPI_TOKEN required)
 ```
 
 **Implementation Strategy:**
@@ -225,10 +225,10 @@ aperture api pokeapi pokemon api_v2_pokemon_retrieve pikachu --quiet
 #### Verbose Mode
 ```bash
 aperture api assembla tickets get-ticket-by-number "tech-demonstrator" "3501" --verbose
-🔗 Request: GET https://api.assembla.com/v1/spaces/tech-demonstrator/tickets/3501
-📤 Headers: x-api-key, x-api-secret, user-agent
+Request: GET https://api.assembla.com/v1/spaces/tech-demonstrator/tickets/3501
+Headers: x-api-key, x-api-secret, user-agent
 Response time: 234ms
-📥 Response size: 2.1KB
+Response size: 2.1KB
 Status: 200 OK
 ```
 
@@ -239,7 +239,7 @@ Status: 200 OK
 - Extend `--describe-json` to include format options metadata
 - Ensure verbose mode integrates with existing request timing infrastructure
 
-## 🌟 Future Feature Requests
+## Future Feature Requests
 
 ### 6. Response Filtering & Transformation
 **Architectural Impact: HIGH** | **Module: `src/engine/executor.rs`, `src/filters/` (new)**

--- a/docs/archive/plan.md
+++ b/docs/archive/plan.md
@@ -132,14 +132,14 @@ All development will adhere to the following principles:
   - **Action:** Create `src/engine/loader.rs`. Implement a function to load and deserialize a `.bin` file from the cache directory based on a context name.
   - **Test:** Write a unit test that saves a mock cache file and asserts that the loader can read it back correctly.
   - **Commit:** `feat(engine): Implement cached spec loader`
-  - **Status:** ✅ **COMPLETED** - Full implementation with comprehensive error handling and unit tests
+  - **Status:** **COMPLETED** - Full implementation with comprehensive error handling and unit tests
 
 - `[x]` **Task 4.2: Implement Dynamic Command Generator**
 
   - **Action:** Create `src/engine/generator.rs`. Implement a function that takes the cached spec data and recursively builds a `clap::Command` tree according to the rules in SDD §5.1.
   - **Test:** Write a unit test with a sample cached spec. Generate the `clap::Command` and then inspect the generated structure to assert that subcommands and flags are created as expected.
   - **Commit:** `feat(engine): Implement dynamic CLI generator from cached spec`
-  - **Status:** ✅ **COMPLETED** - Dynamic CLI generation with tag-based organization and parameter mapping
+  - **Status:** **COMPLETED** - Dynamic CLI generation with tag-based organization and parameter mapping
 
 - `[x]` **Task 4.3: Implement the HTTP Request Executor**
 
@@ -156,13 +156,13 @@ All development will adhere to the following principles:
     - Assert that the mock server received a request with the correct method, path, query params, headers (including auth), and body.
     - Assert that the executor correctly handles both successful responses and API error responses (e.g., 404, 500).
   - **Commit:** `feat(engine): Implement HTTP request executor and response validator`
-  - **Status:** ✅ **COMPLETED** - Full HTTP executor with authentication, custom headers, and comprehensive error handling
+  - **Status:** **COMPLETED** - Full HTTP executor with authentication, custom headers, and comprehensive error handling
 
 - `[x]` **Task 4.4: Integrate the Engine into `main.rs`**
   - **Action:** Modify `main.rs`. After parsing the context name, it should invoke the loader, generator, and executor in sequence.
   - **Test:** Write full end-to-end tests with `assert_cmd` and a running `wiremock` server.
   - **Commit:** `feat(app): Integrate execution engine into main application flow`
-  - **Status:** ✅ **COMPLETED** - Full pipeline integration with end-to-end testing
+  - **Status:** **COMPLETED** - Full pipeline integration with end-to-end testing
 
 ---
 
@@ -177,20 +177,20 @@ All development will adhere to the following principles:
   - **Action:** Add the global flag. If present, load the cached spec and serialize it into the specified JSON format. Print to stdout and exit.
   - **Test:** Use `assert_cmd` to run `aperture <context> --describe-json`. Capture the stdout and validate it against a JSON schema or a snapshot file.
   - **Commit:** `feat(agent): Implement --describe-json capability manifest`
-  - **Status:** ✅ **COMPLETED** - Full capability manifest generation with security information extraction
+  - **Status:** **COMPLETED** - Full capability manifest generation with security information extraction
 
 - `[x]` **Task 5.2: Implement `--json-errors`**
 
   - **Action:** Add the global flag. Modify the top-level error handling in `main.rs` to serialize the `Error` enum to JSON and print to stderr if the flag is active.
   - **Test:** Use `assert_cmd` to trigger various known errors (e.g., pointing to a non-existent spec) with the flag enabled. Assert that the stderr output is the expected JSON.
   - **Commit:** `feat(agent): Implement --json-errors for structured error reporting`
-  - **Status:** ✅ **COMPLETED** - Structured JSON error output for programmatic error handling
+  - **Status:** **COMPLETED** - Structured JSON error output for programmatic error handling
 
 - `[x]` **Task 5.3: Implement `--dry-run` and Idempotency**
   - **Action:** Modify the `engine::executor`. Before executing the request, check for the `--dry-run` flag. Also, check for the auto-idempotency configuration and the `--idempotency-key` flag to add the correct header.
   - **Test:** For `--dry-run`, use `assert_cmd` to check the JSON output. For idempotency, use `wiremock-rs` to assert the header is present on the request.
   - **Commit:** `feat(agent): Implement --dry-run and idempotency controls`
-  - **Status:** ✅ **COMPLETED** - Request introspection and idempotency support for safe automation
+  - **Status:** **COMPLETED** - Request introspection and idempotency support for safe automation
 
 ---
 
@@ -204,13 +204,13 @@ All development will adhere to the following principles:
   - **Action:** Create a `README.md` that explains the project's purpose, installation, and basic usage.
   - **Action:** Create user documentation (e.g., in a `/docs` directory) that details all commands, the `config.toml` file, and the supported OpenAPI features.
   - **Commit:** `docs: Write initial user and project documentation`
-  - **Status:** ✅ **COMPLETED** - Comprehensive README, architecture docs, ADRs, and SECURITY.md
+  - **Status:** **COMPLETED** - Comprehensive README, architecture docs, ADRs, and SECURITY.md
 
 - `[x]` **Task 6.2: Prepare for Release**
   - **Action:** Integrate `cargo-release` to automate version bumping, tagging, and publishing.
   - **Action:** Enhance the `ci.yml` workflow to build release binaries for multiple targets and attach them to a GitHub Release when a tag is pushed.
   - **Commit:** `chore(release): Configure cargo-release and binary release workflow`
-  - **Status:** ✅ **COMPLETED** - Release automation with GitHub Actions and crates.io publishing
+  - **Status:** **COMPLETED** - Release automation with GitHub Actions and crates.io publishing
 
 ---
 
@@ -239,15 +239,15 @@ Beyond the original plan, the following major features have been successfully im
 
 ---
 
-## **Project Status: Experimental** 🧪
+## **Project Status: Experimental**
 
 **All planned phases completed successfully.** Aperture CLI has been released as an experimental tool and continues to evolve with:
 
-- ✅ **Full Feature Set**: Dynamic CLI generation, authentication, base URL management, agent features
-- ✅ **Comprehensive Testing**: Unit and integration tests, error handling, documentation
-- ✅ **Agent-First Design**: JSON output modes, capability manifests, structured errors
-- ✅ **Security Model**: Environment variable-based authentication with strict separation
-- ✅ **Release Pipeline**: Automated publishing, quality gates, comprehensive changelog
+- **Full Feature Set**: Dynamic CLI generation, authentication, base URL management, agent features
+- **Comprehensive Testing**: Unit and integration tests, error handling, documentation
+- **Agent-First Design**: JSON output modes, capability manifests, structured errors
+- **Security Model**: Environment variable-based authentication with strict separation
+- **Release Pipeline**: Automated publishing, quality gates, comprehensive changelog
 
 **Note**: This is experimental software. While core features are implemented and tested, APIs and behavior may change as we gather feedback and iterate on the design.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -158,11 +158,11 @@ aperture api my-api orders search --status pending --created-after 2024-01-01
 Execution-oriented flags are scoped to execution commands (`api`, `run`) instead of being global.
 
 ```bash
-# ✅ Scoped execution flags on execution commands
+# Supported on execution commands
 aperture api my-api --dry-run users get-user-by-id --id 123
 aperture run --dry-run getUserById --id 123
 
-# ❌ Rejected on non-execution commands
+# Not allowed on non-execution commands
 aperture docs --dry-run
 ```
 

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -446,11 +446,11 @@ impl DocumentationGenerator {
     /// Add metadata section with deprecation and external docs
     fn add_metadata_section(help: &mut String, command: &CachedCommand) {
         if command.deprecated {
-            help.push_str("⚠️  **This operation is deprecated**\n\n");
+            help.push_str("Deprecated: this operation is deprecated\n\n");
         }
 
         if let Some(ref docs_url) = command.external_docs_url {
-            write!(help, "📖 **External Documentation**: {docs_url}\n\n").ok();
+            write!(help, "External documentation: {docs_url}\n\n").ok();
         }
     }
 
@@ -721,7 +721,7 @@ impl HelpFormatter {
         let mut output = String::new();
 
         // Header with API info
-        writeln!(output, "📋 {} API Commands", spec.name).ok();
+        writeln!(output, "{} API Commands", spec.name).ok();
         let visible_commands: Vec<&CachedCommand> = spec
             .commands
             .iter()
@@ -750,7 +750,7 @@ impl HelpFormatter {
         }
 
         for (tag, commands) in tag_groups {
-            writeln!(output, "\n📁 {tag}").ok();
+            writeln!(output, "\nGroup: {tag}").ok();
             output.push_str(&"─".repeat(40));
             output.push('\n');
 
@@ -769,7 +769,7 @@ impl HelpFormatter {
                     "  {} {} {}{}",
                     method_badge,
                     operation_kebab,
-                    if command.deprecated { "⚠️" } else { "" },
+                    if command.deprecated { "Deprecated" } else { "" },
                     description
                 )
                 .ok();
@@ -783,17 +783,8 @@ impl HelpFormatter {
         output
     }
 
-    /// Format HTTP method with color/styling
+    /// Format HTTP method for display.
     fn format_method_badge(method: &str) -> String {
-        match method.to_uppercase().as_str() {
-            "GET" => "🔍 GET   ".to_string(),
-            "POST" => "📝 POST  ".to_string(),
-            "PUT" => "✏️  PUT   ".to_string(),
-            "DELETE" => "🗑️  DELETE".to_string(),
-            "PATCH" => "🔧 PATCH ".to_string(),
-            "HEAD" => "👁️  HEAD  ".to_string(),
-            "OPTIONS" => "⚙️  OPTIONS".to_string(),
-            _ => format!("📋 {:<7}", method.to_uppercase()),
-        }
+        format!("{:<7}", method.to_uppercase())
     }
 }

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -153,6 +153,22 @@ fn test_generate_command_help() {
 }
 
 #[test]
+fn test_generate_command_help_includes_deprecation_notice() {
+    let mut spec = create_test_spec();
+    spec.commands[0].deprecated = true;
+
+    let mut specs = BTreeMap::new();
+    specs.insert("testapi".to_string(), spec);
+
+    let doc_gen = DocumentationGenerator::new(specs);
+    let help = doc_gen
+        .generate_command_help("testapi", "users", "get-user-by-id")
+        .unwrap();
+
+    assert!(help.contains("Deprecated: this operation is deprecated"));
+}
+
+#[test]
 fn test_generate_command_help_with_request_body() {
     let mut specs = BTreeMap::new();
     specs.insert("testapi".to_string(), create_test_spec());

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -148,7 +148,7 @@ fn test_generate_command_help() {
     assert!(help.contains("## Responses"));
     assert!(help.contains("**200**: User found successfully"));
     assert!(help.contains("**404**: User not found"));
-    assert!(help.contains("📖 **External Documentation**"));
+    assert!(help.contains("External documentation:"));
     assert!(help.contains("https://docs.test.com/users"));
 }
 
@@ -292,13 +292,13 @@ fn test_help_formatter_command_list() {
     let spec = create_test_spec();
     let formatted = HelpFormatter::format_command_list(&spec);
 
-    assert!(formatted.contains("📋 TestAPI API Commands"));
+    assert!(formatted.contains("TestAPI API Commands"));
     assert!(formatted.contains("Version: 1.0.0"));
     assert!(formatted.contains("Operations: 2"));
     assert!(formatted.contains("Base URL: https://api.test.com"));
-    assert!(formatted.contains("📁 users"));
-    assert!(formatted.contains("🔍 GET"));
-    assert!(formatted.contains("📝 POST"));
+    assert!(formatted.contains("Group: users"));
+    assert!(formatted.contains("GET"));
+    assert!(formatted.contains("POST"));
     assert!(formatted.contains("get-user"));
     assert!(formatted.contains("create-user"));
     assert!(formatted.contains("Path: /users/{id}"));
@@ -310,9 +310,9 @@ fn test_help_formatter_method_badges() {
     let spec = create_test_spec();
     let formatted = HelpFormatter::format_command_list(&spec);
 
-    // Check that different HTTP methods get different badges
-    assert!(formatted.contains("🔍 GET"));
-    assert!(formatted.contains("📝 POST"));
+    // Check that different HTTP methods remain distinguishable
+    assert!(formatted.contains("GET"));
+    assert!(formatted.contains("POST"));
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn test_deprecated_command_indication() {
     spec.commands[0].deprecated = true;
 
     let formatted = HelpFormatter::format_command_list(&spec);
-    assert!(formatted.contains("⚠️"));
+    assert!(formatted.contains("Deprecated"));
 }
 
 #[test]
@@ -401,7 +401,7 @@ fn test_help_formatter_uses_effective_names_and_hides_hidden_commands() {
     let formatted = HelpFormatter::format_command_list(&spec);
 
     assert!(formatted.contains("Operations: 1"));
-    assert!(formatted.contains("📁 accounts"));
+    assert!(formatted.contains("Group: accounts"));
     assert!(formatted.contains("fetch"));
     assert!(!formatted.contains("create-user"));
 }


### PR DESCRIPTION
Refs #174.

Summary:
- Replaced icon-based markers in CLI docs/help output with plain ASCII labels.
- Updated tests to assert against the new plain-text formatting.
- Removed decorative glyphs from active docs guidance and changelog grouping labels.