### PR TITLE
feat: add HTTP and HTTPS proxy support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,10 +207,10 @@ Aperture redacts proxy credentials in dry-run output, JSON errors, and debug log
 
 ```bash
 # Use a different proxy just for this request
-aperture api my-api users list --proxy "http://other-proxy.example:8080"
+aperture api my-api --proxy "http://other-proxy.example:8080" users list
 
 # Bypass all environment and config-file proxy settings
-aperture api my-api users list --no-proxy
+aperture api my-api --no-proxy users list
 ```
 
 ## Secret Management

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,6 +142,77 @@ aperture api my-api users list --server-var region=eu --server-var version=v2
 - **With enum**: Validated against allowed values
 - **URL encoding**: Values are automatically URL-encoded
 
+## Proxy Configuration
+
+Aperture supports standard HTTP proxy environment variables and optional config-file proxy settings for corporate or restricted networks.
+
+### Priority Order
+
+Proxy configuration is resolved in this order for each API request:
+
+1. Per-invocation flags: `--proxy <url>` or `--no-proxy`
+2. Standard environment variables: `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` (lowercase variants are also honored)
+3. The `[proxy]` section in `config.toml`
+
+### Environment Variables
+
+```bash
+export HTTP_PROXY="http://proxy.corp.example:8080"
+export HTTPS_PROXY="http://proxy.corp.example:8080"
+export NO_PROXY="localhost,127.0.0.1,.internal.corp.example"
+
+aperture api my-api users list
+```
+
+### Config File Setup
+
+Use `config setting` commands to persist proxy defaults:
+
+```bash
+aperture config setting set proxy.http "http://proxy.corp.example:8080"
+aperture config setting set proxy.https "http://proxy.corp.example:8080"
+aperture config setting set proxy.no_proxy "localhost,127.0.0.1,.internal.corp.example"
+```
+
+Equivalent `config.toml`:
+
+```toml
+[proxy]
+http = "http://proxy.corp.example:8080"
+https = "http://proxy.corp.example:8080"
+no_proxy = ["localhost", "127.0.0.1", ".internal.corp.example"]
+```
+
+### Proxy Authentication
+
+Avoid storing proxy passwords in `config.toml`. Store only the username and the environment variable name that contains the password:
+
+```bash
+aperture config setting set proxy.username "proxy-user"
+aperture config setting set proxy.password_env "CORP_PROXY_PASSWORD"
+export CORP_PROXY_PASSWORD="..."
+```
+
+```toml
+[proxy]
+http = "http://proxy.corp.example:8080"
+https = "http://proxy.corp.example:8080"
+username = "proxy-user"
+password_env = "CORP_PROXY_PASSWORD"
+```
+
+Aperture redacts proxy credentials in dry-run output, JSON errors, and debug logs. SOCKS proxies are not enabled in the default build.
+
+### Per-Request Overrides
+
+```bash
+# Use a different proxy just for this request
+aperture api my-api users list --proxy "http://other-proxy.example:8080"
+
+# Bypass all environment and config-file proxy settings
+aperture api my-api users list --no-proxy
+```
+
 ## Secret Management
 
 See [Security Model](security.md) for complete documentation.
@@ -339,6 +410,26 @@ Available configuration settings:
   retry_defaults.max_delay_ms = 30000
     Type: integer  Default: 30000
     Maximum delay cap in milliseconds
+
+  proxy.http = 
+    Type: proxy URL  Default: 
+    Proxy URL for HTTP requests
+
+  proxy.https = 
+    Type: proxy URL  Default: 
+    Proxy URL for HTTPS requests
+
+  proxy.no_proxy = 
+    Type: comma-separated list  Default: 
+    Hosts or domains that bypass configured proxies
+
+  proxy.username = 
+    Type: string  Default: 
+    Proxy username for config-file proxy authentication
+
+  proxy.password_env = 
+    Type: string  Default: 
+    Environment variable containing the proxy password
 ```
 
 ### Get a Setting
@@ -365,6 +456,10 @@ aperture config setting set retry_defaults.max_attempts 3
 
 # Set initial retry delay to 1 second
 aperture config setting set retry_defaults.initial_delay_ms 1000
+
+# Configure proxy defaults
+aperture config setting set proxy.http "http://proxy.corp.example:8080"
+aperture config setting set proxy.no_proxy "localhost,127.0.0.1,.internal"
 ```
 
 Settings are validated against their expected types. Comments and formatting in `config.toml` are preserved.
@@ -386,6 +481,14 @@ json_errors = false
 max_attempts = 3           # 0 = disabled
 initial_delay_ms = 500     # Starting delay for exponential backoff
 max_delay_ms = 30000       # Maximum delay cap (30 seconds)
+
+[proxy]
+# Optional proxy defaults used when proxy environment variables are absent
+http = "http://proxy.corp.example:8080"
+https = "http://proxy.corp.example:8080"
+no_proxy = ["localhost", "127.0.0.1", ".internal"]
+username = "proxy-user"
+password_env = "CORP_PROXY_PASSWORD"
 
 [api_configs.my-api]
 # Per-API base URL override
@@ -412,6 +515,8 @@ name = "API_TOKEN"
 |----------|-------------|---------|
 | `APERTURE_BASE_URL` | Global base URL override | `https://api.example.com` |
 | `APERTURE_ENV` | Environment selector | `staging`, `prod` |
+| `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` | Standard proxy URLs | `http://proxy.corp.example:8080` |
+| `NO_PROXY` | Comma-separated hosts/domains that bypass proxies | `localhost,127.0.0.1,.internal` |
 | `RUST_LOG` | Log level | `debug`, `info`, `warn` |
 
 ## Parameter References

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -219,6 +219,40 @@ aperture -v api myapi users get-user --id 123
 
 The `← 200 OK (XXms)` line shows how long the request took.
 
+### Debugging Proxy Configuration
+
+Use `-v` to see which proxy source was selected. Proxy URLs are logged with credentials removed.
+
+```bash
+# Environment-variable proxy
+HTTP_PROXY="http://user:password@proxy.corp.example:8080" \
+  aperture -v api myapi users list
+
+# Config-file proxy
+aperture config setting set proxy.http "http://proxy.corp.example:8080"
+aperture -v api myapi users list
+
+# Per-request override
+aperture -v api myapi users list --proxy "http://other-proxy.example:8080"
+
+# Confirm proxy bypass
+aperture -v api myapi users list --no-proxy
+```
+
+`--dry-run` also includes sanitized proxy diagnostics:
+
+```bash
+aperture api myapi users list --dry-run
+```
+
+If a request unexpectedly uses or bypasses a proxy, check the priority order:
+
+1. `--proxy` / `--no-proxy`
+2. `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY` and lowercase variants
+3. `[proxy]` settings in `config.toml`
+
+`NO_PROXY` values are comma-separated hosts, IPs, or domains (for example `localhost,127.0.0.1,.internal.corp.example`). SOCKS proxies are not enabled in the default build.
+
 ### Debugging Header-Related Issues
 To inspect all headers being sent and received:
 
@@ -291,6 +325,7 @@ APERTURE_LOG=debug aperture api myapi --batch-file operations.yaml
 3. **Keep body size reasonable**: Increase `APERTURE_LOG_MAX_BODY` only when needed
 4. **Check redaction**: The `[REDACTED]` markers confirm sensitive headers are being protected
 5. **Use with --dry-run**: Combine `-v` with `--dry-run` to see the request without executing it
+6. **Sanitize proxy URLs**: Prefer `proxy.username` plus `proxy.password_env` over embedding credentials in proxy URLs
 
 ## Related Documentation
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -233,16 +233,16 @@ aperture config setting set proxy.http "http://proxy.corp.example:8080"
 aperture -v api myapi users list
 
 # Per-request override
-aperture -v api myapi users list --proxy "http://other-proxy.example:8080"
+aperture -v api myapi --proxy "http://other-proxy.example:8080" users list
 
 # Confirm proxy bypass
-aperture -v api myapi users list --no-proxy
+aperture -v api myapi --no-proxy users list
 ```
 
 `--dry-run` also includes sanitized proxy diagnostics:
 
 ```bash
-aperture api myapi users list --dry-run
+aperture api myapi --dry-run users list
 ```
 
 If a request unexpectedly uses or bypasses a proxy, check the priority order:

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -8,6 +8,7 @@ use crate::duration::parse_duration;
 use crate::engine::executor::RetryContext;
 use crate::engine::generator;
 use crate::error::Error;
+use crate::invocation::ProxyOverride;
 use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroU32;
@@ -159,6 +160,7 @@ pub struct BatchResult {
 /// Batch processor for executing multiple API operations
 pub struct BatchProcessor {
     config: BatchConfig,
+    proxy_override: ProxyOverride,
     rate_limiter: Option<Arc<DefaultDirectRateLimiter>>,
     semaphore: Arc<Semaphore>,
 }
@@ -171,6 +173,16 @@ impl BatchProcessor {
     /// Panics if the rate limit is configured as 0 (which would be invalid)
     #[must_use]
     pub fn new(config: BatchConfig) -> Self {
+        Self::new_with_proxy_override(config, ProxyOverride::Default)
+    }
+
+    /// Creates a new batch processor with a shared proxy override for every operation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the rate limit is configured as 0 (which would be invalid).
+    #[must_use]
+    pub fn new_with_proxy_override(config: BatchConfig, proxy_override: ProxyOverride) -> Self {
         let rate_limiter = config.rate_limit.map(|limit| {
             Arc::new(RateLimiter::direct(Quota::per_second(
                 NonZeroU32::new(limit).unwrap_or(NonZeroU32::new(1).expect("1 is non-zero")),
@@ -181,6 +193,7 @@ impl BatchProcessor {
 
         Self {
             config,
+            proxy_override,
             rate_limiter,
             semaphore,
         }
@@ -253,6 +266,7 @@ impl BatchProcessor {
                 dry_run,
                 output_format,
                 jq_filter,
+                self.proxy_override.clone(),
             )
             .await
         } else {
@@ -264,6 +278,7 @@ impl BatchProcessor {
                 dry_run,
                 output_format,
                 jq_filter,
+                self.proxy_override.clone(),
             )
             .await
         }
@@ -281,6 +296,7 @@ impl BatchProcessor {
         dry_run: bool,
         _output_format: &crate::cli::OutputFormat,
         _jq_filter: Option<&str>,
+        proxy_override: ProxyOverride,
     ) -> Result<BatchResult, Error> {
         let start_time = std::time::Instant::now();
         let operations = batch_file.operations;
@@ -312,6 +328,7 @@ impl BatchProcessor {
                 base_url,
                 dry_run,
                 self.config.show_progress,
+                proxy_override.clone(),
             )
             .await;
 
@@ -357,6 +374,7 @@ impl BatchProcessor {
         base_url: Option<&str>,
         dry_run: bool,
         show_progress: bool,
+        proxy_override: ProxyOverride,
     ) -> BatchOperationResult {
         let op_id = operation
             .id
@@ -382,6 +400,7 @@ impl BatchProcessor {
             global_config,
             base_url,
             dry_run,
+            proxy_override,
         )
         .await
         {
@@ -411,6 +430,7 @@ impl BatchProcessor {
         global_config: Option<&GlobalConfig>,
         base_url: Option<&str>,
         dry_run: bool,
+        proxy_override: ProxyOverride,
     ) -> Result<String, Error> {
         // Suppress output and skip jq_filter: capture needs JSON text that
         // preserves the raw response structure regardless of caller formatting.
@@ -423,6 +443,7 @@ impl BatchProcessor {
             &crate::cli::OutputFormat::Json,
             None,
             true,
+            proxy_override,
         )
         .await
     }
@@ -540,6 +561,7 @@ impl BatchProcessor {
         dry_run: bool,
         output_format: &crate::cli::OutputFormat,
         jq_filter: Option<&str>,
+        proxy_override: ProxyOverride,
     ) -> Result<BatchResult, Error> {
         let start_time = std::time::Instant::now();
         let total_operations = batch_file.operations.len();
@@ -553,6 +575,7 @@ impl BatchProcessor {
             dry_run,
             output_format,
             jq_filter,
+            &proxy_override,
         );
         let results = Self::collect_batch_operation_results(handles).await?;
 
@@ -609,6 +632,7 @@ impl BatchProcessor {
         dry_run: bool,
         output_format: &crate::cli::OutputFormat,
         jq_filter: Option<&str>,
+        proxy_override: &ProxyOverride,
     ) -> Vec<tokio::task::JoinHandle<BatchOperationResult>> {
         let mut handles = Vec::new();
         for (index, operation) in operations.into_iter().enumerate() {
@@ -621,6 +645,7 @@ impl BatchProcessor {
             let rate_limiter = self.rate_limiter.clone();
             let show_progress = self.config.show_progress;
             let suppress_output = self.config.suppress_output;
+            let proxy_override = proxy_override.clone();
 
             handles.push(tokio::spawn(async move {
                 Self::execute_batch_operation_task(
@@ -636,6 +661,7 @@ impl BatchProcessor {
                     show_progress,
                     suppress_output,
                     index,
+                    proxy_override,
                 )
                 .await
             }));
@@ -657,6 +683,7 @@ impl BatchProcessor {
         show_progress: bool,
         suppress_output: bool,
         index: usize,
+        proxy_override: ProxyOverride,
     ) -> BatchOperationResult {
         let _permit = semaphore
             .acquire()
@@ -677,6 +704,7 @@ impl BatchProcessor {
             &output_format,
             jq_filter.as_deref(),
             suppress_output,
+            proxy_override,
         )
         .await;
         let duration = operation_start.elapsed();
@@ -797,6 +825,7 @@ impl BatchProcessor {
         output_format: &crate::cli::OutputFormat,
         jq_filter: Option<&str>,
         suppress_output: bool,
+        proxy_override: ProxyOverride,
     ) -> Result<String, Error> {
         use crate::cli::translate;
         use crate::invocation::ExecutionContext;
@@ -827,7 +856,7 @@ impl BatchProcessor {
             cache_config,
             retry_context,
             base_url: base_url.map(String::from),
-            proxy_override: crate::invocation::ProxyOverride::Default,
+            proxy_override,
             global_config: global_config.cloned(),
             server_var_args: translate::extract_server_var_args(&matches),
             auto_paginate: false,

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -827,6 +827,7 @@ impl BatchProcessor {
             cache_config,
             retry_context,
             base_url: base_url.map(String::from),
+            proxy_override: crate::invocation::ProxyOverride::Default,
             global_config: global_config.cloned(),
             server_var_args: translate::extract_server_var_args(&matches),
             auto_paginate: false,

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -600,7 +600,8 @@ pub async fn execute_batch_operations(
         show_progress: !cli.quiet && !cli.json_errors,
         suppress_output: cli.json_errors,
     };
-    let processor = BatchProcessor::new(batch_config);
+    let proxy_override = crate::cli::translate::proxy_override_from_execution_flags(execution);
+    let processor = BatchProcessor::new_with_proxy_override(batch_config, proxy_override);
     let result = processor
         .execute_batch(
             spec,

--- a/src/cli/commands/api.rs
+++ b/src/cli/commands/api.rs
@@ -211,6 +211,8 @@ const LANDING_INCOMPATIBLE_GLOBAL_FLAGS: &[&str] = &[
     "--json-errors",
     "--dry-run",
     "--idempotency-key",
+    "--proxy",
+    "--no-proxy",
     "--format",
     "--jq",
     "--batch-file",
@@ -360,6 +362,8 @@ const RESERVED_EXECUTION_FLAGS: &[(&str, bool)] = &[
     ("--describe-json", false),
     ("--dry-run", false),
     ("--idempotency-key", true),
+    ("--proxy", true),
+    ("--no-proxy", false),
     ("--format", true),
     ("--jq", true),
     ("--batch-file", true),
@@ -935,5 +939,29 @@ mod tests {
             .expect("misplaced --api should generate a hint");
 
         assert!(hint.contains("aperture run --api test-api <shortcut> ..."));
+    }
+
+    #[test]
+    fn detects_misplaced_proxy_execution_flags_after_operation_path() {
+        let args = vec![
+            "users".to_string(),
+            "get-user-by-id".to_string(),
+            "--proxy".to_string(),
+            "http://proxy.example:8080".to_string(),
+        ];
+        assert_eq!(
+            find_misplaced_execution_flag_after_operation_path_started(&args),
+            Some("--proxy")
+        );
+
+        let args = vec![
+            "users".to_string(),
+            "get-user-by-id".to_string(),
+            "--no-proxy".to_string(),
+        ];
+        assert_eq!(
+            find_misplaced_execution_flag_after_operation_path_started(&args),
+            Some("--no-proxy")
+        );
     }
 }

--- a/src/cli/commands/completion.rs
+++ b/src/cli/commands/completion.rs
@@ -40,6 +40,8 @@ const API_EXECUTION_FLAGS: &[&str] = &[
     "--describe-json",
     "--dry-run",
     "--idempotency-key",
+    "--proxy",
+    "--no-proxy",
     "--format",
     "--jq",
     "--batch-file",
@@ -58,6 +60,7 @@ const API_EXECUTION_FLAGS: &[&str] = &[
 
 const API_PREFIX_FLAGS_WITH_VALUES: &[&str] = &[
     "--idempotency-key",
+    "--proxy",
     "--format",
     "--jq",
     "--batch-file",

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -158,7 +158,7 @@ fn handle_set_setting_command(
     let setting_key: SettingKey = key.parse()?;
     let setting_value = SettingValue::parse_for_key(setting_key, &value)?;
     manager.set_setting(&setting_key, &setting_value)?;
-    output.success(format!("Set {key} = {value}"));
+    output.success(format!("Set {key} = {setting_value}"));
     Ok(())
 }
 

--- a/src/cli/legacy_execute.rs
+++ b/src/cli/legacy_execute.rs
@@ -50,6 +50,7 @@ pub async fn execute_request(
         cache_config: cache_config.cloned(),
         retry_context: retry_context.cloned(),
         base_url: base_url.map(String::from),
+        proxy_override: crate::invocation::ProxyOverride::Default,
         global_config: global_config.cloned(),
         server_var_args: translate::extract_server_var_args(matches),
         auto_paginate: false,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -59,6 +59,19 @@ pub struct ExecutionFlags {
     #[arg(long, value_name = "KEY", help = "Set idempotency key header")]
     pub idempotency_key: Option<String>,
 
+    /// Use a specific HTTP/HTTPS proxy for this invocation
+    #[arg(
+        long,
+        value_name = "URL",
+        conflicts_with = "no_proxy",
+        help = "Route this request through the specified proxy URL"
+    )]
+    pub proxy: Option<String>,
+
+    /// Disable environment and config-file proxy routing for this invocation
+    #[arg(long, help = "Bypass all proxy configuration for this request")]
+    pub no_proxy: bool,
+
     /// Output format for response data
     #[arg(
         long,

--- a/src/cli/translate.rs
+++ b/src/cli/translate.rs
@@ -11,7 +11,7 @@ use crate::constants;
 use crate::duration::parse_duration;
 use crate::engine::executor::RetryContext;
 use crate::error::Error;
-use crate::invocation::{ExecutionContext, OperationCall};
+use crate::invocation::{ExecutionContext, OperationCall, ProxyOverride};
 use crate::response_cache::CacheConfig;
 use crate::utils::to_kebab_case;
 use clap::ArgMatches;
@@ -336,12 +336,21 @@ pub fn cli_to_execution_context(
     // Build retry context
     let retry_context = build_retry_context(execution, global_config.as_ref())?;
 
+    let proxy_override = if execution.no_proxy {
+        ProxyOverride::Disable
+    } else if let Some(proxy) = &execution.proxy {
+        ProxyOverride::Use(proxy.clone())
+    } else {
+        ProxyOverride::Default
+    };
+
     Ok(ExecutionContext {
         dry_run: execution.dry_run,
         idempotency_key: execution.idempotency_key.clone(),
         cache_config,
         retry_context,
         base_url: None, // Resolved by BaseUrlResolver
+        proxy_override,
         global_config,
         server_var_args: Vec::new(), // Populated from dynamic matches in the caller
         auto_paginate: execution.auto_paginate,

--- a/src/cli/translate.rs
+++ b/src/cli/translate.rs
@@ -336,13 +336,7 @@ pub fn cli_to_execution_context(
     // Build retry context
     let retry_context = build_retry_context(execution, global_config.as_ref())?;
 
-    let proxy_override = if execution.no_proxy {
-        ProxyOverride::Disable
-    } else if let Some(proxy) = &execution.proxy {
-        ProxyOverride::Use(proxy.clone())
-    } else {
-        ProxyOverride::Default
-    };
+    let proxy_override = proxy_override_from_execution_flags(execution);
 
     Ok(ExecutionContext {
         dry_run: execution.dry_run,
@@ -355,6 +349,18 @@ pub fn cli_to_execution_context(
         server_var_args: Vec::new(), // Populated from dynamic matches in the caller
         auto_paginate: execution.auto_paginate,
     })
+}
+
+/// Resolves per-invocation proxy behavior from CLI flags.
+#[must_use]
+pub fn proxy_override_from_execution_flags(execution: &ExecutionFlags) -> ProxyOverride {
+    if execution.no_proxy {
+        ProxyOverride::Disable
+    } else if let Some(proxy) = &execution.proxy {
+        ProxyOverride::Use(proxy.clone())
+    } else {
+        ProxyOverride::Default
+    }
 }
 
 /// Builds a [`RetryContext`] from CLI flags and global configuration.

--- a/src/config/manager.rs
+++ b/src/config/manager.rs
@@ -500,7 +500,56 @@ impl<F: FileSystem> ConfigManager<F> {
         doc[table_name][key] = toml_edit::value(i64::try_from(value).unwrap_or(i64::MAX));
     }
 
+    fn set_nested_string(
+        doc: &mut toml_edit::DocumentMut,
+        table_name: &str,
+        key: &str,
+        value: &str,
+    ) {
+        Self::ensure_toml_table(doc, table_name);
+        doc[table_name][key] = toml_edit::value(value);
+    }
+
+    fn set_nested_string_array(
+        doc: &mut toml_edit::DocumentMut,
+        table_name: &str,
+        key: &str,
+        values: &[String],
+    ) {
+        Self::ensure_toml_table(doc, table_name);
+        let mut array = toml_edit::Array::new();
+        for value in values {
+            array.push(value.as_str());
+        }
+        doc[table_name][key] = toml_edit::value(array);
+    }
+
     fn apply_setting_to_document(
+        doc: &mut toml_edit::DocumentMut,
+        key: crate::config::settings::SettingKey,
+        value: &crate::config::settings::SettingValue,
+    ) {
+        if Self::is_proxy_setting(key) {
+            Self::apply_proxy_setting_to_document(doc, key, value);
+        } else {
+            Self::apply_core_setting_to_document(doc, key, value);
+        }
+    }
+
+    const fn is_proxy_setting(key: crate::config::settings::SettingKey) -> bool {
+        use crate::config::settings::SettingKey;
+
+        matches!(
+            key,
+            SettingKey::ProxyHttp
+                | SettingKey::ProxyHttps
+                | SettingKey::ProxyNoProxy
+                | SettingKey::ProxyUsername
+                | SettingKey::ProxyPasswordEnv
+        )
+    }
+
+    fn apply_core_setting_to_document(
         doc: &mut toml_edit::DocumentMut,
         key: crate::config::settings::SettingKey,
         value: &crate::config::settings::SettingValue,
@@ -524,17 +573,47 @@ impl<F: FileSystem> ConfigManager<F> {
             (SettingKey::RetryDefaultsMaxDelayMs, SettingValue::U64(v)) => {
                 Self::set_nested_u64(doc, "retry_defaults", "max_delay_ms", *v);
             }
-            (
-                SettingKey::DefaultTimeoutSecs
-                | SettingKey::RetryDefaultsMaxAttempts
-                | SettingKey::RetryDefaultsInitialDelayMs
-                | SettingKey::RetryDefaultsMaxDelayMs,
-                _,
-            ) => {
-                debug_assert!(false, "Integer settings require U64 value");
-            }
             (SettingKey::AgentDefaultsJsonErrors, _) => {
                 debug_assert!(false, "AgentDefaultsJsonErrors requires Bool value");
+            }
+            _ => {
+                debug_assert!(false, "Integer settings require U64 value");
+            }
+        }
+    }
+
+    fn apply_proxy_setting_to_document(
+        doc: &mut toml_edit::DocumentMut,
+        key: crate::config::settings::SettingKey,
+        value: &crate::config::settings::SettingValue,
+    ) {
+        use crate::config::settings::{SettingKey, SettingValue};
+
+        // Type mismatches are programming errors - parse_for_key guarantees correct types.
+        match (key, value) {
+            (SettingKey::ProxyHttp, SettingValue::ProxyUrl(v)) => {
+                Self::set_nested_string(doc, "proxy", "http", v);
+            }
+            (SettingKey::ProxyHttps, SettingValue::ProxyUrl(v)) => {
+                Self::set_nested_string(doc, "proxy", "https", v);
+            }
+            (SettingKey::ProxyNoProxy, SettingValue::StringList(v)) => {
+                Self::set_nested_string_array(doc, "proxy", "no_proxy", v);
+            }
+            (SettingKey::ProxyUsername, SettingValue::String(v)) => {
+                Self::set_nested_string(doc, "proxy", "username", v);
+            }
+            (SettingKey::ProxyPasswordEnv, SettingValue::String(v)) => {
+                Self::set_nested_string(doc, "proxy", "password_env", v);
+            }
+            (SettingKey::ProxyHttp | SettingKey::ProxyHttps, _) => {
+                debug_assert!(false, "Proxy URL settings require ProxyUrl value");
+            }
+            (SettingKey::ProxyNoProxy, _) => {
+                debug_assert!(false, "ProxyNoProxy requires StringList value");
+            }
+            _ => {
+                debug_assert!(false, "Proxy string settings require String value");
             }
         }
     }

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -10,6 +10,9 @@ pub struct GlobalConfig {
     /// Default retry configuration for transient failures
     #[serde(default)]
     pub retry_defaults: RetryDefaults,
+    /// Default proxy configuration for API requests.
+    #[serde(default)]
+    pub proxy: ProxyConfig,
     /// Per-API configuration overrides
     #[serde(default)]
     pub api_configs: HashMap<String, ApiConfig>,
@@ -23,6 +26,25 @@ const fn default_timeout_secs_value() -> u64 {
 pub struct AgentDefaults {
     #[serde(default)]
     pub json_errors: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq, Eq)]
+pub struct ProxyConfig {
+    /// Proxy URL for HTTP requests.
+    #[serde(default)]
+    pub http: Option<String>,
+    /// Proxy URL for HTTPS requests.
+    #[serde(default)]
+    pub https: Option<String>,
+    /// Hosts or domains that should bypass the configured proxy.
+    #[serde(default)]
+    pub no_proxy: Vec<String>,
+    /// Optional proxy username; the password should come from `password_env`.
+    #[serde(default)]
+    pub username: Option<String>,
+    /// Environment variable containing the proxy password.
+    #[serde(default)]
+    pub password_env: Option<String>,
 }
 
 /// Default retry configuration for API requests.
@@ -69,6 +91,7 @@ impl Default for GlobalConfig {
             default_timeout_secs: 30,
             agent_defaults: AgentDefaults::default(),
             retry_defaults: RetryDefaults::default(),
+            proxy: ProxyConfig::default(),
             api_configs: HashMap::new(),
         }
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -43,6 +43,16 @@ pub enum SettingKey {
     RetryDefaultsInitialDelayMs,
     /// Maximum delay cap in milliseconds (`retry_defaults.max_delay_ms`)
     RetryDefaultsMaxDelayMs,
+    /// Proxy URL for HTTP requests (`proxy.http`)
+    ProxyHttp,
+    /// Proxy URL for HTTPS requests (`proxy.https`)
+    ProxyHttps,
+    /// Comma-separated no-proxy bypass list (`proxy.no_proxy`)
+    ProxyNoProxy,
+    /// Proxy username (`proxy.username`)
+    ProxyUsername,
+    /// Environment variable containing the proxy password (`proxy.password_env`)
+    ProxyPasswordEnv,
 }
 
 impl SettingKey {
@@ -53,17 +63,60 @@ impl SettingKey {
         Self::RetryDefaultsMaxAttempts,
         Self::RetryDefaultsInitialDelayMs,
         Self::RetryDefaultsMaxDelayMs,
+        Self::ProxyHttp,
+        Self::ProxyHttps,
+        Self::ProxyNoProxy,
+        Self::ProxyUsername,
+        Self::ProxyPasswordEnv,
     ];
 
     /// Returns the dot-notation key string for this setting.
     #[must_use]
     pub const fn as_str(&self) -> &'static str {
+        if (*self).is_proxy() {
+            return (*self).proxy_as_str();
+        }
+        (*self).core_as_str()
+    }
+
+    const fn is_proxy(self) -> bool {
+        matches!(
+            self,
+            Self::ProxyHttp
+                | Self::ProxyHttps
+                | Self::ProxyNoProxy
+                | Self::ProxyUsername
+                | Self::ProxyPasswordEnv
+        )
+    }
+
+    const fn core_as_str(self) -> &'static str {
         match self {
             Self::DefaultTimeoutSecs => "default_timeout_secs",
             Self::AgentDefaultsJsonErrors => "agent_defaults.json_errors",
             Self::RetryDefaultsMaxAttempts => "retry_defaults.max_attempts",
             Self::RetryDefaultsInitialDelayMs => "retry_defaults.initial_delay_ms",
             Self::RetryDefaultsMaxDelayMs => "retry_defaults.max_delay_ms",
+            Self::ProxyHttp
+            | Self::ProxyHttps
+            | Self::ProxyNoProxy
+            | Self::ProxyUsername
+            | Self::ProxyPasswordEnv => unreachable!(),
+        }
+    }
+
+    const fn proxy_as_str(self) -> &'static str {
+        match self {
+            Self::ProxyHttp => "proxy.http",
+            Self::ProxyHttps => "proxy.https",
+            Self::ProxyNoProxy => "proxy.no_proxy",
+            Self::ProxyUsername => "proxy.username",
+            Self::ProxyPasswordEnv => "proxy.password_env",
+            Self::DefaultTimeoutSecs
+            | Self::AgentDefaultsJsonErrors
+            | Self::RetryDefaultsMaxAttempts
+            | Self::RetryDefaultsInitialDelayMs
+            | Self::RetryDefaultsMaxDelayMs => unreachable!(),
         }
     }
 
@@ -76,18 +129,48 @@ impl SettingKey {
             | Self::RetryDefaultsInitialDelayMs
             | Self::RetryDefaultsMaxDelayMs => "integer",
             Self::AgentDefaultsJsonErrors => "boolean",
+            Self::ProxyHttp | Self::ProxyHttps => "proxy URL",
+            Self::ProxyNoProxy => "comma-separated list",
+            Self::ProxyUsername | Self::ProxyPasswordEnv => "string",
         }
     }
 
     /// Returns a human-readable description of this setting.
     #[must_use]
     pub const fn description(&self) -> &'static str {
+        if (*self).is_proxy() {
+            return (*self).proxy_description();
+        }
+        (*self).core_description()
+    }
+
+    const fn core_description(self) -> &'static str {
         match self {
             Self::DefaultTimeoutSecs => "Default timeout for API requests in seconds",
             Self::AgentDefaultsJsonErrors => "Output errors as JSON by default",
             Self::RetryDefaultsMaxAttempts => "Maximum retry attempts (0 = disabled)",
             Self::RetryDefaultsInitialDelayMs => "Initial delay between retries in milliseconds",
             Self::RetryDefaultsMaxDelayMs => "Maximum delay cap in milliseconds",
+            Self::ProxyHttp
+            | Self::ProxyHttps
+            | Self::ProxyNoProxy
+            | Self::ProxyUsername
+            | Self::ProxyPasswordEnv => unreachable!(),
+        }
+    }
+
+    const fn proxy_description(self) -> &'static str {
+        match self {
+            Self::ProxyHttp => "Proxy URL for HTTP requests",
+            Self::ProxyHttps => "Proxy URL for HTTPS requests",
+            Self::ProxyNoProxy => "Hosts or domains that bypass configured proxies",
+            Self::ProxyUsername => "Proxy username for config-file proxy authentication",
+            Self::ProxyPasswordEnv => "Environment variable containing the proxy password",
+            Self::DefaultTimeoutSecs
+            | Self::AgentDefaultsJsonErrors
+            | Self::RetryDefaultsMaxAttempts
+            | Self::RetryDefaultsInitialDelayMs
+            | Self::RetryDefaultsMaxDelayMs => unreachable!(),
         }
     }
 
@@ -100,22 +183,78 @@ impl SettingKey {
             Self::RetryDefaultsMaxAttempts => "0",
             Self::RetryDefaultsInitialDelayMs => "500",
             Self::RetryDefaultsMaxDelayMs => "30000",
+            Self::ProxyHttp
+            | Self::ProxyHttps
+            | Self::ProxyNoProxy
+            | Self::ProxyUsername
+            | Self::ProxyPasswordEnv => "",
         }
     }
 
     /// Extracts the current value for this setting from a `GlobalConfig`.
     #[must_use]
-    pub const fn value_from_config(&self, config: &super::models::GlobalConfig) -> SettingValue {
+    pub fn value_from_config(&self, config: &super::models::GlobalConfig) -> SettingValue {
+        if (*self).is_proxy() {
+            return (*self).proxy_value_from_config(config);
+        }
+        (*self).core_value_from_config(config)
+    }
+
+    fn core_value_from_config(self, config: &super::models::GlobalConfig) -> SettingValue {
         match self {
             Self::DefaultTimeoutSecs => SettingValue::U64(config.default_timeout_secs),
             Self::AgentDefaultsJsonErrors => SettingValue::Bool(config.agent_defaults.json_errors),
             Self::RetryDefaultsMaxAttempts => {
-                SettingValue::U64(config.retry_defaults.max_attempts as u64)
+                SettingValue::U64(u64::from(config.retry_defaults.max_attempts))
             }
             Self::RetryDefaultsInitialDelayMs => {
                 SettingValue::U64(config.retry_defaults.initial_delay_ms)
             }
             Self::RetryDefaultsMaxDelayMs => SettingValue::U64(config.retry_defaults.max_delay_ms),
+            Self::ProxyHttp
+            | Self::ProxyHttps
+            | Self::ProxyNoProxy
+            | Self::ProxyUsername
+            | Self::ProxyPasswordEnv => unreachable!(),
+        }
+    }
+
+    fn proxy_value_from_config(self, config: &super::models::GlobalConfig) -> SettingValue {
+        match self {
+            Self::ProxyHttp => SettingValue::ProxyUrl(
+                config
+                    .proxy
+                    .http
+                    .as_ref()
+                    .map_or_else(String::new, Clone::clone),
+            ),
+            Self::ProxyHttps => SettingValue::ProxyUrl(
+                config
+                    .proxy
+                    .https
+                    .as_ref()
+                    .map_or_else(String::new, Clone::clone),
+            ),
+            Self::ProxyNoProxy => SettingValue::StringList(config.proxy.no_proxy.clone()),
+            Self::ProxyUsername => SettingValue::String(
+                config
+                    .proxy
+                    .username
+                    .as_ref()
+                    .map_or_else(String::new, Clone::clone),
+            ),
+            Self::ProxyPasswordEnv => SettingValue::String(
+                config
+                    .proxy
+                    .password_env
+                    .as_ref()
+                    .map_or_else(String::new, Clone::clone),
+            ),
+            Self::DefaultTimeoutSecs
+            | Self::AgentDefaultsJsonErrors
+            | Self::RetryDefaultsMaxAttempts
+            | Self::RetryDefaultsInitialDelayMs
+            | Self::RetryDefaultsMaxDelayMs => unreachable!(),
         }
     }
 }
@@ -130,14 +269,32 @@ impl FromStr for SettingKey {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "default_timeout_secs" => Ok(Self::DefaultTimeoutSecs),
-            "agent_defaults.json_errors" => Ok(Self::AgentDefaultsJsonErrors),
-            "retry_defaults.max_attempts" => Ok(Self::RetryDefaultsMaxAttempts),
-            "retry_defaults.initial_delay_ms" => Ok(Self::RetryDefaultsInitialDelayMs),
-            "retry_defaults.max_delay_ms" => Ok(Self::RetryDefaultsMaxDelayMs),
-            _ => Err(Error::unknown_setting_key(s)),
+        if s.starts_with("proxy.") {
+            return parse_proxy_setting_key(s);
         }
+        parse_core_setting_key(s)
+    }
+}
+
+fn parse_core_setting_key(s: &str) -> Result<SettingKey, Error> {
+    match s {
+        "default_timeout_secs" => Ok(SettingKey::DefaultTimeoutSecs),
+        "agent_defaults.json_errors" => Ok(SettingKey::AgentDefaultsJsonErrors),
+        "retry_defaults.max_attempts" => Ok(SettingKey::RetryDefaultsMaxAttempts),
+        "retry_defaults.initial_delay_ms" => Ok(SettingKey::RetryDefaultsInitialDelayMs),
+        "retry_defaults.max_delay_ms" => Ok(SettingKey::RetryDefaultsMaxDelayMs),
+        _ => Err(Error::unknown_setting_key(s)),
+    }
+}
+
+fn parse_proxy_setting_key(s: &str) -> Result<SettingKey, Error> {
+    match s {
+        "proxy.http" => Ok(SettingKey::ProxyHttp),
+        "proxy.https" => Ok(SettingKey::ProxyHttps),
+        "proxy.no_proxy" => Ok(SettingKey::ProxyNoProxy),
+        "proxy.username" => Ok(SettingKey::ProxyUsername),
+        "proxy.password_env" => Ok(SettingKey::ProxyPasswordEnv),
+        _ => Err(Error::unknown_setting_key(s)),
     }
 }
 
@@ -148,6 +305,12 @@ pub enum SettingValue {
     U64(u64),
     /// Boolean value
     Bool(bool),
+    /// String value
+    String(String),
+    /// Proxy URL value whose credentials are redacted when displayed
+    ProxyUrl(String),
+    /// List of string values
+    StringList(Vec<String>),
 }
 
 /// Maximum allowed timeout value (1 year in seconds).
@@ -214,6 +377,40 @@ fn parse_bool_setting(key: SettingKey, value: &str) -> Result<SettingValue, Erro
     Ok(SettingValue::Bool(parsed))
 }
 
+fn parse_string_list_setting(value: &str) -> SettingValue {
+    let values = value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    SettingValue::StringList(values)
+}
+
+/// Returns a URL with proxy credentials removed for display or diagnostics.
+#[must_use]
+pub fn sanitize_proxy_url(value: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(value) else {
+        return sanitize_unparseable_proxy_url(value);
+    };
+
+    if !url.username().is_empty() || url.password().is_some() {
+        let _ = url.set_username("");
+        let _ = url.set_password(None);
+    }
+    url.to_string()
+}
+
+fn sanitize_unparseable_proxy_url(value: &str) -> String {
+    let Some((scheme, rest)) = value.split_once("://") else {
+        return value.to_string();
+    };
+    let Some((_credentials, host)) = rest.rsplit_once('@') else {
+        return value.to_string();
+    };
+    format!("{scheme}://[REDACTED]@{host}")
+}
+
 impl SettingValue {
     /// Parse a string value into the appropriate type for the given key.
     ///
@@ -251,6 +448,11 @@ impl SettingValue {
                 MAX_DELAY_CAP_MS,
                 &format!("max_delay_ms cannot exceed {MAX_DELAY_CAP_MS}ms (5 minutes)"),
             ),
+            SettingKey::ProxyHttp | SettingKey::ProxyHttps => Ok(Self::ProxyUrl(value.to_string())),
+            SettingKey::ProxyNoProxy => Ok(parse_string_list_setting(value)),
+            SettingKey::ProxyUsername | SettingKey::ProxyPasswordEnv => {
+                Ok(Self::String(value.to_string()))
+            }
         }
     }
 
@@ -259,7 +461,7 @@ impl SettingValue {
     pub const fn as_u64(&self) -> Option<u64> {
         match self {
             Self::U64(v) => Some(*v),
-            Self::Bool(_) => None,
+            Self::Bool(_) | Self::String(_) | Self::ProxyUrl(_) | Self::StringList(_) => None,
         }
     }
 
@@ -268,7 +470,7 @@ impl SettingValue {
     pub const fn as_bool(&self) -> Option<bool> {
         match self {
             Self::Bool(v) => Some(*v),
-            Self::U64(_) => None,
+            Self::U64(_) | Self::String(_) | Self::ProxyUrl(_) | Self::StringList(_) => None,
         }
     }
 }
@@ -278,6 +480,9 @@ impl fmt::Display for SettingValue {
         match self {
             Self::U64(v) => write!(f, "{v}"),
             Self::Bool(v) => write!(f, "{v}"),
+            Self::String(v) => write!(f, "{v}"),
+            Self::ProxyUrl(v) => write!(f, "{}", sanitize_proxy_url(v)),
+            Self::StringList(v) => write!(f, "{}", v.join(",")),
         }
     }
 }
@@ -399,6 +604,64 @@ mod tests {
         assert_eq!(SettingValue::U64(30).to_string(), "30");
         assert_eq!(SettingValue::Bool(true).to_string(), "true");
         assert_eq!(SettingValue::Bool(false).to_string(), "false");
+        assert_eq!(
+            SettingValue::String("value".to_string()).to_string(),
+            "value"
+        );
+        assert_eq!(
+            SettingValue::StringList(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+                .to_string(),
+            "localhost,127.0.0.1"
+        );
+        assert_eq!(
+            SettingValue::ProxyUrl("http://user:secret@proxy.example:8080".to_string()).to_string(),
+            "http://proxy.example:8080/"
+        );
+    }
+
+    #[test]
+    fn test_proxy_settings_from_str() {
+        assert_eq!(
+            "proxy.http".parse::<SettingKey>().unwrap(),
+            SettingKey::ProxyHttp
+        );
+        assert_eq!(
+            "proxy.https".parse::<SettingKey>().unwrap(),
+            SettingKey::ProxyHttps
+        );
+        assert_eq!(
+            "proxy.no_proxy".parse::<SettingKey>().unwrap(),
+            SettingKey::ProxyNoProxy
+        );
+        assert_eq!(
+            "proxy.username".parse::<SettingKey>().unwrap(),
+            SettingKey::ProxyUsername
+        );
+        assert_eq!(
+            "proxy.password_env".parse::<SettingKey>().unwrap(),
+            SettingKey::ProxyPasswordEnv
+        );
+    }
+
+    #[test]
+    fn test_proxy_setting_value_parse() {
+        assert_eq!(
+            SettingValue::parse_for_key(SettingKey::ProxyHttp, "http://proxy.example:8080")
+                .unwrap(),
+            SettingValue::ProxyUrl("http://proxy.example:8080".to_string())
+        );
+        assert_eq!(
+            SettingValue::parse_for_key(
+                SettingKey::ProxyNoProxy,
+                "localhost, 127.0.0.1, .internal"
+            )
+            .unwrap(),
+            SettingValue::StringList(vec![
+                "localhost".to_string(),
+                "127.0.0.1".to_string(),
+                ".internal".to_string()
+            ])
+        );
     }
 
     #[test]

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -390,6 +390,10 @@ fn parse_string_list_setting(value: &str) -> SettingValue {
 /// Returns a URL with proxy credentials removed for display or diagnostics.
 #[must_use]
 pub fn sanitize_proxy_url(value: &str) -> String {
+    if !value.contains("://") && value.contains('@') {
+        return sanitize_unparseable_proxy_url(value);
+    }
+
     let Ok(mut url) = reqwest::Url::parse(value) else {
         return sanitize_unparseable_proxy_url(value);
     };
@@ -402,13 +406,17 @@ pub fn sanitize_proxy_url(value: &str) -> String {
 }
 
 fn sanitize_unparseable_proxy_url(value: &str) -> String {
-    let Some((scheme, rest)) = value.split_once("://") else {
-        return value.to_string();
-    };
-    let Some((_credentials, host)) = rest.rsplit_once('@') else {
-        return value.to_string();
-    };
-    format!("{scheme}://[REDACTED]@{host}")
+    if let Some((scheme, rest)) = value.split_once("://") {
+        return rest.rsplit_once('@').map_or_else(
+            || value.to_string(),
+            |(_credentials, host)| format!("{scheme}://[REDACTED]@{host}"),
+        );
+    }
+
+    value.rsplit_once('@').map_or_else(
+        || value.to_string(),
+        |(_credentials, host)| format!("[REDACTED]@{host}"),
+    )
 }
 
 impl SettingValue {
@@ -617,6 +625,17 @@ mod tests {
             SettingValue::ProxyUrl("http://user:secret@proxy.example:8080".to_string()).to_string(),
             "http://proxy.example:8080/"
         );
+    }
+
+    #[test]
+    fn test_sanitize_proxy_url_redacts_unparseable_credentials() {
+        let sanitized = sanitize_proxy_url("user:secret@proxy.example:8080");
+        assert_eq!(sanitized, "[REDACTED]@proxy.example:8080");
+        assert!(!sanitized.contains("secret"));
+
+        let sanitized = sanitize_proxy_url("http://user:secret@");
+        assert_eq!(sanitized, "http://[REDACTED]@");
+        assert!(!sanitized.contains("secret"));
     }
 
     #[test]

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -204,7 +204,11 @@ fn env_proxy_diagnostics() -> Option<ProxyDiagnostics> {
 }
 
 fn first_env_value(names: &[&str]) -> Option<String> {
-    names.iter().find_map(|name| std::env::var(name).ok())
+    names.iter().find_map(|name| {
+        std::env::var(name)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    })
 }
 
 fn configure_config_proxy(

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -211,6 +211,10 @@ fn configure_config_proxy(
     mut builder: reqwest::ClientBuilder,
     config: &ProxyConfig,
 ) -> Result<(reqwest::ClientBuilder, ProxyDiagnostics), Error> {
+    if !has_config_proxy(config) {
+        return Ok((builder, ProxyDiagnostics::default()));
+    }
+
     builder = builder.no_proxy();
     let no_proxy_env = first_env_value(&["NO_PROXY", "no_proxy"]);
     let no_proxy = config_no_proxy(config, no_proxy_env.as_deref());
@@ -228,11 +232,11 @@ fn configure_config_proxy(
     let (builder, https) = add_config_https_proxy(builder, config, no_proxy)?;
     diagnostics.https = https;
 
-    if diagnostics.http.is_none() && diagnostics.https.is_none() {
-        return Ok((builder, ProxyDiagnostics::default()));
-    }
-
     Ok((builder, diagnostics))
+}
+
+fn has_config_proxy(config: &ProxyConfig) -> bool {
+    non_empty(config.http.as_deref()).is_some() || non_empty(config.https.as_deref()).is_some()
 }
 
 fn add_config_http_proxy(

--- a/src/engine/executor.rs
+++ b/src/engine/executor.rs
@@ -1,9 +1,9 @@
 use crate::cache::models::{CachedCommand, CachedSecurityScheme, CachedSpec};
-use crate::config::models::GlobalConfig;
+use crate::config::models::{GlobalConfig, ProxyConfig};
 use crate::config::url_resolver::BaseUrlResolver;
 use crate::constants;
 use crate::error::Error;
-use crate::invocation::ExecutionResult;
+use crate::invocation::{ExecutionResult, ProxyOverride};
 use crate::logging;
 use crate::resilience::{
     calculate_retry_delay_with_header, is_retryable_status, parse_retry_after_value, RetryConfig,
@@ -109,17 +109,265 @@ impl RetryContext {
 
 // Helper functions
 
-/// Build HTTP client with default timeout
-fn build_http_client() -> Result<reqwest::Client, Error> {
-    reqwest::Client::builder()
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ProxyDiagnostics {
+    source: &'static str,
+    disabled: bool,
+    all: Option<String>,
+    http: Option<String>,
+    https: Option<String>,
+    no_proxy: Vec<String>,
+}
+
+impl ProxyDiagnostics {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "source": self.source,
+            "disabled": self.disabled,
+            "all": self.all,
+            "http": self.http,
+            "https": self.https,
+            "no_proxy": self.no_proxy,
+        })
+    }
+}
+
+struct ProxyBuildResult {
+    client: reqwest::Client,
+    diagnostics: ProxyDiagnostics,
+}
+
+fn configure_proxy(
+    builder: reqwest::ClientBuilder,
+    ctx: &crate::invocation::ExecutionContext,
+) -> Result<(reqwest::ClientBuilder, ProxyDiagnostics), Error> {
+    match &ctx.proxy_override {
+        ProxyOverride::Disable => Ok((builder.no_proxy(), disabled_proxy_diagnostics())),
+        ProxyOverride::Use(url) => configure_cli_proxy(builder, url),
+        ProxyOverride::Default => configure_default_proxy(builder, ctx.global_config.as_ref()),
+    }
+}
+
+fn disabled_proxy_diagnostics() -> ProxyDiagnostics {
+    ProxyDiagnostics {
+        source: "cli",
+        disabled: true,
+        ..ProxyDiagnostics::default()
+    }
+}
+
+fn configure_cli_proxy(
+    builder: reqwest::ClientBuilder,
+    url: &str,
+) -> Result<(reqwest::ClientBuilder, ProxyDiagnostics), Error> {
+    let proxy = proxy_all(url, "CLI")?;
+    let diagnostics = ProxyDiagnostics {
+        source: "cli",
+        all: Some(crate::config::settings::sanitize_proxy_url(url)),
+        ..ProxyDiagnostics::default()
+    };
+    Ok((builder.no_proxy().proxy(proxy), diagnostics))
+}
+
+fn configure_default_proxy(
+    builder: reqwest::ClientBuilder,
+    global_config: Option<&GlobalConfig>,
+) -> Result<(reqwest::ClientBuilder, ProxyDiagnostics), Error> {
+    if let Some(diagnostics) = env_proxy_diagnostics() {
+        return Ok((builder, diagnostics));
+    }
+
+    let Some(config) = global_config else {
+        return Ok((builder, ProxyDiagnostics::default()));
+    };
+    configure_config_proxy(builder, &config.proxy)
+}
+
+fn env_proxy_diagnostics() -> Option<ProxyDiagnostics> {
+    let http = first_env_value(&["HTTP_PROXY", "http_proxy"]);
+    let https = first_env_value(&["HTTPS_PROXY", "https_proxy"]);
+    let all = first_env_value(&["ALL_PROXY", "all_proxy"]);
+    let no_proxy = first_env_value(&["NO_PROXY", "no_proxy"]);
+
+    if http.is_none() && https.is_none() && all.is_none() {
+        return None;
+    }
+
+    Some(ProxyDiagnostics {
+        source: "environment",
+        all: all.map(|value| crate::config::settings::sanitize_proxy_url(&value)),
+        http: http.map(|value| crate::config::settings::sanitize_proxy_url(&value)),
+        https: https.map(|value| crate::config::settings::sanitize_proxy_url(&value)),
+        no_proxy: no_proxy.map_or_else(Vec::new, |value| parse_no_proxy_entries(&value)),
+        ..ProxyDiagnostics::default()
+    })
+}
+
+fn first_env_value(names: &[&str]) -> Option<String> {
+    names.iter().find_map(|name| std::env::var(name).ok())
+}
+
+fn configure_config_proxy(
+    mut builder: reqwest::ClientBuilder,
+    config: &ProxyConfig,
+) -> Result<(reqwest::ClientBuilder, ProxyDiagnostics), Error> {
+    builder = builder.no_proxy();
+    let no_proxy_env = first_env_value(&["NO_PROXY", "no_proxy"]);
+    let no_proxy = config_no_proxy(config, no_proxy_env.as_deref());
+    let mut diagnostics = ProxyDiagnostics {
+        source: "config",
+        no_proxy: no_proxy_env.map_or_else(
+            || config.no_proxy.clone(),
+            |value| parse_no_proxy_entries(&value),
+        ),
+        ..ProxyDiagnostics::default()
+    };
+
+    let (builder, http) = add_config_http_proxy(builder, config, no_proxy.clone())?;
+    diagnostics.http = http;
+    let (builder, https) = add_config_https_proxy(builder, config, no_proxy)?;
+    diagnostics.https = https;
+
+    if diagnostics.http.is_none() && diagnostics.https.is_none() {
+        return Ok((builder, ProxyDiagnostics::default()));
+    }
+
+    Ok((builder, diagnostics))
+}
+
+fn add_config_http_proxy(
+    builder: reqwest::ClientBuilder,
+    config: &ProxyConfig,
+    no_proxy: Option<reqwest::NoProxy>,
+) -> Result<(reqwest::ClientBuilder, Option<String>), Error> {
+    let Some(url) = non_empty(config.http.as_deref()) else {
+        return Ok((builder, None));
+    };
+    let proxy = proxy_http(url, "config HTTP")?.no_proxy(no_proxy);
+    let builder = builder.proxy(apply_config_proxy_auth(proxy, config)?);
+    Ok((
+        builder,
+        Some(crate::config::settings::sanitize_proxy_url(url)),
+    ))
+}
+
+fn add_config_https_proxy(
+    builder: reqwest::ClientBuilder,
+    config: &ProxyConfig,
+    no_proxy: Option<reqwest::NoProxy>,
+) -> Result<(reqwest::ClientBuilder, Option<String>), Error> {
+    let Some(url) = non_empty(config.https.as_deref()) else {
+        return Ok((builder, None));
+    };
+    let proxy = proxy_https(url, "config HTTPS")?.no_proxy(no_proxy);
+    let builder = builder.proxy(apply_config_proxy_auth(proxy, config)?);
+    Ok((
+        builder,
+        Some(crate::config::settings::sanitize_proxy_url(url)),
+    ))
+}
+
+fn config_no_proxy(config: &ProxyConfig, env_no_proxy: Option<&str>) -> Option<reqwest::NoProxy> {
+    env_no_proxy
+        .and_then(reqwest::NoProxy::from_string)
+        .or_else(|| reqwest::NoProxy::from_string(&config.no_proxy.join(",")))
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn apply_config_proxy_auth(
+    proxy: reqwest::Proxy,
+    config: &ProxyConfig,
+) -> Result<reqwest::Proxy, Error> {
+    match (
+        non_empty(config.username.as_deref()),
+        non_empty(config.password_env.as_deref()),
+    ) {
+        (Some(username), Some(password_env)) => {
+            let password = std::env::var(password_env).map_err(|_| {
+                Error::invalid_config(format!(
+                    "Proxy password environment variable '{password_env}' is not set"
+                ))
+            })?;
+            Ok(proxy.basic_auth(username, &password))
+        }
+        (None, None) => Ok(proxy),
+        _ => Err(Error::invalid_config(
+            "Proxy authentication requires both proxy.username and proxy.password_env",
+        )),
+    }
+}
+
+fn proxy_http(url: &str, label: &str) -> Result<reqwest::Proxy, Error> {
+    reqwest::Proxy::http(url).map_err(|_| invalid_proxy_url(label, url))
+}
+
+fn proxy_https(url: &str, label: &str) -> Result<reqwest::Proxy, Error> {
+    reqwest::Proxy::https(url).map_err(|_| invalid_proxy_url(label, url))
+}
+
+fn proxy_all(url: &str, label: &str) -> Result<reqwest::Proxy, Error> {
+    reqwest::Proxy::all(url).map_err(|_| invalid_proxy_url(label, url))
+}
+
+fn invalid_proxy_url(label: &str, url: &str) -> Error {
+    Error::invalid_config(format!(
+        "Invalid {label} proxy URL: {}",
+        crate::config::settings::sanitize_proxy_url(url)
+    ))
+}
+
+fn parse_no_proxy_entries(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn log_proxy_diagnostics(diagnostics: &ProxyDiagnostics) {
+    if diagnostics.disabled {
+        tracing::debug!(target: "aperture::executor", "Proxy routing disabled for request");
+        return;
+    }
+
+    if diagnostics.source.is_empty() {
+        tracing::debug!(target: "aperture::executor", "No proxy configuration selected");
+        return;
+    }
+
+    tracing::debug!(
+        target: "aperture::executor",
+        source = diagnostics.source,
+        all = diagnostics.all.as_deref().unwrap_or(""),
+        http = diagnostics.http.as_deref().unwrap_or(""),
+        https = diagnostics.https.as_deref().unwrap_or(""),
+        no_proxy = diagnostics.no_proxy.join(","),
+        "Proxy configuration selected"
+    );
+}
+
+/// Build HTTP client with default timeout and resolved proxy behavior.
+fn build_http_client(ctx: &crate::invocation::ExecutionContext) -> Result<ProxyBuildResult, Error> {
+    let (builder, diagnostics) = configure_proxy(reqwest::Client::builder(), ctx)?;
+    let client = builder
         .timeout(std::time::Duration::from_secs(30))
         .build()
-        .map_err(|e| {
+        .map_err(|_| {
             Error::request_failed(
                 reqwest::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to create HTTP client: {e}"),
+                "Failed to create HTTP client",
             )
-        })
+        })?;
+
+    log_proxy_diagnostics(&diagnostics);
+    Ok(ProxyBuildResult {
+        client,
+        diagnostics,
+    })
 }
 
 /// Send HTTP request and get response
@@ -856,6 +1104,7 @@ fn build_dry_run_result(
     headers: &HeaderMap,
     body: Option<&str>,
     operation_id: &str,
+    proxy: &ProxyDiagnostics,
 ) -> Option<ExecutionResult> {
     if !dry_run {
         return None;
@@ -879,7 +1128,8 @@ fn build_dry_run_result(
         "url": url,
         "headers": headers_map,
         "body": body,
-        "operation_id": operation_id
+        "operation_id": operation_id,
+        "proxy": proxy.to_json()
     });
 
     Some(ExecutionResult::DryRun { request_info })
@@ -938,26 +1188,32 @@ async fn finalize_execution_result(
 ///
 /// Returns errors for authentication failures, network issues, or response
 /// validation problems.
-async fn resolve_pre_execution_result(
-    cache_context: Option<&(CacheKey, ResponseCache)>,
+struct PreExecutionInput<'a> {
+    cache_context: Option<&'a (CacheKey, ResponseCache)>,
     dry_run: bool,
-    method: &Method,
-    url: &str,
-    headers: &HeaderMap,
-    body: Option<&str>,
-    operation_id: &str,
+    method: &'a Method,
+    url: &'a str,
+    headers: &'a HeaderMap,
+    body: Option<&'a str>,
+    operation_id: &'a str,
+    proxy: &'a ProxyDiagnostics,
+}
+
+async fn resolve_pre_execution_result(
+    input: PreExecutionInput<'_>,
 ) -> Result<Option<ExecutionResult>, Error> {
-    if let Some(result) = cached_execution_result(cache_context).await? {
+    if let Some(result) = cached_execution_result(input.cache_context).await? {
         return Ok(Some(result));
     }
 
     Ok(build_dry_run_result(
-        dry_run,
-        method,
-        url,
-        headers,
-        body,
-        operation_id,
+        input.dry_run,
+        input.method,
+        input.url,
+        input.headers,
+        input.body,
+        input.operation_id,
+        input.proxy,
     ))
 }
 
@@ -975,15 +1231,16 @@ pub async fn execute(
 ) -> Result<crate::invocation::ExecutionResult, Error> {
     let prepared = prepare_execution(spec, call, &ctx)?;
 
-    if let Some(result) = resolve_pre_execution_result(
-        prepared.cache_context.as_ref(),
-        ctx.dry_run,
-        &prepared.method,
-        &prepared.url,
-        &prepared.headers_clone,
-        prepared.body.as_deref(),
-        &prepared.operation.operation_id,
-    )
+    if let Some(result) = resolve_pre_execution_result(PreExecutionInput {
+        cache_context: prepared.cache_context.as_ref(),
+        dry_run: ctx.dry_run,
+        method: &prepared.method,
+        url: &prepared.url,
+        headers: &prepared.headers_clone,
+        body: prepared.body.as_deref(),
+        operation_id: &prepared.operation.operation_id,
+        proxy: &prepared.proxy_diagnostics,
+    })
     .await?
     {
         return Ok(result);
@@ -1022,6 +1279,7 @@ struct PreparedExecution<'a> {
     method: Method,
     url: String,
     client: reqwest::Client,
+    proxy_diagnostics: ProxyDiagnostics,
     headers: HeaderMap,
     headers_clone: HeaderMap,
     cache_context: Option<(CacheKey, ResponseCache)>,
@@ -1036,6 +1294,7 @@ struct PreparedRequest<'a> {
     method: Method,
     url: String,
     client: reqwest::Client,
+    proxy_diagnostics: ProxyDiagnostics,
     headers: HeaderMap,
     headers_clone: HeaderMap,
     body: Option<String>,
@@ -1069,6 +1328,7 @@ fn prepare_execution<'a>(
         method: request.method,
         url: request.url,
         client: request.client,
+        proxy_diagnostics: request.proxy_diagnostics,
         headers: request.headers,
         headers_clone: request.headers_clone,
         cache_context: runtime.cache_context,
@@ -1094,7 +1354,7 @@ fn prepare_request<'a>(
         &call.path_params,
         &call.query_params,
     )?;
-    let client = build_http_client()?;
+    let proxy_build_result = build_http_client(ctx)?;
     let mut headers = build_headers_from_params(
         spec,
         operation,
@@ -1112,7 +1372,8 @@ fn prepare_request<'a>(
         operation,
         method,
         url,
-        client,
+        client: proxy_build_result.client,
+        proxy_diagnostics: proxy_build_result.diagnostics,
         headers,
         headers_clone,
         body: call.body,

--- a/src/invocation.rs
+++ b/src/invocation.rs
@@ -42,6 +42,17 @@ pub struct OperationCall {
 /// Controls retry behavior, caching, dry-run mode, and authentication
 /// context. Does **not** include rendering concerns (output format, JQ
 /// filters) — those belong in the CLI rendering layer.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ProxyOverride {
+    /// Use normal proxy resolution: environment first, then config file.
+    #[default]
+    Default,
+    /// Use this proxy URL for this invocation.
+    Use(String),
+    /// Disable all proxy routing for this invocation.
+    Disable,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ExecutionContext {
     /// If true, show the request that would be made without executing it.
@@ -58,6 +69,9 @@ pub struct ExecutionContext {
 
     /// Base URL override. `None` uses `BaseUrlResolver` priority chain.
     pub base_url: Option<String>,
+
+    /// Per-invocation proxy behavior override.
+    pub proxy_override: ProxyOverride,
 
     /// Global configuration for URL resolution and secret lookup.
     pub global_config: Option<GlobalConfig>,

--- a/tests/cli_translate_tests.rs
+++ b/tests/cli_translate_tests.rs
@@ -8,6 +8,7 @@ use aperture_cli::cli::translate::{
 use aperture_cli::cli::{ExecutionFlags, OutputFormat};
 use aperture_cli::config::models::GlobalConfig;
 use aperture_cli::engine::generator::generate_command_tree_with_flags;
+use aperture_cli::invocation::ProxyOverride;
 use clap::{Arg, ArgAction, Command};
 use std::collections::HashMap;
 
@@ -134,6 +135,8 @@ fn base_execution_flags() -> ExecutionFlags {
         describe_json: false,
         dry_run: false,
         idempotency_key: None,
+        proxy: None,
+        no_proxy: false,
         format: OutputFormat::Json,
         jq: None,
         batch_file: None,
@@ -319,8 +322,32 @@ fn cli_to_execution_context_builds_retry_and_cache_settings() {
     assert!(retry.force_retry);
     assert!(retry.has_idempotency_key);
 
+    assert_eq!(ctx.proxy_override, ProxyOverride::Default);
     assert!(ctx.global_config.is_some());
     assert!(ctx.server_var_args.is_empty());
+}
+
+#[test]
+fn cli_to_execution_context_sets_proxy_override() {
+    let mut execution = base_execution_flags();
+    execution.proxy = Some("http://proxy.example:8080".to_string());
+
+    let ctx =
+        cli_to_execution_context(&execution, None).expect("context construction should succeed");
+    assert_eq!(
+        ctx.proxy_override,
+        ProxyOverride::Use("http://proxy.example:8080".to_string())
+    );
+}
+
+#[test]
+fn cli_to_execution_context_sets_no_proxy_override() {
+    let mut execution = base_execution_flags();
+    execution.no_proxy = true;
+
+    let ctx =
+        cli_to_execution_context(&execution, None).expect("context construction should succeed");
+    assert_eq!(ctx.proxy_override, ProxyOverride::Disable);
 }
 
 #[test]

--- a/tests/completion_integration_tests.rs
+++ b/tests/completion_integration_tests.rs
@@ -398,5 +398,7 @@ fn runtime_completion_tolerates_missing_execution_flag_value() {
         .assert()
         .success()
         .stdout(predicate::str::contains("users"))
-        .stdout(predicate::str::contains("--dry-run"));
+        .stdout(predicate::str::contains("--dry-run"))
+        .stdout(predicate::str::contains("--proxy"))
+        .stdout(predicate::str::contains("--no-proxy"));
 }

--- a/tests/config_manager_tests.rs
+++ b/tests/config_manager_tests.rs
@@ -1410,8 +1410,8 @@ fn test_list_settings() {
 
     let settings = manager.list_settings().unwrap();
 
-    // Should have 5 settings (timeout, json_errors, and 3 retry settings)
-    assert_eq!(settings.len(), 5);
+    // Should have 10 settings (timeout, json_errors, 3 retry settings, and 5 proxy settings)
+    assert_eq!(settings.len(), 10);
 
     // Check setting keys are present
     let keys: Vec<_> = settings.iter().map(|s| s.key.as_str()).collect();
@@ -1420,6 +1420,11 @@ fn test_list_settings() {
     assert!(keys.contains(&"retry_defaults.max_attempts"));
     assert!(keys.contains(&"retry_defaults.initial_delay_ms"));
     assert!(keys.contains(&"retry_defaults.max_delay_ms"));
+    assert!(keys.contains(&"proxy.http"));
+    assert!(keys.contains(&"proxy.https"));
+    assert!(keys.contains(&"proxy.no_proxy"));
+    assert!(keys.contains(&"proxy.username"));
+    assert!(keys.contains(&"proxy.password_env"));
 }
 
 #[test]

--- a/tests/config_models_tests.rs
+++ b/tests/config_models_tests.rs
@@ -51,6 +51,35 @@ fn test_global_config_agent_defaults_only() {
 }
 
 #[test]
+fn test_global_config_proxy_deserialization() {
+    let toml_str = r#"
+        [proxy]
+        http = "http://proxy.example:8080"
+        https = "http://secure-proxy.example:8443"
+        no_proxy = ["localhost", "127.0.0.1", ".internal"]
+        username = "proxy-user"
+        password_env = "PROXY_PASSWORD"
+    "#;
+
+    let config: GlobalConfig = toml::from_str(toml_str).unwrap();
+
+    assert_eq!(
+        config.proxy.http.as_deref(),
+        Some("http://proxy.example:8080")
+    );
+    assert_eq!(
+        config.proxy.https.as_deref(),
+        Some("http://secure-proxy.example:8443")
+    );
+    assert_eq!(
+        config.proxy.no_proxy,
+        vec!["localhost", "127.0.0.1", ".internal"]
+    );
+    assert_eq!(config.proxy.username.as_deref(), Some("proxy-user"));
+    assert_eq!(config.proxy.password_env.as_deref(), Some("PROXY_PASSWORD"));
+}
+
+#[test]
 fn test_aperture_secret_deserialization() {
     let yaml_str = r"
         source: env

--- a/tests/config_settings_integration_tests.rs
+++ b/tests/config_settings_integration_tests.rs
@@ -20,6 +20,8 @@ fn test_config_settings_lists_all() {
         .success()
         .stdout(predicate::str::contains("default_timeout_secs"))
         .stdout(predicate::str::contains("agent_defaults.json_errors"))
+        .stdout(predicate::str::contains("proxy.http"))
+        .stdout(predicate::str::contains("proxy.no_proxy"))
         .stdout(predicate::str::contains("Type: integer"))
         .stdout(predicate::str::contains("Type: boolean"));
 }
@@ -35,7 +37,8 @@ fn test_config_setting_list_nested_command() {
         .assert()
         .success()
         .stdout(predicate::str::contains("default_timeout_secs"))
-        .stdout(predicate::str::contains("agent_defaults.json_errors"));
+        .stdout(predicate::str::contains("agent_defaults.json_errors"))
+        .stdout(predicate::str::contains("proxy.http"));
 }
 
 /// Test `aperture config setting set/get` nested commands roundtrip
@@ -76,8 +79,8 @@ fn test_config_settings_json_output() {
     assert!(parsed.is_array());
     let settings = parsed.as_array().unwrap();
 
-    // Should have 5 settings (default_timeout_secs, json_errors, and 3 retry_defaults)
-    assert_eq!(settings.len(), 5);
+    // Should have 10 settings (timeout, json_errors, 3 retry defaults, and 5 proxy settings)
+    assert_eq!(settings.len(), 10);
 
     // Check structure of first setting
     let first = &settings[0];
@@ -139,6 +142,74 @@ fn test_config_set_get_roundtrip() {
         .assert()
         .success()
         .stdout(predicate::str::contains("120"));
+}
+
+/// Test proxy settings roundtrip through nested config setting commands
+#[test]
+fn test_config_setting_proxy_roundtrip() {
+    let temp_dir = TempDir::new().unwrap();
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "config",
+            "setting",
+            "set",
+            "proxy.http",
+            "http://proxy.example:8080",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Set proxy.http = http://proxy.example:8080",
+        ));
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "config",
+            "setting",
+            "set",
+            "proxy.no_proxy",
+            "localhost,127.0.0.1,.internal",
+        ])
+        .assert()
+        .success();
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "setting", "get", "proxy.no_proxy"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("localhost,127.0.0.1,.internal"));
+}
+
+/// Test proxy URLs with credentials are redacted in setting output
+#[test]
+fn test_config_setting_proxy_url_redacts_credentials() {
+    let temp_dir = TempDir::new().unwrap();
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args([
+            "config",
+            "setting",
+            "set",
+            "proxy.http",
+            "http://user:secret@proxy.example:8080",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("secret").not())
+        .stdout(predicate::str::contains("http://proxy.example:8080"));
+
+    aperture_cmd()
+        .env("APERTURE_CONFIG_DIR", temp_dir.path())
+        .args(["config", "setting", "get", "proxy.http"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("secret").not())
+        .stdout(predicate::str::contains("http://proxy.example:8080"));
 }
 
 /// Test `aperture config set` with nested key

--- a/tests/pagination_integration_tests.rs
+++ b/tests/pagination_integration_tests.rs
@@ -40,6 +40,7 @@ const fn base_ctx() -> ExecutionContext {
         cache_config: None,
         retry_context: None,
         base_url: None,
+        proxy_override: aperture_cli::invocation::ProxyOverride::Default,
         global_config: None,
         server_var_args: vec![],
         auto_paginate: true,

--- a/tests/proxy_support_tests.rs
+++ b/tests/proxy_support_tests.rs
@@ -1,0 +1,443 @@
+#![cfg(feature = "integration")]
+
+mod test_helpers;
+
+use aperture_cli::cache::models::{CachedSpec, CACHE_FORMAT_VERSION};
+use aperture_cli::config::models::{GlobalConfig, ProxyConfig};
+use aperture_cli::engine::executor::execute;
+use aperture_cli::invocation::{ExecutionContext, ExecutionResult, OperationCall, ProxyOverride};
+use base64::{engine::general_purpose, Engine as _};
+use std::collections::HashMap;
+use std::env;
+use std::sync::OnceLock;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Duration};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PROXY_ENV_VARS: &[&str] = &[
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+    "APERTURE_PROXY_TEST_PASSWORD",
+];
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+struct EnvGuard {
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    fn clear_proxy_env() -> Self {
+        let saved = PROXY_ENV_VARS
+            .iter()
+            .map(|name| (*name, env::var(name).ok()))
+            .collect();
+        for name in PROXY_ENV_VARS {
+            env::remove_var(name);
+        }
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (name, value) in &self.saved {
+            if let Some(value) = value {
+                env::set_var(name, value);
+            } else {
+                env::remove_var(name);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CapturedProxyRequest {
+    request_line: String,
+    headers: HashMap<String, String>,
+}
+
+async fn spawn_proxy(
+    status_line: &'static str,
+) -> (String, JoinHandle<Option<CapturedProxyRequest>>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("proxy listener should bind");
+    let addr = listener.local_addr().expect("proxy address should exist");
+    let handle = tokio::spawn(async move {
+        let Ok(Ok((mut socket, _))) = timeout(Duration::from_secs(2), listener.accept()).await
+        else {
+            return None;
+        };
+
+        let mut buffer = vec![0_u8; 8192];
+        let bytes_read = socket
+            .read(&mut buffer)
+            .await
+            .expect("proxy should read request");
+        let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+        let captured = parse_proxy_request(&request);
+        let response = format!(
+            "{status_line}\r\nContent-Type: application/json\r\nContent-Length: 11\r\n\r\n{{\"ok\":true}}"
+        );
+        let _ = socket.write_all(response.as_bytes()).await;
+        captured
+    });
+    (format!("http://{addr}"), handle)
+}
+
+fn parse_proxy_request(raw: &str) -> Option<CapturedProxyRequest> {
+    let mut lines = raw.lines();
+    let request_line = lines.next()?.trim_end_matches('\r').to_string();
+    let headers = lines
+        .take_while(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let (name, value) = line.trim_end_matches('\r').split_once(':')?;
+            Some((name.to_ascii_lowercase(), value.trim().to_string()))
+        })
+        .collect();
+    Some(CapturedProxyRequest {
+        request_line,
+        headers,
+    })
+}
+
+fn test_spec(base_url: &str) -> CachedSpec {
+    CachedSpec {
+        cache_format_version: CACHE_FORMAT_VERSION,
+        name: "proxy-test".to_string(),
+        version: "1.0.0".to_string(),
+        commands: vec![test_helpers::test_command(
+            "resource",
+            "getResource",
+            "GET",
+            "/resource",
+        )],
+        base_url: Some(base_url.to_string()),
+        servers: vec![base_url.to_string()],
+        security_schemes: HashMap::new(),
+        skipped_endpoints: vec![],
+        server_variables: HashMap::new(),
+    }
+}
+
+fn test_call() -> OperationCall {
+    OperationCall {
+        operation_id: "getResource".to_string(),
+        path_params: HashMap::new(),
+        query_params: HashMap::new(),
+        header_params: HashMap::new(),
+        body: None,
+        custom_headers: vec![],
+    }
+}
+
+fn context_with_config(config: GlobalConfig) -> ExecutionContext {
+    ExecutionContext {
+        global_config: Some(config),
+        ..ExecutionContext::default()
+    }
+}
+
+async fn execute_ok(spec: CachedSpec, ctx: ExecutionContext) {
+    let result = execute(&spec, test_call(), ctx)
+        .await
+        .expect("request should succeed");
+    assert!(matches!(
+        result,
+        ExecutionResult::Success { status: 200, .. }
+    ));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http_proxy_env_routes_http_requests() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 200 OK").await;
+    env::set_var("HTTP_PROXY", &proxy_url);
+
+    execute_ok(
+        test_spec("http://example.test"),
+        ExecutionContext::default(),
+    )
+    .await;
+
+    let captured = proxy_handle
+        .await
+        .unwrap()
+        .expect("proxy should receive request");
+    assert_eq!(
+        captured.request_line,
+        "GET http://example.test/resource HTTP/1.1"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn https_proxy_env_routes_https_connect_requests() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 502 Bad Gateway").await;
+    env::set_var("HTTPS_PROXY", &proxy_url);
+
+    let result = execute(
+        &test_spec("https://example.test"),
+        test_call(),
+        ExecutionContext::default(),
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "CONNECT failure should surface as request error"
+    );
+
+    let captured = proxy_handle
+        .await
+        .unwrap()
+        .expect("proxy should receive CONNECT");
+    assert_eq!(captured.request_line, "CONNECT example.test:443 HTTP/1.1");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn no_proxy_env_bypasses_proxy_for_matching_hosts() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let target = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/resource"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "ok": true })))
+        .expect(1)
+        .mount(&target)
+        .await;
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 200 OK").await;
+    env::set_var("HTTP_PROXY", &proxy_url);
+    env::set_var("NO_PROXY", "127.0.0.1,localhost");
+
+    execute_ok(test_spec(&target.uri()), ExecutionContext::default()).await;
+
+    assert!(
+        proxy_handle.await.unwrap().is_none(),
+        "proxy should not receive request"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn config_proxy_is_used_when_env_proxy_is_absent() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 200 OK").await;
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some(proxy_url),
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+
+    execute_ok(
+        test_spec("http://example.test"),
+        context_with_config(config),
+    )
+    .await;
+
+    let captured = proxy_handle
+        .await
+        .unwrap()
+        .expect("config proxy should receive request");
+    assert_eq!(
+        captured.request_line,
+        "GET http://example.test/resource HTTP/1.1"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn environment_proxy_beats_config_proxy() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 200 OK").await;
+    env::set_var("HTTP_PROXY", &proxy_url);
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some("http://127.0.0.1:9".to_string()),
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+
+    execute_ok(
+        test_spec("http://example.test"),
+        context_with_config(config),
+    )
+    .await;
+
+    let captured = proxy_handle
+        .await
+        .unwrap()
+        .expect("environment proxy should receive request");
+    assert_eq!(
+        captured.request_line,
+        "GET http://example.test/resource HTTP/1.1"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn config_no_proxy_bypasses_config_proxy_for_matching_hosts() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let target = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/resource"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "ok": true })))
+        .expect(1)
+        .mount(&target)
+        .await;
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 200 OK").await;
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some(proxy_url),
+            no_proxy: vec!["127.0.0.1".to_string(), "localhost".to_string()],
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+
+    execute_ok(test_spec(&target.uri()), context_with_config(config)).await;
+
+    assert!(
+        proxy_handle.await.unwrap().is_none(),
+        "config proxy should be bypassed"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cli_proxy_override_beats_env_and_config_proxy() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 200 OK").await;
+    env::set_var("HTTP_PROXY", "http://127.0.0.1:9");
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some("http://127.0.0.1:9".to_string()),
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+    let ctx = ExecutionContext {
+        proxy_override: ProxyOverride::Use(proxy_url),
+        global_config: Some(config),
+        ..ExecutionContext::default()
+    };
+
+    execute_ok(test_spec("http://example.test"), ctx).await;
+
+    let captured = proxy_handle
+        .await
+        .unwrap()
+        .expect("CLI proxy should receive request");
+    assert_eq!(
+        captured.request_line,
+        "GET http://example.test/resource HTTP/1.1"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn no_proxy_flag_disables_env_and_config_proxy() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let target = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/resource"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "ok": true })))
+        .expect(1)
+        .mount(&target)
+        .await;
+    env::set_var("HTTP_PROXY", "http://127.0.0.1:9");
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some("http://127.0.0.1:9".to_string()),
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+    let ctx = ExecutionContext {
+        proxy_override: ProxyOverride::Disable,
+        global_config: Some(config),
+        ..ExecutionContext::default()
+    };
+
+    execute_ok(test_spec(&target.uri()), ctx).await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn config_proxy_auth_uses_password_env_without_printing_password() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 200 OK").await;
+    env::set_var("APERTURE_PROXY_TEST_PASSWORD", "secret-password");
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some(proxy_url),
+            username: Some("proxy-user".to_string()),
+            password_env: Some("APERTURE_PROXY_TEST_PASSWORD".to_string()),
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+
+    execute_ok(
+        test_spec("http://example.test"),
+        context_with_config(config),
+    )
+    .await;
+
+    let captured = proxy_handle
+        .await
+        .unwrap()
+        .expect("proxy should receive request");
+    let expected = format!(
+        "Basic {}",
+        general_purpose::STANDARD.encode("proxy-user:secret-password")
+    );
+    assert_eq!(captured.headers.get("proxy-authorization"), Some(&expected));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn dry_run_proxy_diagnostics_redact_credentials() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some("http://user:secret@proxy.example:8080".to_string()),
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+    let ctx = ExecutionContext {
+        dry_run: true,
+        global_config: Some(config),
+        ..ExecutionContext::default()
+    };
+
+    let result = execute(&test_spec("http://example.test"), test_call(), ctx)
+        .await
+        .expect("dry run should succeed");
+    let ExecutionResult::DryRun { request_info } = result else {
+        panic!("expected dry-run result");
+    };
+
+    let rendered = serde_json::to_string(&request_info).unwrap();
+    assert!(!rendered.contains("secret"));
+    assert_eq!(
+        request_info["proxy"]["http"].as_str(),
+        Some("http://proxy.example:8080/")
+    );
+}

--- a/tests/proxy_support_tests.rs
+++ b/tests/proxy_support_tests.rs
@@ -290,6 +290,36 @@ async fn environment_proxy_beats_config_proxy() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn empty_environment_proxy_does_not_shadow_config_proxy() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let (proxy_url, proxy_handle) = spawn_proxy("HTTP/1.1 200 OK").await;
+    env::set_var("HTTP_PROXY", "   ");
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some(proxy_url),
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+
+    execute_ok(
+        test_spec("http://example.test"),
+        context_with_config(config),
+    )
+    .await;
+
+    let captured = proxy_handle
+        .await
+        .unwrap()
+        .expect("config proxy should receive request");
+    assert_eq!(
+        captured.request_line,
+        "GET http://example.test/resource HTTP/1.1"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn config_no_proxy_bypasses_config_proxy_for_matching_hosts() {
     let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
     let _env = EnvGuard::clear_proxy_env();

--- a/tests/proxy_support_tests.rs
+++ b/tests/proxy_support_tests.rs
@@ -2,6 +2,7 @@
 
 mod test_helpers;
 
+use aperture_cli::batch::{BatchConfig, BatchFile, BatchOperation, BatchProcessor};
 use aperture_cli::cache::models::{CachedSpec, CACHE_FORMAT_VERSION};
 use aperture_cli::config::models::{GlobalConfig, ProxyConfig};
 use aperture_cli::engine::executor::execute;
@@ -470,4 +471,56 @@ async fn dry_run_proxy_diagnostics_redact_credentials() {
         request_info["proxy"]["http"].as_str(),
         Some("http://proxy.example:8080/")
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn batch_no_proxy_override_disables_env_and_config_proxy() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().await;
+    let _env = EnvGuard::clear_proxy_env();
+    let target = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/resource"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "ok": true })))
+        .expect(1)
+        .mount(&target)
+        .await;
+    env::set_var("HTTP_PROXY", "http://127.0.0.1:9");
+    let config = GlobalConfig {
+        proxy: ProxyConfig {
+            http: Some("http://127.0.0.1:9".to_string()),
+            ..ProxyConfig::default()
+        },
+        ..GlobalConfig::default()
+    };
+    let batch = BatchFile {
+        metadata: None,
+        operations: vec![BatchOperation {
+            args: vec!["resource".to_string(), "get-resource".to_string()],
+            ..BatchOperation::default()
+        }],
+    };
+    let processor = BatchProcessor::new_with_proxy_override(
+        BatchConfig {
+            show_progress: false,
+            suppress_output: true,
+            ..BatchConfig::default()
+        },
+        ProxyOverride::Disable,
+    );
+
+    let result = processor
+        .execute_batch(
+            &test_spec(&target.uri()),
+            batch,
+            Some(&config),
+            None,
+            false,
+            &aperture_cli::cli::OutputFormat::Json,
+            None,
+        )
+        .await
+        .expect("batch request should bypass proxy and succeed");
+
+    assert_eq!(result.success_count, 1);
+    assert_eq!(result.failure_count, 0);
 }


### PR DESCRIPTION
Closes #59.\n\n## Summary\n- Added global [proxy] config settings and config setting set/get/list support.\n- Added per-request --proxy and --no-proxy execution overrides.\n- Made request execution proxy-aware with CLI > environment > config priority, config password_env authentication, sanitized debug/dry-run diagnostics, and deterministic proxy tests.\n- Documented corporate proxy setup and troubleshooting.\n\n## Validation\n- cargo test\n- cargo test --features integration\n- cargo fmt --check\n- cargo clippy