### PR TITLE
feat: add optional semantic color to discovery output

### DIFF
--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -6,6 +6,7 @@ use crate::cli::{Cli, ExecutionFlags};
 use crate::config::manager::{get_config_dir, ConfigManager};
 use crate::config::models::GlobalConfig;
 use crate::constants;
+use crate::discovery_style::DiscoveryStyle;
 use crate::engine::{executor, generator, loader};
 use crate::error::Error;
 use crate::fs::OsFileSystem;
@@ -167,36 +168,42 @@ fn handle_show_examples_command(
 }
 
 fn render_api_context_landing(context: &str, spec: &CachedSpec) -> Result<(), Error> {
+    let style = DiscoveryStyle::for_stdout();
     let mut specs = std::collections::BTreeMap::new();
     specs.insert(context.to_string(), spec.clone());
 
     let doc_gen = crate::docs::DocumentationGenerator::new(specs);
-    let mut overview = doc_gen.generate_api_overview(context)?;
+    let mut overview = doc_gen.generate_api_overview_styled(context, style)?;
 
-    overview.push_str("## Next Steps\n\n");
+    writeln!(overview, "## {}\n", style.heading("Next Steps")).ok();
     writeln!(
         overview,
-        "- Discover by intent: `aperture search \"<keyword>\" --api {context}`"
+        "- {} `aperture search \"<keyword>\" --api {context}`",
+        style.next_label("Discover by intent:")
     )
     .ok();
     writeln!(
         overview,
-        "- Inspect command paths: `aperture commands {context}`"
+        "- {} `aperture commands {context}`",
+        style.next_label("Inspect command paths:")
     )
     .ok();
     writeln!(
         overview,
-        "- Read operation docs: `aperture docs {context} <tag> <operation>`"
+        "- {} `aperture docs {context} <tag> <operation>`",
+        style.next_label("Read operation docs:")
     )
     .ok();
     writeln!(
         overview,
-        "- Execute an operation: `aperture api {context} <tag> <operation> ...`"
+        "- {} `aperture api {context} <tag> <operation> ...`",
+        style.next_label("Execute an operation:")
     )
     .ok();
     writeln!(
         overview,
-        "- Machine manifest: `aperture api {context} --describe-json`"
+        "- {} `aperture api {context} --describe-json`",
+        style.next_label("Machine manifest:")
     )
     .ok();
 

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -4,6 +4,7 @@ use crate::config::context_name::ApiContextName;
 use crate::config::manager::{get_config_dir, ConfigManager};
 use crate::config::models::SecretSource;
 use crate::constants;
+use crate::discovery_style::DiscoveryStyle;
 use crate::error::Error;
 use crate::fs::OsFileSystem;
 use crate::output::Output;
@@ -29,9 +30,10 @@ async fn handle_add_spec_command(
     manager
         .add_spec_auto(&name, &file_or_url, force, strict)
         .await?;
-    output.success(format!("Spec '{name}' added successfully."));
-    print_partial_add_acceptance_summary(manager, &name, output);
-    print_config_add_next_steps(&name, output);
+    let style = DiscoveryStyle::for_stdout();
+    output.success(style.success(format!("Spec '{name}' added successfully.")));
+    print_partial_add_acceptance_summary(manager, &name, output, style);
+    print_config_add_next_steps(&name, output, style);
     Ok(())
 }
 
@@ -39,6 +41,7 @@ fn print_partial_add_acceptance_summary(
     manager: &ConfigManager<OsFileSystem>,
     name: &ApiContextName,
     output: &Output,
+    style: DiscoveryStyle,
 ) {
     let cache_dir = manager.config_dir().join(constants::DIR_CACHE);
     let Ok(cached_spec) = crate::engine::loader::load_cached_spec(&cache_dir, name.as_str()) else {
@@ -52,20 +55,38 @@ fn print_partial_add_acceptance_summary(
 
     let available = cached_spec.commands.len();
     let total = available + skipped;
-    output.info(format!(
+    output.info(style.warning(format!(
         "Partial spec acceptance: {available} of {total} endpoints available ({skipped} skipped)."
+    )));
+    output.tip(format!(
+        "{} skipped endpoints with 'aperture config list --verbose'.",
+        style.next_label("Review")
     ));
-    output.tip("Review skipped endpoints with 'aperture config list --verbose'.");
 }
 
-fn print_config_add_next_steps(name: &ApiContextName, output: &Output) {
+fn print_config_add_next_steps(name: &ApiContextName, output: &Output, style: DiscoveryStyle) {
     let context = name.as_str();
-    output.info("Next steps:");
-    output.tip(format!("  1. aperture overview {context}"));
-    output.tip(format!("  2. aperture search <term> --api {context}"));
-    output.tip(format!("  3. aperture list-commands {context}"));
-    output.tip(format!("  4. aperture docs {context} <tag> <operation>"));
-    output.tip(format!("  5. aperture api {context} --describe-json"));
+    output.info(style.next_label("Next steps:"));
+    output.tip(format!(
+        "  {} aperture overview {context}",
+        style.next_label("1.")
+    ));
+    output.tip(format!(
+        "  {} aperture search <term> --api {context}",
+        style.next_label("2.")
+    ));
+    output.tip(format!(
+        "  {} aperture list-commands {context}",
+        style.next_label("3.")
+    ));
+    output.tip(format!(
+        "  {} aperture docs {context} <tag> <operation>",
+        style.next_label("4.")
+    ));
+    output.tip(format!(
+        "  {} aperture api {context} --describe-json",
+        style.next_label("5.")
+    ));
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -4,6 +4,7 @@ use crate::cache::models::{CachedCommand, CachedSpec};
 use crate::cli::DiscoveryFormat;
 use crate::config::manager::{get_config_dir, ConfigManager};
 use crate::constants;
+use crate::discovery_style::DiscoveryStyle;
 use crate::docs::{DocumentationGenerator, HelpFormatter};
 use crate::engine::loader;
 use crate::error::Error;
@@ -201,20 +202,25 @@ pub fn list_commands(
 
     match format {
         DiscoveryFormat::Text => {
-            let formatted_output = HelpFormatter::format_command_list(&spec);
+            let style = DiscoveryStyle::for_stdout();
+            let formatted_output = HelpFormatter::format_command_list_with_style(&spec, style);
             // ast-grep-ignore: no-println
             println!("{formatted_output}");
             output.tip(format!(
-                "Next: 'aperture overview {context}' for high-level API orientation"
+                "{} 'aperture overview {context}' for high-level API orientation",
+                style.next_label("Next:")
             ));
             output.tip(format!(
-                "Next: 'aperture search <term> --api {context}' to find operations by intent"
+                "{} 'aperture search <term> --api {context}' to find operations by intent",
+                style.next_label("Next:")
             ));
             output.tip(format!(
-                "Next: 'aperture docs {context} <tag> <operation>' for deep operation docs"
+                "{} 'aperture docs {context} <tag> <operation>' for deep operation docs",
+                style.next_label("Next:")
             ));
             output.tip(format!(
-                "Execute: 'aperture api {context} <tag> <operation> ...'"
+                "{} 'aperture api {context} <tag> <operation> ...'",
+                style.next_label("Execute:")
             ));
             Ok(())
         }
@@ -311,16 +317,19 @@ fn render_api_reference_index(
     api: &str,
     output: &Output,
 ) -> Result<(), Error> {
+    let style = DiscoveryStyle::for_stdout();
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
-    let reference = doc_gen.generate_api_reference_index(api)?;
+    let reference = doc_gen.generate_api_reference_index_styled(api, style)?;
     // ast-grep-ignore: no-println
     println!("{reference}");
     output.tip(format!(
-        "Execute operations with 'aperture api {api} <tag> <operation> ...'"
+        "{} operations with 'aperture api {api} <tag> <operation> ...'",
+        style.next_label("Execute")
     ));
     output.tip(format!(
-        "Machine workflow: 'aperture api {api} --describe-json'"
+        "{} 'aperture api {api} --describe-json'",
+        style.next_label("Machine workflow:")
     ));
     Ok(())
 }
@@ -384,19 +393,24 @@ fn render_command_help(
     enhanced: bool,
     output: &Output,
 ) -> Result<(), Error> {
+    let style = DiscoveryStyle::for_stdout();
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
-    let help = doc_gen.generate_command_help(api, tag, operation)?;
+    let help = doc_gen.generate_command_help_styled(api, tag, operation, style)?;
     if enhanced {
         // ast-grep-ignore: no-println
         println!("{help}");
     } else {
         // ast-grep-ignore: no-println
         println!("{}", help.lines().take(20).collect::<Vec<_>>().join("\n"));
-        output.tip("Use --enhanced for full documentation with examples");
+        output.tip(format!(
+            "{} --enhanced for full documentation with examples",
+            style.next_label("Use")
+        ));
     }
     output.tip(format!(
-        "Execute with 'aperture api {api} <tag> <operation> ...' after inspection"
+        "{} with 'aperture api {api} <tag> <operation> ...' after inspection",
+        style.next_label("Execute")
     ));
     Ok(())
 }
@@ -563,22 +577,27 @@ fn render_single_api_overview(
     api: &str,
     output: &Output,
 ) -> Result<(), Error> {
+    let style = DiscoveryStyle::for_stdout();
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
-    let overview = doc_gen.generate_api_overview(api)?;
+    let overview = doc_gen.generate_api_overview_styled(api, style)?;
     // ast-grep-ignore: no-println
     println!("{overview}");
     output.tip(format!(
-        "Next: 'aperture search <term> --api {api}' to find specific operations"
+        "{} 'aperture search <term> --api {api}' to find specific operations",
+        style.next_label("Next:")
     ));
     output.tip(format!(
-        "Next: 'aperture commands {api}' for a terse command tree"
+        "{} 'aperture commands {api}' for a terse command tree",
+        style.next_label("Next:")
     ));
     output.tip(format!(
-        "Next: 'aperture docs {api} <tag> <operation>' for deep operation reference"
+        "{} 'aperture docs {api} <tag> <operation>' for deep operation reference",
+        style.next_label("Next:")
     ));
     output.tip(format!(
-        "Machine workflow: 'aperture api {api} --describe-json'"
+        "{} 'aperture api {api} --describe-json'",
+        style.next_label("Machine workflow:")
     ));
     Ok(())
 }

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -2,11 +2,12 @@
 
 use crate::config::manager::ConfigManager;
 use crate::constants;
+use crate::discovery_style::DiscoveryStyle;
 use crate::engine::loader;
 use crate::error::Error;
 use crate::fs::OsFileSystem;
 use crate::output::Output;
-use crate::search::{format_search_results, CommandSearcher};
+use crate::search::CommandSearcher;
 
 pub fn execute_search_command(
     manager: &ConfigManager<OsFileSystem>,
@@ -34,7 +35,9 @@ pub fn execute_search_command(
 
     let searcher = CommandSearcher::new();
     let results = searcher.search(&all_specs, query, api_filter)?;
-    let formatted_results = format_search_results(&results, verbose);
+    let style = DiscoveryStyle::for_stdout();
+    let formatted_results =
+        crate::search::format_search_results_with_style(&results, verbose, style);
     for line in formatted_results {
         // ast-grep-ignore: no-println
         println!("{line}");

--- a/src/discovery_style.rs
+++ b/src/discovery_style.rs
@@ -117,4 +117,29 @@ mod tests {
         let style = DiscoveryStyle::from_detection(true, Some(std::ffi::OsStr::new("1")));
         assert!(!style.is_enabled());
     }
+
+    #[test]
+    fn empty_no_color_value_disables_when_tty() {
+        let style = DiscoveryStyle::from_detection(true, Some(std::ffi::OsStr::new("")));
+        assert!(!style.is_enabled());
+    }
+
+    #[test]
+    fn method_normalizes_lowercase_tokens() {
+        let style = DiscoveryStyle::new(false);
+        assert_eq!(style.method("get"), "GET");
+    }
+
+    #[test]
+    fn method_falls_back_to_bold_for_unknown_tokens() {
+        let style = DiscoveryStyle::new(true);
+        assert_eq!(style.method("BREW"), "\u{1b}[1mBREW\u{1b}[0m");
+    }
+
+    #[test]
+    fn method_handles_empty_or_whitespace_tokens_safely() {
+        let style = DiscoveryStyle::new(false);
+        assert_eq!(style.method(""), "");
+        assert_eq!(style.method("   "), "   ");
+    }
 }

--- a/src/discovery_style.rs
+++ b/src/discovery_style.rs
@@ -1,0 +1,120 @@
+//! Semantic ANSI styling for human-facing discovery output.
+//!
+//! Styling is enabled only when stdout is a TTY and `NO_COLOR` is not set.
+
+use std::io::IsTerminal;
+
+#[derive(Debug, Clone, Copy)]
+pub struct DiscoveryStyle {
+    enabled: bool,
+}
+
+impl DiscoveryStyle {
+    #[must_use]
+    pub fn for_stdout() -> Self {
+        let no_color = std::env::var_os("NO_COLOR");
+        Self::from_detection(std::io::stdout().is_terminal(), no_color.as_deref())
+    }
+
+    #[must_use]
+    pub const fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+
+    #[must_use]
+    const fn from_detection(is_stdout_tty: bool, no_color: Option<&std::ffi::OsStr>) -> Self {
+        Self::new(is_stdout_tty && no_color.is_none())
+    }
+
+    #[must_use]
+    pub const fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    #[must_use]
+    pub fn api_title(self, text: impl AsRef<str>) -> String {
+        self.wrap("1;97", text)
+    }
+
+    #[must_use]
+    pub fn heading(self, text: impl AsRef<str>) -> String {
+        self.wrap("1", text)
+    }
+
+    #[must_use]
+    pub fn metadata(self, text: impl AsRef<str>) -> String {
+        self.wrap("2", text)
+    }
+
+    #[must_use]
+    pub fn next_label(self, text: impl AsRef<str>) -> String {
+        self.wrap("36", text)
+    }
+
+    #[must_use]
+    pub fn required(self, text: impl AsRef<str>) -> String {
+        self.wrap("1;33", text)
+    }
+
+    #[must_use]
+    pub fn success(self, text: impl AsRef<str>) -> String {
+        self.wrap("32", text)
+    }
+
+    #[must_use]
+    pub fn warning(self, text: impl AsRef<str>) -> String {
+        self.wrap("33", text)
+    }
+
+    #[must_use]
+    pub fn method(self, method: &str) -> String {
+        let code = match method.to_ascii_uppercase().as_str() {
+            "GET" => "32",
+            "POST" => "34",
+            "PUT" => "33",
+            "PATCH" => "36",
+            "DELETE" => "31",
+            _ => "1",
+        };
+        self.wrap(code, method.to_ascii_uppercase())
+    }
+
+    #[must_use]
+    pub fn muted_count(self, text: impl AsRef<str>) -> String {
+        self.metadata(text)
+    }
+
+    #[must_use]
+    fn wrap(self, code: &str, text: impl AsRef<str>) -> String {
+        if !self.enabled {
+            return text.as_ref().to_string();
+        }
+
+        format!("\x1b[{code}m{}\x1b[0m", text.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DiscoveryStyle;
+
+    #[test]
+    fn enabled_styles_wrap_with_ansi() {
+        let style = DiscoveryStyle::new(true);
+        let rendered = style.method("GET");
+        assert!(rendered.starts_with("\u{1b}[32mGET"));
+        assert!(rendered.ends_with("\u{1b}[0m"));
+    }
+
+    #[test]
+    fn disabled_styles_return_plain_text() {
+        let style = DiscoveryStyle::new(false);
+        assert_eq!(style.heading("Usage"), "Usage");
+    }
+
+    #[test]
+    fn no_color_disables_even_when_tty() {
+        let style = DiscoveryStyle::from_detection(true, Some(std::ffi::OsStr::new("1")));
+        assert!(!style.is_enabled());
+    }
+}

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -2,6 +2,7 @@
 
 use crate::cache::models::{CachedCommand, CachedParameter, CachedSpec, CommandExample};
 use crate::constants;
+use crate::discovery_style::DiscoveryStyle;
 use crate::error::Error;
 use crate::utils::to_kebab_case;
 use std::collections::BTreeMap;
@@ -30,6 +31,20 @@ impl DocumentationGenerator {
         tag: &str,
         operation_id: &str,
     ) -> Result<String, Error> {
+        self.generate_command_help_styled(api_name, tag, operation_id, DiscoveryStyle::new(false))
+    }
+
+    /// Generate command help documentation with optional semantic styling.
+    ///
+    /// # Errors
+    /// Returns an error if the API or operation is not found
+    pub fn generate_command_help_styled(
+        &self,
+        api_name: &str,
+        tag: &str,
+        operation_id: &str,
+        style: DiscoveryStyle,
+    ) -> Result<String, Error> {
         let spec = self
             .specs
             .get(api_name)
@@ -48,14 +63,14 @@ impl DocumentationGenerator {
         let mut help = String::new();
 
         // Build help sections
-        Self::add_command_header(&mut help, command);
-        Self::add_usage_section(&mut help, api_name, command);
-        Self::add_parameters_section(&mut help, command);
-        Self::add_request_body_section(&mut help, command);
-        Self::add_examples_section(&mut help, api_name, command);
-        Self::add_responses_section(&mut help, command);
-        Self::add_authentication_section(&mut help, command);
-        Self::add_metadata_section(&mut help, command);
+        Self::add_command_header(&mut help, command, style);
+        Self::add_usage_section(&mut help, api_name, command, style);
+        Self::add_parameters_section(&mut help, command, style);
+        Self::add_request_body_section(&mut help, command, style);
+        Self::add_examples_section(&mut help, api_name, command, style);
+        Self::add_responses_section(&mut help, command, style);
+        Self::add_authentication_section(&mut help, command, style);
+        Self::add_metadata_section(&mut help, command, style);
 
         Ok(help)
     }
@@ -140,11 +155,11 @@ impl DocumentationGenerator {
     }
 
     /// Add command header with title and description
-    fn add_command_header(help: &mut String, command: &CachedCommand) {
+    fn add_command_header(help: &mut String, command: &CachedCommand, style: DiscoveryStyle) {
         write!(
             help,
             "# {} {}\n\n",
-            command.method.to_uppercase(),
+            style.method(&command.method),
             command.path
         )
         .ok();
@@ -159,8 +174,13 @@ impl DocumentationGenerator {
     }
 
     /// Add usage section with command syntax
-    fn add_usage_section(help: &mut String, api_name: &str, command: &CachedCommand) {
-        help.push_str("## Usage\n\n");
+    fn add_usage_section(
+        help: &mut String,
+        api_name: &str,
+        command: &CachedCommand,
+        style: DiscoveryStyle,
+    ) {
+        writeln!(help, "## {}\n", style.heading("Usage")).ok();
         write!(
             help,
             "```bash\n{}\n```\n\n",
@@ -194,17 +214,17 @@ impl DocumentationGenerator {
     }
 
     /// Add parameters section if parameters exist
-    fn add_parameters_section(help: &mut String, command: &CachedCommand) {
+    fn add_parameters_section(help: &mut String, command: &CachedCommand, style: DiscoveryStyle) {
         if command.parameters.is_empty() {
             return;
         }
 
-        help.push_str("## Parameters\n\n");
+        writeln!(help, "## {}\n", style.heading("Parameters")).ok();
         for param in &command.parameters {
             let required_badge = if param.required {
-                " **(required)**"
+                format!(" {}", style.required("**(required)**"))
             } else {
-                ""
+                String::new()
             };
             let param_type = param.schema_type.as_deref().unwrap_or("string");
             writeln!(
@@ -221,12 +241,12 @@ impl DocumentationGenerator {
     }
 
     /// Add request body section if present
-    fn add_request_body_section(help: &mut String, command: &CachedCommand) {
+    fn add_request_body_section(help: &mut String, command: &CachedCommand, style: DiscoveryStyle) {
         let Some(ref body) = command.request_body else {
             return;
         };
 
-        help.push_str("## Request Body\n\n");
+        writeln!(help, "## {}\n", style.heading("Request Body")).ok();
         if let Some(ref description) = body.description {
             write!(help, "{description}\n\n").ok();
         }
@@ -234,14 +254,19 @@ impl DocumentationGenerator {
     }
 
     /// Add examples section with command examples
-    fn add_examples_section(help: &mut String, api_name: &str, command: &CachedCommand) {
+    fn add_examples_section(
+        help: &mut String,
+        api_name: &str,
+        command: &CachedCommand,
+        style: DiscoveryStyle,
+    ) {
         let examples = Self::canonical_examples(api_name, command);
 
-        help.push_str(if examples.len() > 1 {
-            "## Examples\n\n"
+        if examples.len() > 1 {
+            writeln!(help, "## {}\n", style.heading("Examples")).ok();
         } else {
-            "## Example\n\n"
-        });
+            writeln!(help, "## {}\n", style.heading("Example")).ok();
+        }
 
         for (i, example) in examples.iter().enumerate() {
             if examples.len() > 1 {
@@ -415,9 +440,9 @@ impl DocumentationGenerator {
     }
 
     /// Add responses section if responses exist
-    fn add_responses_section(help: &mut String, command: &CachedCommand) {
+    fn add_responses_section(help: &mut String, command: &CachedCommand, style: DiscoveryStyle) {
         if !command.responses.is_empty() {
-            help.push_str("## Responses\n\n");
+            writeln!(help, "## {}\n", style.heading("Responses")).ok();
             for response in &command.responses {
                 writeln!(
                     help,
@@ -432,9 +457,13 @@ impl DocumentationGenerator {
     }
 
     /// Add authentication section if security requirements exist
-    fn add_authentication_section(help: &mut String, command: &CachedCommand) {
+    fn add_authentication_section(
+        help: &mut String,
+        command: &CachedCommand,
+        style: DiscoveryStyle,
+    ) {
         if !command.security_requirements.is_empty() {
-            help.push_str("## Authentication\n\n");
+            writeln!(help, "## {}\n", style.heading("Authentication")).ok();
             help.push_str("This operation requires authentication. Available schemes:\n\n");
             for scheme_name in &command.security_requirements {
                 writeln!(help, "- {scheme_name}").ok();
@@ -444,9 +473,14 @@ impl DocumentationGenerator {
     }
 
     /// Add metadata section with deprecation and external docs
-    fn add_metadata_section(help: &mut String, command: &CachedCommand) {
+    fn add_metadata_section(help: &mut String, command: &CachedCommand, style: DiscoveryStyle) {
         if command.deprecated {
-            help.push_str("Deprecated: this operation is deprecated\n\n");
+            writeln!(
+                help,
+                "{}\n",
+                style.warning("Deprecated: this operation is deprecated")
+            )
+            .ok();
         }
 
         if let Some(ref docs_url) = command.external_docs_url {
@@ -459,6 +493,18 @@ impl DocumentationGenerator {
     /// # Errors
     /// Returns an error if the API is not found
     pub fn generate_api_overview(&self, api_name: &str) -> Result<String, Error> {
+        self.generate_api_overview_styled(api_name, DiscoveryStyle::new(false))
+    }
+
+    /// Generate API overview with statistics and optional semantic styling.
+    ///
+    /// # Errors
+    /// Returns an error if the API is not found
+    pub fn generate_api_overview_styled(
+        &self,
+        api_name: &str,
+        style: DiscoveryStyle,
+    ) -> Result<String, Error> {
         let spec = self
             .specs
             .get(api_name)
@@ -471,10 +517,10 @@ impl DocumentationGenerator {
             .collect();
 
         let mut overview = String::new();
-        Self::write_api_overview_header(&mut overview, spec);
-        Self::write_api_overview_statistics(&mut overview, &visible_commands);
-        Self::write_api_overview_quick_start(&mut overview, api_name);
-        Self::write_api_overview_samples(&mut overview, api_name, &visible_commands);
+        Self::write_api_overview_header(&mut overview, spec, style);
+        Self::write_api_overview_statistics(&mut overview, &visible_commands, style);
+        Self::write_api_overview_quick_start(&mut overview, api_name, style);
+        Self::write_api_overview_samples(&mut overview, api_name, &visible_commands, style);
 
         Ok(overview)
     }
@@ -484,6 +530,18 @@ impl DocumentationGenerator {
     /// # Errors
     /// Returns an error if the API is not found
     pub fn generate_api_reference_index(&self, api_name: &str) -> Result<String, Error> {
+        self.generate_api_reference_index_styled(api_name, DiscoveryStyle::new(false))
+    }
+
+    /// Generate API reference index with optional semantic styling.
+    ///
+    /// # Errors
+    /// Returns an error if the API is not found
+    pub fn generate_api_reference_index_styled(
+        &self,
+        api_name: &str,
+        style: DiscoveryStyle,
+    ) -> Result<String, Error> {
         let spec = self
             .specs
             .get(api_name)
@@ -503,25 +561,36 @@ impl DocumentationGenerator {
         }
 
         let mut reference = String::new();
-        Self::write_api_reference_header(&mut reference, spec);
-        Self::write_api_reference_navigation(&mut reference, api_name);
-        Self::write_api_reference_categories(&mut reference, &category_counts);
-        Self::write_api_reference_examples(&mut reference, api_name, &visible_commands);
+        Self::write_api_reference_header(&mut reference, spec, style);
+        Self::write_api_reference_navigation(&mut reference, api_name, style);
+        Self::write_api_reference_categories(&mut reference, &category_counts, style);
+        Self::write_api_reference_examples(&mut reference, api_name, &visible_commands, style);
 
         Ok(reference)
     }
 
-    fn write_api_overview_header(overview: &mut String, spec: &CachedSpec) {
-        write!(overview, "# {} API\n\n", spec.name).ok();
-        writeln!(overview, "**Version**: {}", spec.version).ok();
+    fn write_api_overview_header(overview: &mut String, spec: &CachedSpec, style: DiscoveryStyle) {
+        writeln!(overview, "# {} API", style.api_title(&spec.name)).ok();
+        overview.push('\n');
+        writeln!(
+            overview,
+            "{}: {}",
+            style.metadata("**Version**"),
+            spec.version
+        )
+        .ok();
 
         if let Some(base_url) = spec.base_url.as_deref() {
-            writeln!(overview, "**Base URL**: {base_url}").ok();
+            writeln!(overview, "{}: {base_url}", style.metadata("**Base URL**")).ok();
         }
         overview.push('\n');
     }
 
-    fn write_api_overview_statistics(overview: &mut String, visible_commands: &[&CachedCommand]) {
+    fn write_api_overview_statistics(
+        overview: &mut String,
+        visible_commands: &[&CachedCommand],
+        style: DiscoveryStyle,
+    ) {
         let mut method_counts = BTreeMap::new();
         let mut tag_counts = BTreeMap::new();
 
@@ -532,26 +601,31 @@ impl DocumentationGenerator {
                 .or_insert(0) += 1;
         }
 
-        overview.push_str("## Statistics\n\n");
+        writeln!(overview, "## {}\n", style.heading("Statistics")).ok();
         writeln!(
             overview,
-            "- **Total Operations**: {}",
+            "- {}: {}",
+            style.muted_count("**Total Operations**"),
             visible_commands.len()
         )
         .ok();
-        overview.push_str("- **Methods**:\n");
+        writeln!(overview, "- {}:", style.metadata("**Methods**")).ok();
         for (method, count) in method_counts {
-            writeln!(overview, "  - {method}: {count}").ok();
+            writeln!(overview, "  - {}: {count}", style.method(&method)).ok();
         }
-        overview.push_str("- **Categories**:\n");
+        writeln!(overview, "- {}:", style.metadata("**Categories**")).ok();
         for (tag, count) in tag_counts {
             writeln!(overview, "  - {tag}: {count}").ok();
         }
         overview.push('\n');
     }
 
-    fn write_api_overview_quick_start(overview: &mut String, api_name: &str) {
-        overview.push_str("## Quick Start\n\n");
+    fn write_api_overview_quick_start(
+        overview: &mut String,
+        api_name: &str,
+        style: DiscoveryStyle,
+    ) {
+        writeln!(overview, "## {}\n", style.heading("Quick Start")).ok();
         write!(
             overview,
             "List all available commands:\n```bash\naperture commands {api_name}\n```\n\n"
@@ -569,12 +643,13 @@ impl DocumentationGenerator {
         overview: &mut String,
         api_name: &str,
         visible_commands: &[&CachedCommand],
+        style: DiscoveryStyle,
     ) {
         if visible_commands.is_empty() {
             return;
         }
 
-        overview.push_str("## Sample Operations\n\n");
+        writeln!(overview, "## {}\n", style.heading("Sample Operations")).ok();
         for (i, command) in visible_commands.iter().take(3).enumerate() {
             let tag = Self::effective_group(command);
             let operation = Self::effective_operation(command);
@@ -583,18 +658,29 @@ impl DocumentationGenerator {
                 "{}. **{}** ({})\n   ```bash\n   aperture api {api_name} {tag} {operation}\n   ```\n   {}\n\n",
                 i + 1,
                 command.summary.as_deref().unwrap_or(&operation),
-                command.method.to_uppercase(),
+                style.method(&command.method),
                 command.description.as_deref().unwrap_or("No description")
             )
             .ok();
         }
     }
 
-    fn write_api_reference_header(reference: &mut String, spec: &CachedSpec) {
-        write!(reference, "# {} API Reference\n\n", spec.name).ok();
-        writeln!(reference, "**Version**: {}", spec.version).ok();
+    fn write_api_reference_header(
+        reference: &mut String,
+        spec: &CachedSpec,
+        style: DiscoveryStyle,
+    ) {
+        writeln!(reference, "# {} API Reference", style.api_title(&spec.name)).ok();
+        reference.push('\n');
+        writeln!(
+            reference,
+            "{}: {}",
+            style.metadata("**Version**"),
+            spec.version
+        )
+        .ok();
         if let Some(base_url) = spec.base_url.as_deref() {
-            writeln!(reference, "**Base URL**: {base_url}").ok();
+            writeln!(reference, "{}: {base_url}", style.metadata("**Base URL**")).ok();
         }
         reference.push('\n');
         reference.push_str(
@@ -602,8 +688,12 @@ impl DocumentationGenerator {
         );
     }
 
-    fn write_api_reference_navigation(reference: &mut String, api_name: &str) {
-        reference.push_str("## Reference Workflow\n\n");
+    fn write_api_reference_navigation(
+        reference: &mut String,
+        api_name: &str,
+        style: DiscoveryStyle,
+    ) {
+        writeln!(reference, "## {}\n", style.heading("Reference Workflow")).ok();
         write!(
             reference,
             "1. Find operations by intent:\n```bash\naperture search \"keyword\" --api {api_name}\n```\n\n"
@@ -624,8 +714,9 @@ impl DocumentationGenerator {
     fn write_api_reference_categories(
         reference: &mut String,
         category_counts: &BTreeMap<String, usize>,
+        style: DiscoveryStyle,
     ) {
-        reference.push_str("## Categories\n\n");
+        writeln!(reference, "## {}\n", style.heading("Categories")).ok();
 
         if category_counts.is_empty() {
             reference.push_str("No visible operations found.\n\n");
@@ -642,12 +733,13 @@ impl DocumentationGenerator {
         reference: &mut String,
         api_name: &str,
         visible_commands: &[&CachedCommand],
+        style: DiscoveryStyle,
     ) {
         if visible_commands.is_empty() {
             return;
         }
 
-        reference.push_str("## Example Docs Paths\n\n");
+        writeln!(reference, "## {}\n", style.heading("Example Docs Paths")).ok();
         for command in visible_commands.iter().take(3) {
             let tag = Self::effective_group(command);
             let operation = Self::effective_operation(command);
@@ -718,10 +810,16 @@ impl HelpFormatter {
     /// Format command list with enhanced styling
     #[must_use]
     pub fn format_command_list(spec: &CachedSpec) -> String {
+        Self::format_command_list_with_style(spec, DiscoveryStyle::new(false))
+    }
+
+    /// Format command list with optional semantic styling.
+    #[must_use]
+    pub fn format_command_list_with_style(spec: &CachedSpec, style: DiscoveryStyle) -> String {
         let mut output = String::new();
 
         // Header with API info
-        writeln!(output, "{} API Commands", spec.name).ok();
+        writeln!(output, "{} API Commands", style.api_title(&spec.name)).ok();
         let visible_commands: Vec<&CachedCommand> = spec
             .commands
             .iter()
@@ -730,14 +828,16 @@ impl HelpFormatter {
 
         writeln!(
             output,
-            "   Version: {} | Operations: {}",
+            "   {}: {} | {}: {}",
+            style.metadata("Version"),
             spec.version,
+            style.metadata("Operations"),
             visible_commands.len()
         )
         .ok();
 
         if let Some(ref base_url) = spec.base_url {
-            writeln!(output, "   Base URL: {base_url}").ok();
+            writeln!(output, "   {}: {base_url}", style.metadata("Base URL")).ok();
         }
         output.push_str(&"═".repeat(60));
         output.push('\n');
@@ -750,13 +850,13 @@ impl HelpFormatter {
         }
 
         for (tag, commands) in tag_groups {
-            writeln!(output, "\nGroup: {tag}").ok();
+            writeln!(output, "\n{}: {}", style.heading("Group"), tag).ok();
             output.push_str(&"─".repeat(40));
             output.push('\n');
 
             for command in commands {
                 let operation_kebab = DocumentationGenerator::effective_operation(command);
-                let method_badge = Self::format_method_badge(&command.method);
+                let method_badge = Self::format_method_badge(&command.method, style);
                 let description = command
                     .summary
                     .as_ref()
@@ -775,7 +875,7 @@ impl HelpFormatter {
                 .ok();
 
                 // Show path as subdued text
-                writeln!(output, "     Path: {}", command.path).ok();
+                writeln!(output, "     {}: {}", style.metadata("Path"), command.path).ok();
             }
         }
 
@@ -784,7 +884,7 @@ impl HelpFormatter {
     }
 
     /// Format HTTP method for display.
-    fn format_method_badge(method: &str) -> String {
-        format!("{:<7}", method.to_uppercase())
+    fn format_method_badge(method: &str, style: DiscoveryStyle) -> String {
+        format!("{:<7}", style.method(method))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod command_guidance;
 pub mod config;
 pub mod constants;
+pub mod discovery_style;
 pub mod docs;
 pub mod duration;
 pub mod engine;

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,6 +6,7 @@
 
 use crate::cache::models::{CachedCommand, CachedParameter, CachedSpec};
 use crate::constants;
+use crate::discovery_style::DiscoveryStyle;
 use crate::error::Error;
 use crate::utils::to_kebab_case;
 use fuzzy_matcher::skim::SkimMatcherV2;
@@ -376,6 +377,16 @@ fn format_param_flag(p: &CachedParameter) -> String {
 /// Format search results for display
 #[must_use]
 pub fn format_search_results(results: &[CommandSearchResult], verbose: bool) -> Vec<String> {
+    format_search_results_with_style(results, verbose, DiscoveryStyle::new(false))
+}
+
+/// Format search results for display with optional semantic styling.
+#[must_use]
+pub fn format_search_results_with_style(
+    results: &[CommandSearchResult],
+    verbose: bool,
+    style: DiscoveryStyle,
+) -> Vec<String> {
     let mut lines = Vec::new();
 
     if results.is_empty() {
@@ -387,7 +398,11 @@ pub fn format_search_results(results: &[CommandSearchResult], verbose: bool) -> 
         return lines;
     }
 
-    lines.push(format!("Found {} matching operation(s):", results.len()));
+    lines.push(format!(
+        "{} {} matching operation(s):",
+        style.heading("Found"),
+        results.len()
+    ));
     lines.push(String::new());
 
     for (idx, result) in results.iter().enumerate() {
@@ -402,8 +417,8 @@ pub fn format_search_results(results: &[CommandSearchResult], verbose: bool) -> 
         // Method and path
         lines.push(format!(
             "   {} {}",
-            result.command.method.to_uppercase(),
-            result.command.path
+            style.method(&result.command.method),
+            style.metadata(&result.command.path)
         ));
 
         // Description if available
@@ -412,12 +427,16 @@ pub fn format_search_results(results: &[CommandSearchResult], verbose: bool) -> 
         }
 
         lines.push(format!(
-            "   Inspect: aperture docs {} {}",
-            result.api_context, result.command_path
+            "   {} aperture docs {} {}",
+            style.next_label("Inspect:"),
+            result.api_context,
+            result.command_path
         ));
         lines.push(format!(
-            "   Execute: aperture api {} {} ...",
-            result.api_context, result.command_path
+            "   {} aperture api {} {} ...",
+            style.next_label("Execute:"),
+            result.api_context,
+            result.command_path
         ));
 
         if !verbose {
@@ -427,7 +446,11 @@ pub fn format_search_results(results: &[CommandSearchResult], verbose: bool) -> 
 
         // Show highlights
         if !result.highlights.is_empty() {
-            lines.push(format!("   Matches: {}", result.highlights.join(", ")));
+            lines.push(format!(
+                "   {} {}",
+                style.next_label("Matches:"),
+                result.highlights.join(", ")
+            ));
         }
 
         // Show parameters
@@ -438,7 +461,11 @@ pub fn format_search_results(results: &[CommandSearchResult], verbose: bool) -> 
                 .iter()
                 .map(format_param_flag)
                 .collect();
-            lines.push(format!("   Parameters: {}", params.join(" ")));
+            lines.push(format!(
+                "   {} {}",
+                style.next_label("Parameters:"),
+                params.join(" ")
+            ));
         }
 
         // Show request body if present

--- a/tests/discovery_structured_output_integration_tests.rs
+++ b/tests/discovery_structured_output_integration_tests.rs
@@ -97,6 +97,10 @@ fn commands_support_json_format() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("\u{1b}["),
+        "structured output must not include ANSI color escapes"
+    );
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
 
     assert_eq!(parsed["api"]["context"], "test-api");

--- a/tests/docs_tests.rs
+++ b/tests/docs_tests.rs
@@ -7,6 +7,7 @@ use aperture_cli::cache::models::{
     CachedCommand, CachedParameter, CachedRequestBody, CachedResponse, CachedSpec, CommandExample,
     PaginationInfo,
 };
+use aperture_cli::discovery_style::DiscoveryStyle;
 use aperture_cli::docs::{DocumentationGenerator, HelpFormatter};
 use std::collections::{BTreeMap, HashMap};
 
@@ -329,6 +330,15 @@ fn test_help_formatter_method_badges() {
     // Check that different HTTP methods remain distinguishable
     assert!(formatted.contains("GET"));
     assert!(formatted.contains("POST"));
+}
+
+#[test]
+fn test_help_formatter_supports_semantic_color_when_enabled() {
+    let spec = create_test_spec();
+    let formatted = HelpFormatter::format_command_list_with_style(&spec, DiscoveryStyle::new(true));
+
+    assert!(formatted.contains("\u{1b}[32mGET\u{1b}[0m"));
+    assert!(formatted.contains("\u{1b}[34mPOST\u{1b}[0m"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a centralized `DiscoveryStyle` module for semantic ANSI styling
- apply optional color to human-facing discovery surfaces (`overview`, `commands`, `docs`, API landing, `config api add`, and `search`)
- gate color by stdout TTY and `NO_COLOR`, while keeping machine/JSON output uncolored
- add tests for colored rendering, `NO_COLOR` disablement, and ANSI-free structured output

## Validation
- `cargo test`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #175
