### PR TITLE
fix: repair cargo deny audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,28 +1558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,9 +1818,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2112,21 +2090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
 dependencies = [
  "papergrid",
- "tabled_derive",
  "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ serde = "1.0.228"
 serde_json = "1.0.149"
 serde_yaml = "0.9.34"
 shellexpand = "3.1.1"
-tabled = "0.20.0"
+tabled = { version = "0.20.0", default-features = false, features = ["std"] }
 thiserror = "2.0.18"
 tokio = { version = "1.51.1", features = ["rt-multi-thread", "macros", "sync", "time", "fs"] }
 dirs = "6.0.0"

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -13,28 +13,47 @@ use crate::invocation::ExecutionResult;
 use crate::output::write_stdout_line;
 use crate::utils::to_kebab_case;
 use serde_json::Value;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::fmt::Write;
-use tabled::Table;
+use tabled::{Table, Tabled};
 
 /// Maximum number of rows to display in table format to prevent memory exhaustion.
 const MAX_TABLE_ROWS: usize = 1000;
 
 // Table structures for tabled crate
-#[derive(tabled::Tabled)]
 struct TableRow {
-    #[tabled(rename = "Key")]
     key: String,
-    #[tabled(rename = "Value")]
     value: String,
 }
 
-#[derive(tabled::Tabled)]
+impl Tabled for TableRow {
+    const LENGTH: usize = 2;
+
+    fn fields(&self) -> Vec<Cow<'_, str>> {
+        vec![Cow::Borrowed(&self.key), Cow::Borrowed(&self.value)]
+    }
+
+    fn headers() -> Vec<Cow<'static, str>> {
+        vec![Cow::Borrowed("Key"), Cow::Borrowed("Value")]
+    }
+}
+
 struct KeyValue {
-    #[tabled(rename = "Key")]
     key: String,
-    #[tabled(rename = "Value")]
     value: String,
+}
+
+impl Tabled for KeyValue {
+    const LENGTH: usize = 2;
+
+    fn fields(&self) -> Vec<Cow<'_, str>> {
+        vec![Cow::Borrowed(&self.key), Cow::Borrowed(&self.value)]
+    }
+
+    fn headers() -> Vec<Cow<'static, str>> {
+        vec![Cow::Borrowed("Key"), Cow::Borrowed("Value")]
+    }
 }
 
 /// Renders an [`ExecutionResult`] to stdout in the given format.


### PR DESCRIPTION
## Summary
- update rustls-webpki to the patched 0.103.13 release
- disable tabled's derive feature and implement Tabled manually to remove the unmaintained proc-macro-error2 dependency

## Validation
- cargo deny check
- cargo audit
- cargo test --lib --no-default-features
- cargo test --features integration
- cargo fmt --check
- cargo clippy --all-targets --features integration -- -D warnings