### PR TITLE
Handle broken pipe on stdout writes

### DIFF
--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -290,7 +290,7 @@ impl BatchProcessor {
 
         if self.config.show_progress {
             // ast-grep-ignore: no-println
-            println!("Starting dependent batch execution: {total_operations} operations");
+            crate::stdoutln!("Starting dependent batch execution: {total_operations} operations");
         }
 
         let mut store = interpolation::VariableStore::default();
@@ -330,7 +330,7 @@ impl BatchProcessor {
 
         if self.config.show_progress {
             // ast-grep-ignore: no-println
-            println!(
+            crate::stdoutln!(
                 "Dependent batch completed: {success_count}/{total_operations} operations successful in {:.2}s",
                 total_duration.as_secs_f64()
             );
@@ -505,7 +505,7 @@ impl BatchProcessor {
     fn log_progress(show_progress: bool, msg: impl FnOnce() -> String) {
         if show_progress {
             // ast-grep-ignore: no-println
-            println!("{}", msg());
+            crate::stdoutln!("{}", msg());
         }
     }
 
@@ -578,7 +578,7 @@ impl BatchProcessor {
     fn log_batch_start(show_progress: bool, total_operations: usize) {
         if show_progress {
             // ast-grep-ignore: no-println
-            println!("Starting batch execution: {total_operations} operations");
+            crate::stdoutln!("Starting batch execution: {total_operations} operations");
         }
     }
 
@@ -590,7 +590,7 @@ impl BatchProcessor {
     ) {
         if show_progress {
             // ast-grep-ignore: no-println
-            println!(
+            crate::stdoutln!(
                 "Batch execution completed: {}/{} operations successful in {:.2}s",
                 success_count,
                 total_operations,
@@ -685,14 +685,14 @@ impl BatchProcessor {
             Ok(resp) => {
                 if show_progress {
                     // ast-grep-ignore: no-println
-                    println!("Operation {} completed", index + 1);
+                    crate::stdoutln!("Operation {} completed", index + 1);
                 }
                 (true, None, Some(resp))
             }
             Err(e) => {
                 if show_progress {
                     // ast-grep-ignore: no-println
-                    println!("Operation {} failed: {}", index + 1, e);
+                    crate::stdoutln!("Operation {} failed: {}", index + 1, e);
                 }
                 (false, Some(e.to_string()), None)
             }

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -10,7 +10,7 @@ use crate::discovery_style::DiscoveryStyle;
 use crate::engine::{executor, generator, loader};
 use crate::error::Error;
 use crate::fs::OsFileSystem;
-use crate::output::Output;
+use crate::output::{write_stdout_line, Output};
 use crate::shortcuts::{ResolutionResult, ShortcutResolver};
 use std::fmt::Write as _;
 use std::path::PathBuf;
@@ -127,9 +127,7 @@ fn handle_describe_json_command(
         Some(jq_filter) => executor::apply_jq_filter(&manifest, jq_filter)?,
         None => manifest,
     };
-    // ast-grep-ignore: no-println
-    println!("{output}");
-    Ok(())
+    write_stdout_line(&output)
 }
 
 async fn handle_batch_file_command(
@@ -207,9 +205,7 @@ fn render_api_context_landing(context: &str, spec: &CachedSpec) -> Result<(), Er
     )
     .ok();
 
-    // ast-grep-ignore: no-println
-    println!("{overview}");
-    Ok(())
+    write_stdout_line(&overview)
 }
 
 const LANDING_INCOMPATIBLE_GLOBAL_FLAGS: &[&str] = &[
@@ -620,8 +616,7 @@ pub async fn execute_batch_operations(
         return Ok(());
     }
 
-    render_batch_text_summary(&result, &output);
-    Ok(())
+    render_batch_text_summary(&result, &output)
 }
 
 fn render_batch_json_summary(
@@ -652,27 +647,28 @@ fn render_batch_json_summary(
         None => serde_json::to_string_pretty(&summary)
             .expect("JSON serialization of valid structure cannot fail"),
     };
-    // ast-grep-ignore: no-println
-    println!("{json_output}");
+    write_stdout_line(&json_output)?;
     if result.failure_count > 0 {
         std::process::exit(1);
     }
     Ok(())
 }
 
-fn render_batch_text_summary(result: &crate::batch::BatchResult, output: &Output) {
+fn render_batch_text_summary(
+    result: &crate::batch::BatchResult,
+    output: &Output,
+) -> Result<(), Error> {
     output.info("\n=== Batch Execution Summary ===");
-    // ast-grep-ignore: no-println
-    println!("Total operations: {}", result.results.len());
-    // ast-grep-ignore: no-println
-    println!("Successful: {}", result.success_count);
-    // ast-grep-ignore: no-println
-    println!("Failed: {}", result.failure_count);
-    // ast-grep-ignore: no-println
-    println!("Total time: {:.2}s", result.total_duration.as_secs_f64());
+    write_stdout_line(&format!("Total operations: {}", result.results.len()))?;
+    write_stdout_line(&format!("Successful: {}", result.success_count))?;
+    write_stdout_line(&format!("Failed: {}", result.failure_count))?;
+    write_stdout_line(&format!(
+        "Total time: {:.2}s",
+        result.total_duration.as_secs_f64()
+    ))?;
 
     if result.failure_count == 0 {
-        return;
+        return Ok(());
     }
 
     output.info("\nFailed operations:");
@@ -680,13 +676,12 @@ fn render_batch_text_summary(result: &crate::batch::BatchResult, output: &Output
         if op_result.success {
             continue;
         }
-        // ast-grep-ignore: no-println
-        println!(
+        write_stdout_line(&format!(
             "  {} - {}: {}",
             i + 1,
             op_result.operation.args.join(" "),
             op_result.error.as_deref().unwrap_or("Unknown error")
-        );
+        ))?;
     }
 
     std::process::exit(1);

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -161,8 +161,7 @@ fn handle_show_examples_command(
         .iter()
         .find(|cmd| cmd.operation_id == operation_id)
         .ok_or_else(|| Error::spec_not_found(context))?;
-    crate::cli::render::render_examples(context, operation);
-    Ok(())
+    crate::cli::render::render_examples(context, operation)
 }
 
 fn render_api_context_landing(context: &str, spec: &CachedSpec) -> Result<(), Error> {

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -5,6 +5,7 @@ use crate::constants;
 use crate::engine::loader;
 use crate::error::Error;
 use crate::fs::OsFileSystem;
+use crate::output::write_stdout_line;
 use crate::utils::to_kebab_case;
 use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
@@ -97,9 +98,7 @@ pub fn execute_completion_script_command(shell: &CompletionShell) -> Result<(), 
         CompletionShell::PowerShell => powershell_completion_script(),
     };
 
-    // ast-grep-ignore: no-println
-    println!("{script}");
-    Ok(())
+    write_stdout_line(&script)
 }
 
 pub fn execute_completion_runtime_command(
@@ -112,8 +111,7 @@ pub fn execute_completion_runtime_command(
     let suggestions = complete_words(&input, &catalog);
 
     for suggestion in suggestions {
-        // ast-grep-ignore: no-println
-        println!("{suggestion}");
+        write_stdout_line(&suggestion)?;
     }
 
     Ok(())

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -224,7 +224,7 @@ fn handle_list_specs(
     if json {
         let payload = collect_specs_with_details(manager, specs, verbose);
         // ast-grep-ignore: no-println
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        crate::stdoutln!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(());
     }
 
@@ -422,13 +422,13 @@ fn handle_get_setting(
     let value = manager.get_setting(&setting_key)?;
     if json {
         // ast-grep-ignore: no-println
-        println!(
+        crate::stdoutln!(
             "{}",
             serde_json::json!({ "key": key, "value": value.to_string() })
         );
     } else {
         // ast-grep-ignore: no-println
-        println!("{value}");
+        crate::stdoutln!("{value}");
     }
     Ok(())
 }
@@ -830,7 +830,7 @@ pub fn print_secrets_list(
         match secret.source {
             SecretSource::Env => {
                 // ast-grep-ignore: no-println
-                println!("  {scheme_name}: environment variable '{}'", secret.name);
+                crate::stdoutln!("  {scheme_name}: environment variable '{}'", secret.name);
             }
         }
     }
@@ -844,16 +844,16 @@ pub fn print_api_url_entry(
     output: &Output,
 ) {
     // ast-grep-ignore: no-println
-    println!("\n{api_name}:");
+    crate::stdoutln!("\n{api_name}:");
     if let Some(base) = base_override {
         // ast-grep-ignore: no-println
-        println!("  Base override: {base}");
+        crate::stdoutln!("  Base override: {base}");
     }
     if !env_urls.is_empty() {
         output.info("  Environment URLs:");
         for (env, url) in env_urls {
             // ast-grep-ignore: no-println
-            println!("    {env}: {url}");
+            crate::stdoutln!("    {env}: {url}");
         }
     }
 }
@@ -869,21 +869,21 @@ pub fn print_url_configuration(
     output.info(format!("Base URL configuration for '{name}':"));
     if let Some(base) = base_override {
         // ast-grep-ignore: no-println
-        println!("  Base override: {base}");
+        crate::stdoutln!("  Base override: {base}");
     } else {
         // ast-grep-ignore: no-println
-        println!("  Base override: (none)");
+        crate::stdoutln!("  Base override: (none)");
     }
     if !env_urls.is_empty() {
         // ast-grep-ignore: no-println
-        println!("  Environment URLs:");
+        crate::stdoutln!("  Environment URLs:");
         for (env, url) in env_urls {
             // ast-grep-ignore: no-println
-            println!("    {env}: {url}");
+            crate::stdoutln!("    {env}: {url}");
         }
     }
     // ast-grep-ignore: no-println
-    println!("\nResolved URL (current): {resolved}");
+    crate::stdoutln!("\nResolved URL (current): {resolved}");
     if let Ok(current_env) = std::env::var(constants::ENV_APERTURE_ENV) {
         output.info(format!("(Using APERTURE_ENV={current_env})"));
     }
@@ -1040,17 +1040,17 @@ pub fn list_specs_with_details(
     for spec_name in specs {
         if !verbose {
             // ast-grep-ignore: no-println
-            println!("- {spec_name}");
+            crate::stdoutln!("- {spec_name}");
             continue;
         }
         let Ok(cached_spec) = crate::engine::loader::load_cached_spec(&cache_dir, &spec_name)
         else {
             // ast-grep-ignore: no-println
-            println!("- {spec_name}");
+            crate::stdoutln!("- {spec_name}");
             continue;
         };
         // ast-grep-ignore: no-println
-        println!("- {spec_name}:");
+        crate::stdoutln!("- {spec_name}:");
         output.info(format!("  Version: {}", cached_spec.version));
         let available = cached_spec.commands.len();
         let skipped = cached_spec.skipped_endpoints.len();
@@ -1083,24 +1083,25 @@ pub fn print_settings_list(
 ) -> Result<(), Error> {
     if json {
         // ast-grep-ignore: no-println
-        println!("{}", serde_json::to_string_pretty(&settings)?);
+        crate::stdoutln!("{}", serde_json::to_string_pretty(&settings)?);
         return Ok(());
     }
     output.info("Available configuration settings:");
     // ast-grep-ignore: no-println
-    println!();
+    crate::stdoutln!();
     for setting in settings {
         // ast-grep-ignore: no-println
-        println!("  {} = {}", setting.key, setting.value);
+        crate::stdoutln!("  {} = {}", setting.key, setting.value);
         // ast-grep-ignore: no-println
-        println!(
+        crate::stdoutln!(
             "    Type: {}  Default: {}",
-            setting.type_name, setting.default
+            setting.type_name,
+            setting.default
         );
         // ast-grep-ignore: no-println
-        println!("    {}", setting.description);
+        crate::stdoutln!("    {}", setting.description);
         // ast-grep-ignore: no-println
-        println!();
+        crate::stdoutln!();
     }
     Ok(())
 }
@@ -1175,20 +1176,20 @@ pub async fn show_cache_stats(
         output.info("Cache statistics for all APIs:");
     }
     // ast-grep-ignore: no-println
-    println!("  Total entries: {}", stats.total_entries);
+    crate::stdoutln!("  Total entries: {}", stats.total_entries);
     // ast-grep-ignore: no-println
-    println!("  Valid entries: {}", stats.valid_entries);
+    crate::stdoutln!("  Valid entries: {}", stats.valid_entries);
     // ast-grep-ignore: no-println
-    println!("  Expired entries: {}", stats.expired_entries);
+    crate::stdoutln!("  Expired entries: {}", stats.expired_entries);
     #[allow(clippy::cast_precision_loss)]
     let size_mb = stats.total_size_bytes as f64 / 1024.0 / 1024.0;
     // ast-grep-ignore: no-println
-    println!("  Total size: {size_mb:.2} MB");
+    crate::stdoutln!("  Total size: {size_mb:.2} MB");
     if stats.total_entries != 0 {
         #[allow(clippy::cast_precision_loss)]
         let hit_rate = stats.valid_entries as f64 / stats.total_entries as f64 * 100.0;
         // ast-grep-ignore: no-println
-        println!("  Hit rate: {hit_rate:.1}%");
+        crate::stdoutln!("  Hit rate: {hit_rate:.1}%");
     }
     Ok(())
 }
@@ -1309,16 +1310,16 @@ pub fn handle_list_mappings(
 
     if !mapping.groups.is_empty() {
         // ast-grep-ignore: no-println
-        println!("\n  Group renames:");
+        crate::stdoutln!("\n  Group renames:");
         for (original, new_name) in &mapping.groups {
             // ast-grep-ignore: no-println
-            println!("    '{original}' → '{new_name}'");
+            crate::stdoutln!("    '{original}' → '{new_name}'");
         }
     }
 
     if !mapping.operations.is_empty() {
         // ast-grep-ignore: no-println
-        println!("\n  Operation mappings:");
+        crate::stdoutln!("\n  Operation mappings:");
         for (op_id, op_mapping) in &mapping.operations {
             print_operation_mapping(op_id, op_mapping);
         }
@@ -1366,21 +1367,21 @@ pub fn handle_remove_mapping(
 /// Prints details of a single operation mapping
 fn print_operation_mapping(op_id: &str, op_mapping: &crate::config::models::OperationMapping) {
     // ast-grep-ignore: no-println
-    println!("    {op_id}:");
+    crate::stdoutln!("    {op_id}:");
     if let Some(ref name) = op_mapping.name {
         // ast-grep-ignore: no-println
-        println!("      name: {name}");
+        crate::stdoutln!("      name: {name}");
     }
     if let Some(ref group) = op_mapping.group {
         // ast-grep-ignore: no-println
-        println!("      group: {group}");
+        crate::stdoutln!("      group: {group}");
     }
     if !op_mapping.aliases.is_empty() {
         // ast-grep-ignore: no-println
-        println!("      aliases: {}", op_mapping.aliases.join(", "));
+        crate::stdoutln!("      aliases: {}", op_mapping.aliases.join(", "));
     }
     if op_mapping.hidden {
         // ast-grep-ignore: no-println
-        println!("      hidden: true");
+        crate::stdoutln!("      hidden: true");
     }
 }

--- a/src/cli/commands/docs.rs
+++ b/src/cli/commands/docs.rs
@@ -9,10 +9,11 @@ use crate::docs::{DocumentationGenerator, HelpFormatter};
 use crate::engine::loader;
 use crate::error::Error;
 use crate::fs::OsFileSystem;
-use crate::output::Output;
+use crate::output::{write_stdout_line, Output};
 use crate::utils::to_kebab_case;
 use serde::Serialize;
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 #[derive(Debug, Serialize)]
@@ -201,31 +202,36 @@ pub fn list_commands(
     })?;
 
     match format {
-        DiscoveryFormat::Text => {
-            let style = DiscoveryStyle::for_stdout();
-            let formatted_output = HelpFormatter::format_command_list_with_style(&spec, style);
-            // ast-grep-ignore: no-println
-            println!("{formatted_output}");
-            output.tip(format!(
-                "{} 'aperture overview {context}' for high-level API orientation",
-                style.next_label("Next:")
-            ));
-            output.tip(format!(
-                "{} 'aperture search <term> --api {context}' to find operations by intent",
-                style.next_label("Next:")
-            ));
-            output.tip(format!(
-                "{} 'aperture docs {context} <tag> <operation>' for deep operation docs",
-                style.next_label("Next:")
-            ));
-            output.tip(format!(
-                "{} 'aperture api {context} <tag> <operation> ...'",
-                style.next_label("Execute:")
-            ));
-            Ok(())
-        }
+        DiscoveryFormat::Text => render_command_list_text(context, &spec, output),
         DiscoveryFormat::Json => render_command_list_json(context, &spec),
     }
+}
+
+fn render_command_list_text(
+    context: &str,
+    spec: &CachedSpec,
+    output: &Output,
+) -> Result<(), Error> {
+    let style = DiscoveryStyle::for_stdout();
+    let formatted_output = HelpFormatter::format_command_list_with_style(spec, style);
+    write_stdout_line(&formatted_output)?;
+    output.tip(format!(
+        "{} 'aperture overview {context}' for high-level API orientation",
+        style.next_label("Next:")
+    ));
+    output.tip(format!(
+        "{} 'aperture search <term> --api {context}' to find operations by intent",
+        style.next_label("Next:")
+    ));
+    output.tip(format!(
+        "{} 'aperture docs {context} <tag> <operation>' for deep operation docs",
+        style.next_label("Next:")
+    ));
+    output.tip(format!(
+        "{} 'aperture api {context} <tag> <operation> ...'",
+        style.next_label("Execute:")
+    ));
+    Ok(())
 }
 
 /// Execute help command with enhanced documentation
@@ -294,8 +300,7 @@ fn render_interactive_menu(
 ) -> Result<(), Error> {
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
-    // ast-grep-ignore: no-println
-    println!("{}", doc_gen.generate_interactive_menu());
+    write_stdout_line(&doc_gen.generate_interactive_menu())?;
     output.tip("Try 'aperture overview <api>' to orient to one API before drilling in");
     Ok(())
 }
@@ -321,8 +326,7 @@ fn render_api_reference_index(
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
     let reference = doc_gen.generate_api_reference_index_styled(api, style)?;
-    // ast-grep-ignore: no-println
-    println!("{reference}");
+    write_stdout_line(&reference)?;
     output.tip(format!(
         "{} operations with 'aperture api {api} <tag> <operation> ...'",
         style.next_label("Execute")
@@ -398,11 +402,9 @@ fn render_command_help(
     let doc_gen = DocumentationGenerator::new(specs);
     let help = doc_gen.generate_command_help_styled(api, tag, operation, style)?;
     if enhanced {
-        // ast-grep-ignore: no-println
-        println!("{help}");
+        write_stdout_line(&help)?;
     } else {
-        // ast-grep-ignore: no-println
-        println!("{}", help.lines().take(20).collect::<Vec<_>>().join("\n"));
+        write_stdout_line(&help.lines().take(20).collect::<Vec<_>>().join("\n"))?;
         output.tip(format!(
             "{} --enhanced for full documentation with examples",
             style.next_label("Use")
@@ -581,8 +583,7 @@ fn render_single_api_overview(
     let specs = load_all_specs(manager)?;
     let doc_gen = DocumentationGenerator::new(specs);
     let overview = doc_gen.generate_api_overview_styled(api, style)?;
-    // ast-grep-ignore: no-println
-    println!("{overview}");
+    write_stdout_line(&overview)?;
     output.tip(format!(
         "{} 'aperture search <term> --api {api}' to find specific operations",
         style.next_label("Next:")
@@ -650,28 +651,30 @@ fn render_all_api_overviews(
         return Ok(());
     }
 
-    // ast-grep-ignore: no-println
-    println!("All APIs Overview\n");
-    // ast-grep-ignore: no-println
-    println!("{}", "=".repeat(60));
+    let mut overview = String::new();
+    writeln!(&mut overview, "All APIs Overview\n").expect("writing to String cannot fail");
+    writeln!(&mut overview, "{}", "=".repeat(60)).expect("writing to String cannot fail");
     for (api_name, spec) in &specs {
-        // ast-grep-ignore: no-println
-        println!("\n** {} ** (v{})", spec.name, spec.version);
+        writeln!(&mut overview, "\n** {} ** (v{})", spec.name, spec.version)
+            .expect("writing to String cannot fail");
         if let Some(ref base_url) = spec.base_url {
-            // ast-grep-ignore: no-println
-            println!("   Base URL: {base_url}");
+            writeln!(&mut overview, "   Base URL: {base_url}")
+                .expect("writing to String cannot fail");
         }
         let operation_count = spec.commands.len();
-        // ast-grep-ignore: no-println
-        println!("   Operations: {operation_count}");
+        writeln!(&mut overview, "   Operations: {operation_count}")
+            .expect("writing to String cannot fail");
         let method_summary = summarize_methods(&spec.commands);
-        // ast-grep-ignore: no-println
-        println!("   Methods: {}", method_summary.join(", "));
-        // ast-grep-ignore: no-println
-        println!("   Quick start: aperture commands {api_name}");
+        writeln!(&mut overview, "   Methods: {}", method_summary.join(", "))
+            .expect("writing to String cannot fail");
+        writeln!(
+            &mut overview,
+            "   Quick start: aperture commands {api_name}"
+        )
+        .expect("writing to String cannot fail");
     }
-    // ast-grep-ignore: no-println
-    println!("\n{}", "=".repeat(60));
+    writeln!(&mut overview, "\n{}", "=".repeat(60)).expect("writing to String cannot fail");
+    write_stdout_line(overview.trim_end())?;
     output.tip("Use 'aperture overview <api>' to orient to a specific API");
     output.tip("Then use 'aperture search <term> --api <api>' to find operations by intent");
     output.tip("Use 'aperture commands <api>' for a terse command tree");
@@ -773,8 +776,7 @@ fn operation_summary(command: &CachedCommand) -> OperationSummaryJson {
 }
 
 fn print_json<T: Serialize>(payload: &T) -> Result<(), Error> {
-    // ast-grep-ignore: no-println
-    println!("{}", serde_json::to_string_pretty(payload)?);
+    write_stdout_line(&serde_json::to_string_pretty(payload)?)?;
     Ok(())
 }
 

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -6,7 +6,7 @@ use crate::discovery_style::DiscoveryStyle;
 use crate::engine::loader;
 use crate::error::Error;
 use crate::fs::OsFileSystem;
-use crate::output::Output;
+use crate::output::{write_stdout_line, Output};
 use crate::search::CommandSearcher;
 
 pub fn execute_search_command(
@@ -39,8 +39,7 @@ pub fn execute_search_command(
     let formatted_results =
         crate::search::format_search_results_with_style(&results, verbose, style);
     for line in formatted_results {
-        // ast-grep-ignore: no-println
-        println!("{line}");
+        write_stdout_line(&line)?;
     }
     Ok(())
 }

--- a/src/cli/legacy_execute.rs
+++ b/src/cli/legacy_execute.rs
@@ -85,6 +85,6 @@ fn maybe_render_examples(spec: &CachedSpec, matches: &ArgMatches) -> Result<bool
         .iter()
         .find(|cmd| cmd.operation_id == operation_id)
         .ok_or_else(|| Error::spec_not_found(&spec.name))?;
-    crate::cli::render::render_examples("<api>", operation);
+    crate::cli::render::render_examples("<api>", operation)?;
     Ok(true)
 }

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -2,7 +2,7 @@
 //!
 //! Converts structured execution results into user-facing output
 //! (stdout) in the requested format (JSON, YAML, table). This module
-//! owns all `println!` calls for API response rendering.
+//! owns API response rendering writes.
 
 use crate::cache::models::CachedCommand;
 use crate::cli::OutputFormat;
@@ -10,6 +10,7 @@ use crate::constants;
 use crate::engine::executor::apply_jq_filter;
 use crate::error::Error;
 use crate::invocation::ExecutionResult;
+use crate::output::write_stdout_line;
 use crate::utils::to_kebab_case;
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -57,8 +58,7 @@ pub fn render_result(
             let output = serde_json::to_string_pretty(request_info).map_err(|e| {
                 Error::serialization_error(format!("Failed to serialize dry run info: {e}"))
             })?;
-            // ast-grep-ignore: no-println
-            println!("{output}");
+            write_stdout_line(&output)?;
         }
         ExecutionResult::Empty => {}
     }
@@ -95,104 +95,105 @@ pub fn render_result_to_string(
 }
 
 /// Renders extended examples for a command to stdout.
-pub fn render_examples(api_name: &str, operation: &CachedCommand) {
+///
+/// # Errors
+///
+/// Returns an error when writing to stdout fails for a reason other than a
+/// broken pipe.
+pub fn render_examples(api_name: &str, operation: &CachedCommand) -> Result<(), Error> {
     let operation_name = crate::docs::DocumentationGenerator::effective_operation(operation);
     let examples = crate::docs::DocumentationGenerator::canonical_examples(api_name, operation);
+    let mut output = String::new();
 
-    // ast-grep-ignore: no-println
-    println!("Command: {operation_name}\n");
+    writeln!(&mut output, "Command: {operation_name}\n").expect("writing to String cannot fail");
 
     if let Some(ref summary) = operation.summary {
-        // ast-grep-ignore: no-println
-        println!("Description: {summary}\n");
+        writeln!(&mut output, "Description: {summary}\n").expect("writing to String cannot fail");
     }
 
-    // ast-grep-ignore: no-println
-    println!("Method: {} {}\n", operation.method, operation.path);
+    writeln!(
+        &mut output,
+        "Method: {} {}\n",
+        operation.method, operation.path
+    )
+    .expect("writing to String cannot fail");
 
-    // ast-grep-ignore: no-println
-    println!("Examples:\n");
+    writeln!(&mut output, "Examples:\n").expect("writing to String cannot fail");
     for (i, example) in examples.iter().enumerate() {
-        // ast-grep-ignore: no-println
-        println!("{}. {}", i + 1, example.description);
-        // ast-grep-ignore: no-println
-        println!("   {}", example.command_line);
+        writeln!(&mut output, "{}. {}", i + 1, example.description)
+            .expect("writing to String cannot fail");
+        writeln!(&mut output, "   {}", example.command_line)
+            .expect("writing to String cannot fail");
         if let Some(ref explanation) = example.explanation {
-            // ast-grep-ignore: no-println
-            println!("   {explanation}");
+            writeln!(&mut output, "   {explanation}").expect("writing to String cannot fail");
         }
-        // ast-grep-ignore: no-println
-        println!();
+        writeln!(&mut output).expect("writing to String cannot fail");
     }
 
     // Additional helpful information
     if operation.parameters.is_empty() {
-        return;
+        return write_stdout_line(output.trim_end());
     }
 
-    // ast-grep-ignore: no-println
-    println!("Parameters:");
+    writeln!(&mut output, "Parameters:").expect("writing to String cannot fail");
     for param in &operation.parameters {
         let required = if param.required { " (required)" } else { "" };
         let param_type = param.schema_type.as_deref().unwrap_or("string");
-        // ast-grep-ignore: no-println
-        println!(
+        writeln!(
+            &mut output,
             "  --{}{} [{}]",
             to_kebab_case(&param.name),
             required,
             param_type
-        );
+        )
+        .expect("writing to String cannot fail");
 
         let Some(ref desc) = param.description else {
             continue;
         };
-        // ast-grep-ignore: no-println
-        println!("      {desc}");
+        writeln!(&mut output, "      {desc}").expect("writing to String cannot fail");
     }
-    // ast-grep-ignore: no-println
-    println!();
+    writeln!(&mut output).expect("writing to String cannot fail");
 
     if operation.request_body.is_some() {
-        // ast-grep-ignore: no-println
-        println!("Request Body:");
-        // ast-grep-ignore: no-println
-        println!("  --body JSON (required)");
-        // ast-grep-ignore: no-println
-        println!("      JSON data to send in the request body");
+        writeln!(&mut output, "Request Body:").expect("writing to String cannot fail");
+        writeln!(&mut output, "  --body JSON (required)").expect("writing to String cannot fail");
+        writeln!(&mut output, "      JSON data to send in the request body")
+            .expect("writing to String cannot fail");
     }
+
+    write_stdout_line(output.trim_end())
 }
 
 // ── Internal helpers ────────────────────────────────────────────────
 
 /// Core formatting logic shared by `render_result` and `render_result_to_string`.
-fn render_json_output(processed_text: &str, capture_output: bool) -> Option<String> {
+fn render_json_output(processed_text: &str, capture_output: bool) -> Result<Option<String>, Error> {
     let output = serde_json::from_str::<Value>(processed_text)
         .ok()
         .and_then(|json_value| serde_json::to_string_pretty(&json_value).ok())
         .unwrap_or_else(|| processed_text.to_string());
 
     if capture_output {
-        return Some(output);
+        return Ok(Some(output));
     }
 
-    // ast-grep-ignore: no-println
-    println!("{output}");
-    None
+    write_stdout_line(&output)?;
+    Ok(None)
 }
 
-fn render_yaml_output(processed_text: &str, capture_output: bool) -> Option<String> {
+fn render_yaml_output(processed_text: &str, capture_output: bool) -> Result<Option<String>, Error> {
     let output = serde_json::from_str::<Value>(processed_text)
         .ok()
         .and_then(|json_value| serde_yaml::to_string(&json_value).ok())
         .unwrap_or_else(|| processed_text.to_string());
 
     if capture_output {
-        return Some(output);
+        return Ok(Some(output));
     }
 
-    // ast-grep-ignore: no-println
-    println!("{output}");
-    None
+    write_stdout_line(&output)?;
+    Ok(None)
 }
 
 fn render_table_output(
@@ -200,15 +201,10 @@ fn render_table_output(
     capture_output: bool,
 ) -> Result<Option<String>, Error> {
     let Ok(json_value) = serde_json::from_str::<Value>(processed_text) else {
-        return Ok(output_or_capture(processed_text, capture_output));
+        return output_or_capture(processed_text, capture_output);
     };
 
-    let table_output = print_as_table(&json_value, capture_output)?;
-    if capture_output {
-        return Ok(table_output);
-    }
-
-    Ok(None)
+    print_as_table(&json_value, capture_output)
 }
 
 fn format_and_print(
@@ -224,54 +220,52 @@ fn format_and_print(
     };
 
     match output_format {
-        OutputFormat::Json => Ok(render_json_output(&processed_text, capture_output)),
-        OutputFormat::Yaml => Ok(render_yaml_output(&processed_text, capture_output)),
+        OutputFormat::Json => render_json_output(&processed_text, capture_output),
+        OutputFormat::Yaml => render_yaml_output(&processed_text, capture_output),
         OutputFormat::Table => render_table_output(&processed_text, capture_output),
     }
 }
 
 /// Prints items as a numbered list.
-fn print_numbered_list(items: &[Value], capture_output: bool) -> Option<String> {
+fn print_numbered_list(items: &[Value], capture_output: bool) -> Result<Option<String>, Error> {
     if capture_output {
         let mut output = String::new();
         for (i, item) in items.iter().enumerate() {
             writeln!(&mut output, "{}: {}", i, format_value_for_table(item))
                 .expect("writing to String cannot fail");
         }
-        return Some(output.trim_end().to_string());
+        return Ok(Some(output.trim_end().to_string()));
     }
 
     for (i, item) in items.iter().enumerate() {
-        // ast-grep-ignore: no-println
-        println!("{}: {}", i, format_value_for_table(item));
+        write_stdout_line(&format!("{}: {}", i, format_value_for_table(item)))?;
     }
-    None
+    Ok(None)
 }
 
 /// Helper to output or capture a message.
-fn output_or_capture(message: &str, capture_output: bool) -> Option<String> {
+fn output_or_capture(message: &str, capture_output: bool) -> Result<Option<String>, Error> {
     if capture_output {
-        return Some(message.to_string());
+        return Ok(Some(message.to_string()));
     }
-    // ast-grep-ignore: no-println
-    println!("{message}");
-    None
+    write_stdout_line(message)?;
+    Ok(None)
 }
 
 /// Prints JSON data as a formatted table.
 #[allow(clippy::unnecessary_wraps, clippy::too_many_lines)]
 fn print_as_table(json_value: &Value, capture_output: bool) -> Result<Option<String>, Error> {
     match json_value {
-        Value::Array(items) => Ok(render_array_as_table(items, capture_output)),
-        Value::Object(obj) => Ok(render_object_as_table(obj, capture_output)),
+        Value::Array(items) => render_array_as_table(items, capture_output),
+        Value::Object(obj) => render_object_as_table(obj, capture_output),
         _ => {
             let formatted = format_value_for_table(json_value);
-            Ok(output_or_capture(&formatted, capture_output))
+            output_or_capture(&formatted, capture_output)
         }
     }
 }
 
-fn render_array_as_table(items: &[Value], capture_output: bool) -> Option<String> {
+fn render_array_as_table(items: &[Value], capture_output: bool) -> Result<Option<String>, Error> {
     if items.is_empty() {
         return output_or_capture(constants::EMPTY_ARRAY, capture_output);
     }
@@ -300,7 +294,7 @@ fn render_array_as_table(items: &[Value], capture_output: bool) -> Option<String
 fn render_object_as_table(
     obj: &serde_json::Map<String, Value>,
     capture_output: bool,
-) -> Option<String> {
+) -> Result<Option<String>, Error> {
     if obj.len() > MAX_TABLE_ROWS {
         return output_or_capture(
             &format_large_collection_message("Object", obj.len()),

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -1302,7 +1302,7 @@ impl<F: FileSystem> ConfigManager<F> {
 
         if cached_spec.security_schemes.is_empty() {
             // ast-grep-ignore: no-println
-            println!("No security schemes found in API '{api_name}'.");
+            crate::stdoutln!("No security schemes found in API '{api_name}'.");
             return Ok(());
         }
 
@@ -1321,7 +1321,7 @@ impl<F: FileSystem> ConfigManager<F> {
         )?;
 
         // ast-grep-ignore: no-println
-        println!("\nInteractive configuration complete!");
+        crate::stdoutln!("\nInteractive configuration complete!");
         Ok(())
     }
 
@@ -1542,9 +1542,9 @@ impl<F: FileSystem> ConfigManager<F> {
     /// Displays the interactive configuration header
     fn display_interactive_header(api_name: &str, cached_spec: &crate::cache::models::CachedSpec) {
         // ast-grep-ignore: no-println
-        println!("Interactive Secret Configuration for API: {api_name}");
+        crate::stdoutln!("Interactive Secret Configuration for API: {api_name}");
         // ast-grep-ignore: no-println
-        println!(
+        crate::stdoutln!(
             "Found {} security scheme(s):\n",
             cached_spec.security_schemes.len()
         );
@@ -1656,7 +1656,7 @@ impl<F: FileSystem> ConfigManager<F> {
 
             if env_var.is_empty() {
                 // ast-grep-ignore: no-println
-                println!("Skipping configuration for '{selected_scheme}'");
+                crate::stdoutln!("Skipping configuration for '{selected_scheme}'");
             } else {
                 self.handle_secret_configuration(
                     api_name,
@@ -1682,12 +1682,12 @@ impl<F: FileSystem> ConfigManager<F> {
         current_secrets: &std::collections::HashMap<String, ApertureSecret>,
     ) {
         // ast-grep-ignore: no-println
-        println!("\nConfiguration for '{selected_scheme}':");
+        crate::stdoutln!("\nConfiguration for '{selected_scheme}':");
         // ast-grep-ignore: no-println
-        println!("   Type: {}", scheme.scheme_type);
+        crate::stdoutln!("   Type: {}", scheme.scheme_type);
         if let Some(desc) = &scheme.description {
             // ast-grep-ignore: no-println
-            println!("   Description: {desc}");
+            crate::stdoutln!("   Description: {desc}");
         }
 
         // Show current configuration - use pattern matching to avoid nested if
@@ -1697,18 +1697,18 @@ impl<F: FileSystem> ConfigManager<F> {
         ) {
             (Some(current_secret), _) => {
                 // ast-grep-ignore: no-println
-                println!("   Current: environment variable '{}'", current_secret.name);
+                crate::stdoutln!("   Current: environment variable '{}'", current_secret.name);
             }
             (None, Some(aperture_secret)) => {
                 // ast-grep-ignore: no-println
-                println!(
+                crate::stdoutln!(
                     "   Current: x-aperture-secret -> '{}'",
                     aperture_secret.name
                 );
             }
             (None, None) => {
                 // ast-grep-ignore: no-println
-                println!("   Current: not configured");
+                crate::stdoutln!("   Current: not configured");
             }
         }
     }
@@ -1728,27 +1728,27 @@ impl<F: FileSystem> ConfigManager<F> {
         // Validate environment variable name using the comprehensive validator
         if let Err(e) = crate::interactive::validate_env_var_name(env_var) {
             // ast-grep-ignore: no-println
-            println!("Invalid environment variable name: {e}");
+            crate::stdoutln!("Invalid environment variable name: {e}");
             return Ok(()); // Continue the loop, don't fail completely
         }
 
         // Show preview and confirm
         // ast-grep-ignore: no-println
-        println!("\nConfiguration Preview:");
+        crate::stdoutln!("\nConfiguration Preview:");
         // ast-grep-ignore: no-println
-        println!("   API: {api_name}");
+        crate::stdoutln!("   API: {api_name}");
         // ast-grep-ignore: no-println
-        println!("   Scheme: {selected_scheme}");
+        crate::stdoutln!("   Scheme: {selected_scheme}");
         // ast-grep-ignore: no-println
-        println!("   Environment Variable: {env_var}");
+        crate::stdoutln!("   Environment Variable: {env_var}");
 
         if confirm("Apply this configuration?")? {
             self.set_secret(validated_name, selected_scheme, env_var)?;
             // ast-grep-ignore: no-println
-            println!("Configuration saved successfully!");
+            crate::stdoutln!("Configuration saved successfully!");
         } else {
             // ast-grep-ignore: no-println
-            println!("Configuration cancelled.");
+            crate::stdoutln!("Configuration cancelled.");
         }
 
         Ok(())

--- a/src/interactive/mock.rs
+++ b/src/interactive/mock.rs
@@ -46,13 +46,11 @@ pub struct RealInputOutput;
 
 impl InputOutput for RealInputOutput {
     fn print(&self, text: &str) -> Result<(), Error> {
-        print!("{text}");
-        Ok(())
+        crate::output::write_stdout(text)
     }
 
     fn println(&self, text: &str) -> Result<(), Error> {
-        crate::stdoutln!("{text}");
-        Ok(())
+        crate::output::write_stdout_line(text)
     }
 
     fn flush(&self) -> Result<(), Error> {

--- a/src/interactive/mock.rs
+++ b/src/interactive/mock.rs
@@ -51,7 +51,7 @@ impl InputOutput for RealInputOutput {
     }
 
     fn println(&self, text: &str) -> Result<(), Error> {
-        println!("{text}");
+        crate::stdoutln!("{text}");
         Ok(())
     }
 

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -481,7 +481,7 @@ pub fn confirm_with_io_and_timeout<T: InputOutput>(
 /// Returns an error if stdin operations fail
 pub fn confirm_exit() -> Result<bool, Error> {
     // ast-grep-ignore: no-println
-    println!("\nInteractive session interrupted.");
+    crate::stdoutln!("\nInteractive session interrupted.");
     confirm("Do you want to exit without saving changes?")
 }
 
@@ -492,7 +492,7 @@ pub fn confirm_exit() -> Result<bool, Error> {
 /// Returns an error if the confirmation input operation fails
 pub fn handle_cancellation_input() -> Result<bool, Error> {
     // ast-grep-ignore: no-println
-    println!("Empty input detected. This will cancel the current operation.");
+    crate::stdoutln!("Empty input detected. This will cancel the current operation.");
     confirm("Do you want to continue with the current operation?")
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -24,21 +24,52 @@ pub fn write_stdout_line(msg: &str) -> Result<(), Error> {
     write_line(&mut stdout.lock(), msg)
 }
 
+/// Write data to stdout without appending a newline.
+///
+/// Broken pipes are treated as successful termination so commands compose with
+/// consumers like `head` without panicking after the consumer exits early.
+///
+/// # Errors
+///
+/// Returns an error when writing to stdout fails for a reason other than a
+/// broken pipe.
+pub fn write_stdout(msg: &str) -> Result<(), Error> {
+    let stdout = io::stdout();
+    write_all(&mut stdout.lock(), msg.as_bytes())
+}
+
 fn write_line(writer: &mut impl Write, msg: &str) -> Result<(), Error> {
-    match writeln!(writer, "{msg}") {
+    write_all_fmt(writer, format_args!("{msg}\n"))
+}
+
+fn write_all(writer: &mut impl Write, bytes: &[u8]) -> Result<(), Error> {
+    match writer.write_all(bytes) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
         Err(err) => Err(err.into()),
     }
 }
 
+fn write_all_fmt(writer: &mut impl Write, args: std::fmt::Arguments<'_>) -> Result<(), Error> {
+    match writer.write_fmt(args) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[allow(clippy::missing_panics_doc)]
+pub fn write_stdout_line_or_panic(msg: &str) {
+    write_stdout_line(msg).unwrap_or_else(|err| panic!("failed writing to stdout: {err}"));
+}
+
 #[macro_export]
 macro_rules! stdoutln {
     () => {
-        let _ = $crate::output::write_stdout_line("");
+        $crate::output::write_stdout_line_or_panic("");
     };
     ($($arg:tt)*) => {
-        let _ = $crate::output::write_stdout_line(&format!($($arg)*));
+        $crate::output::write_stdout_line_or_panic(&format!($($arg)*));
     };
 }
 
@@ -67,7 +98,7 @@ impl Output {
     /// Use for general status messages like "Registered API specifications:".
     pub fn info(&self, msg: impl std::fmt::Display) {
         if !self.quiet {
-            let _ = write_stdout_line(&msg.to_string());
+            write_stdout_line_or_panic(&msg.to_string());
         }
     }
 
@@ -76,7 +107,7 @@ impl Output {
     /// Use for confirmation messages like "Spec 'foo' added successfully".
     pub fn success(&self, msg: impl std::fmt::Display) {
         if !self.quiet {
-            let _ = write_stdout_line(&msg.to_string());
+            write_stdout_line_or_panic(&msg.to_string());
         }
     }
 
@@ -85,7 +116,7 @@ impl Output {
     /// Use for helpful suggestions like usage tips after commands.
     pub fn tip(&self, msg: impl std::fmt::Display) {
         if !self.quiet {
-            let _ = write_stdout_line(&msg.to_string());
+            write_stdout_line_or_panic(&msg.to_string());
         }
     }
 
@@ -161,5 +192,17 @@ mod tests {
     fn test_write_line_surfaces_other_errors() {
         let mut writer = OtherErrorWriter;
         assert!(write_line(&mut writer, "data").is_err());
+    }
+
+    #[test]
+    fn test_write_all_ignores_broken_pipe() {
+        let mut writer = BrokenPipeWriter;
+        assert!(write_all(&mut writer, b"data").is_ok());
+    }
+
+    #[test]
+    fn test_write_all_surfaces_other_errors() {
+        let mut writer = OtherErrorWriter;
+        assert!(write_all(&mut writer, b"data").is_err());
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -32,6 +32,16 @@ fn write_line(writer: &mut impl Write, msg: &str) -> Result<(), Error> {
     }
 }
 
+#[macro_export]
+macro_rules! stdoutln {
+    () => {
+        let _ = $crate::output::write_stdout_line("");
+    };
+    ($($arg:tt)*) => {
+        let _ = $crate::output::write_stdout_line(&format!($($arg)*));
+    };
+}
+
 /// Output handler that respects quiet mode.
 ///
 /// Quiet mode is enabled if either `--quiet` is passed or `--json-errors` is used.

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,6 +7,31 @@
 //! - Tips/hints (suppressed in quiet mode)
 //! - Data output (never suppressed)
 
+use crate::error::Error;
+use std::io::{self, ErrorKind, Write};
+
+/// Write one line of data to stdout.
+///
+/// Broken pipes are treated as successful termination so commands compose with
+/// consumers like `head` without panicking after the consumer exits early.
+///
+/// # Errors
+///
+/// Returns an error when writing to stdout fails for a reason other than a
+/// broken pipe.
+pub fn write_stdout_line(msg: &str) -> Result<(), Error> {
+    let stdout = io::stdout();
+    write_line(&mut stdout.lock(), msg)
+}
+
+fn write_line(writer: &mut impl Write, msg: &str) -> Result<(), Error> {
+    match writeln!(writer, "{msg}") {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::BrokenPipe => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// Output handler that respects quiet mode.
 ///
 /// Quiet mode is enabled if either `--quiet` is passed or `--json-errors` is used.
@@ -93,5 +118,44 @@ mod tests {
     fn test_not_quiet_when_no_flags() {
         let output = Output::new(false, false);
         assert!(!output.is_quiet());
+    }
+
+    struct BrokenPipeWriter;
+
+    impl std::io::Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "closed pipe",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct OtherErrorWriter;
+
+    impl std::io::Write for OtherErrorWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("disk full"))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_write_line_ignores_broken_pipe() {
+        let mut writer = BrokenPipeWriter;
+        assert!(write_line(&mut writer, "data").is_ok());
+    }
+
+    #[test]
+    fn test_write_line_surfaces_other_errors() {
+        let mut writer = OtherErrorWriter;
+        assert!(write_line(&mut writer, "data").is_err());
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -57,9 +57,7 @@ impl Output {
     /// Use for general status messages like "Registered API specifications:".
     pub fn info(&self, msg: impl std::fmt::Display) {
         if !self.quiet {
-            // Intentional CLI output, not debug logging
-            // ast-grep-ignore: no-println
-            println!("{msg}");
+            let _ = write_stdout_line(&msg.to_string());
         }
     }
 
@@ -68,9 +66,7 @@ impl Output {
     /// Use for confirmation messages like "Spec 'foo' added successfully".
     pub fn success(&self, msg: impl std::fmt::Display) {
         if !self.quiet {
-            // Intentional CLI output, not debug logging
-            // ast-grep-ignore: no-println
-            println!("{msg}");
+            let _ = write_stdout_line(&msg.to_string());
         }
     }
 
@@ -79,9 +75,7 @@ impl Output {
     /// Use for helpful suggestions like usage tips after commands.
     pub fn tip(&self, msg: impl std::fmt::Display) {
         if !self.quiet {
-            // Intentional CLI output, not debug logging
-            // ast-grep-ignore: no-println
-            println!("{msg}");
+            let _ = write_stdout_line(&msg.to_string());
         }
     }
 

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -48,7 +48,11 @@ fn write_json_line<W: std::io::Write + ?Sized, T: serde::Serialize>(
 ) -> Result<(), Error> {
     let line = serde_json::to_string(value)
         .map_err(|e| Error::serialization_error(format!("Failed to serialize output line: {e}")))?;
-    writeln!(writer, "{line}").map_err(|e| Error::io_error(format!("Failed to write output: {e}")))
+    match writeln!(writer, "{line}") {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        Err(e) => Err(Error::io_error(format!("Failed to write output: {e}"))),
+    }
 }
 
 async fn fetch_page_payload<W: std::io::Write + ?Sized>(
@@ -535,6 +539,45 @@ mod tests {
     fn test_extract_items_empty_array() {
         let json = serde_json::json!([]);
         assert_eq!(extract_items(&json).len(), 0);
+    }
+
+    struct BrokenPipeWriter;
+
+    impl std::io::Write for BrokenPipeWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "closed pipe",
+            ))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct OtherErrorWriter;
+
+    impl std::io::Write for OtherErrorWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::other("disk full"))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_write_json_line_ignores_broken_pipe() {
+        let mut writer = BrokenPipeWriter;
+        assert!(write_json_line(&mut writer, &serde_json::json!({"id": 1})).is_ok());
+    }
+
+    #[test]
+    fn test_write_json_line_surfaces_other_errors() {
+        let mut writer = OtherErrorWriter;
+        assert!(write_json_line(&mut writer, &serde_json::json!({"id": 1})).is_err());
     }
 
     // ── advance_offset_strategy ───────────────────────────────────────────


### PR DESCRIPTION
Closes #190.

## Summary

- Added pipe-safe stdout helpers that treat `BrokenPipe` as graceful termination while surfacing other write errors.
- Routed API, response rendering, discovery/docs/search/completion, config, batch, and interactive stdout output away from direct `println!` usage.
- Added unit coverage for broken-pipe and non-broken-pipe write behavior.

## Validation

- `cargo run --quiet -- api line --describe-json | head -80`
- `cargo run --quiet -- commands line | head -20`
- `cargo run --quiet -- docs line | head -20`
- `cargo run --quiet -- api line --help | head -20`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`